### PR TITLE
Add boat deployment manifest with gitcloud URLs

### DIFF
--- a/config/bootstrap.yaml
+++ b/config/bootstrap.yaml
@@ -1,0 +1,3 @@
+git_url: git@gitcloud:field/unh_echoboats_project11.git
+branch: jazzy
+layer: platforms

--- a/config/layers.txt
+++ b/config/layers.txt
@@ -1,0 +1,4 @@
+underlay
+core
+platforms
+site

--- a/config/optional_layers.txt
+++ b/config/optional_layers.txt
@@ -1,0 +1,3 @@
+# Layers that are allowed to fail during setup (e.g., private repos).
+# One layer name per line. Blank lines and comments (#) are ignored.
+site

--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -1,0 +1,25 @@
+repositories:
+  manda_coverage:
+    type: git
+    url: git@gitcloud:field/manda_coverage.git
+    version: jazzy
+  marine_ais:
+    type: git
+    url: git@gitcloud:field/marine_ais.git
+    version: jazzy
+  udp_bridge:
+    type: git
+    url: git@gitcloud:field/udp_bridge.git
+    version: jazzy
+  unh_marine_navigation:
+    type: git
+    url: git@gitcloud:field/unh_marine_navigation.git
+    version: jazzy
+  s57_tools:
+    type: git
+    url: git@gitcloud:field/s57_tools.git
+    version: jazzy
+  unh_marine_autonomy:
+    type: git
+    url: git@gitcloud:field/unh_marine_autonomy.git
+    version: jazzy

--- a/config/repos/platforms.repos
+++ b/config/repos/platforms.repos
@@ -1,0 +1,13 @@
+repositories:
+  unh_echoboats_project11:
+    type: git
+    url: git@gitcloud:field/unh_echoboats_project11.git
+    version: jazzy
+  mru_transform:
+    type: git
+    url: git@gitcloud:field/mru_transform.git
+    version: jazzy
+  seafloor_echoboat_project11:
+    type: git
+    url: git@gitcloud:field/seafloor_echoboat_project11.git
+    version: jazzy

--- a/config/repos/site.repos
+++ b/config/repos/site.repos
@@ -1,0 +1,5 @@
+repositories:
+  ccomjhc_project11:
+    type: git
+    url: git@gitcloud:field/ccomjhc_project11.git
+    version: jazzy

--- a/config/repos/underlay.repos
+++ b/config/repos/underlay.repos
@@ -1,0 +1,17 @@
+repositories:
+  ros2launch_gui:
+    type: git
+    url: git@gitcloud:field/ros2launch_gui.git
+    version: jazzy
+  ros2launch_session:
+    type: git
+    url: git@gitcloud:field/ros2launch_session.git
+    version: jazzy
+  geographic_info:
+    type: git
+    url: git@gitcloud:field/geographic_info.git
+    version: ros2
+  nmea_navsat_driver:
+    type: git
+    url: git@gitcloud:field/nmea_navsat_driver.git
+    version: add_pashr


### PR DESCRIPTION
Closes #15

## Summary

- Add `config/` directory with boat deployment manifest for gitcloud
- 4 layers: underlay, core, platforms (echoboat-only), site (optional)
- All `.repos` files point at `git@gitcloud:field/`
- Bootstrap config: Pattern B, `layer: platforms`

## Layers

| Layer | Repos |
|-------|-------|
| underlay | ros2launch_gui, ros2launch_session, geographic_info, nmea_navsat_driver |
| core | manda_coverage, marine_ais, udp_bridge, unh_marine_navigation, s57_tools, unh_marine_autonomy |
| platforms | unh_echoboats_project11, mru_transform, seafloor_echoboat_project11 |
| site (optional) | ccomjhc_project11 |

Excluded from main workspace manifest: simulation, UI, sensors layers;
ben/drix/molab/lr30 platform repos; norbit, ros2sonic, vrx, audio_common,
detection_visualizer from underlay.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
