### PR TITLE
[PLAN] Add sensors layer to boat manifest (OAK cameras + DeltaT)

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-23.md
+++ b/.agent/work-plans/PLAN_ISSUE-23.md
@@ -27,11 +27,6 @@ The boat manifest uses `git@gitcloud:field/` URLs (not `https://github.com/rolke
    (underlay → core → platforms → sensors → site). The sensors layer depends
    on core packages and should be built before site.
 
-3. **Verify gitcloud repos exist and have `jazzy` branches** — this is a
-   prerequisite noted in the issue; both repos are reported as already pushed.
-   The plan includes a verification step but this may need to be done on
-   gabby or a machine with gitcloud access.
-
 ## Files to Change
 
 | File | Change |
@@ -60,13 +55,15 @@ The boat manifest uses `git@gitcloud:field/` URLs (not `https://github.com/rolke
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
 | `config/layers.txt` adds sensors | `config/repos/sensors.repos` must exist | Yes |
-| sensors layer added | `depthai` / `depthai_bridge` dependencies needed at build time | No — noted as follow-up (rosdep or manual install on gabby) |
+| sensors layer added | `depthai` / `depthai_bridge` dependencies needed at build time | Yes — rosdep handles these |
 
 ## Open Questions
 
-- **Gitcloud default branches**: Are `jazzy` branches set as default on gitcloud for both `unh_marine_perception` and `imagenex_deltat`? (Issue says repos are pushed but doesn't confirm default branch.)
-- **External dependencies**: `depthai` and `depthai_bridge` are not ROS packages — how should they be installed on gabby? Separate issue for rosdep keys or manual install?
-- **Optional layer?**: Should `sensors` be added to `config/optional_layers.txt` so setup doesn't fail on machines without gitcloud access, similar to `site`?
+All resolved:
+
+- ~~Gitcloud default branches~~: Doesn't matter — `.repos` specifies `version: jazzy` explicitly.
+- ~~External dependencies~~: `rosdep` picks up `depthai` / `depthai_bridge`.
+- ~~Optional layer?~~: No — `sensors` stays required.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/PLAN_ISSUE-23.md
+++ b/.agent/work-plans/PLAN_ISSUE-23.md
@@ -1,0 +1,73 @@
+# Plan: Add sensors layer to boat manifest (OAK cameras + DeltaT)
+
+## Issue
+
+https://github.com/rolker/unh_echoboats_project11/issues/23
+
+## Context
+
+The boat manifest (`unh_echoboats_project11`) currently defines four layers:
+`underlay`, `core`, `platforms`, and `site`. There is no `sensors` layer, so
+sensor packages (Luxonis OAK cameras, DeltaT sonar) are unavailable on gabby.
+
+The main workspace manifest includes a full `sensors.repos` with six repos, but
+the boat manifest only needs `unh_marine_perception` (OAK camera packages) and
+`imagenex_deltat` (DeltaT sonar driver) for now.
+
+The boat manifest uses `git@gitcloud:field/` URLs (not `https://github.com/rolker/`).
+
+## Approach
+
+1. **Create `config/repos/sensors.repos`** — add `unh_marine_perception` and
+   `imagenex_deltat` entries using gitcloud URLs and `jazzy` branch, matching
+   the format of existing `.repos` files in this manifest.
+
+2. **Add `sensors` to `config/layers.txt`** — insert `sensors` after
+   `platforms` and before `site` to match the main manifest layer ordering
+   (underlay → core → platforms → sensors → site). The sensors layer depends
+   on core packages and should be built before site.
+
+3. **Verify gitcloud repos exist and have `jazzy` branches** — this is a
+   prerequisite noted in the issue; both repos are reported as already pushed.
+   The plan includes a verification step but this may need to be done on
+   gabby or a machine with gitcloud access.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `config/repos/sensors.repos` | **New file** — two entries: `unh_marine_perception` and `imagenex_deltat` |
+| `config/layers.txt` | Add `sensors` between `platforms` and `site` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Scoping to two repos instead of the full six-repo sensors layer — matches issue scope |
+| A change includes its consequences | `layers.txt` must be updated alongside the new `.repos` file so the layer is actually built |
+| Improve incrementally | Small addition of one layer; more sensor repos can be added later |
+| Workspace vs. project separation | This is a boat-specific manifest change in the project repo — correct location |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0003 (workspace is project-agnostic) | No | Change is in the boat manifest (project repo), not the workspace |
+| ADR-0008 (ROS 2 conventions) | No | Standard `.repos` format used |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `config/layers.txt` adds sensors | `config/repos/sensors.repos` must exist | Yes |
+| sensors layer added | `depthai` / `depthai_bridge` dependencies needed at build time | No — noted as follow-up (rosdep or manual install on gabby) |
+
+## Open Questions
+
+- **Gitcloud default branches**: Are `jazzy` branches set as default on gitcloud for both `unh_marine_perception` and `imagenex_deltat`? (Issue says repos are pushed but doesn't confirm default branch.)
+- **External dependencies**: `depthai` and `depthai_bridge` are not ROS packages — how should they be installed on gabby? Separate issue for rosdep keys or manual install?
+- **Optional layer?**: Should `sensors` be added to `config/optional_layers.txt` so setup doesn't fail on machines without gitcloud access, similar to `site`?
+
+## Estimated Scope
+
+Single PR — two file changes (one new, one modified).

--- a/config/layers.txt
+++ b/config/layers.txt
@@ -1,4 +1,5 @@
 underlay
 core
 platforms
+sensors
 site

--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -1,0 +1,9 @@
+repositories:
+  unh_marine_perception:
+    type: git
+    url: git@gitcloud:field/unh_marine_perception.git
+    version: jazzy
+  imagenex_deltat:
+    type: git
+    url: git@gitcloud:field/imagenex_deltat.git
+    version: jazzy


### PR DESCRIPTION
Closes #23

# Plan: Add sensors layer to boat manifest (OAK cameras + DeltaT)

## Issue

https://github.com/rolker/unh_echoboats_project11/issues/23

## Context

The boat manifest (`unh_echoboats_project11`) currently defines four layers:
`underlay`, `core`, `platforms`, and `site`. There is no `sensors` layer, so
sensor packages (Luxonis OAK cameras, DeltaT sonar) are unavailable on gabby.

The main workspace manifest includes a full `sensors.repos` with six repos, but
the boat manifest only needs `unh_marine_perception` (OAK camera packages) and
`imagenex_deltat` (DeltaT sonar driver) for now.

The boat manifest uses `git@gitcloud:field/` URLs (not `https://github.com/rolker/`).

## Approach

1. **Create `config/repos/sensors.repos`** — add `unh_marine_perception` and
   `imagenex_deltat` entries using gitcloud URLs and `jazzy` branch, matching
   the format of existing `.repos` files in this manifest.

2. **Add `sensors` to `config/layers.txt`** — insert `sensors` after
   `platforms` and before `site` to match the main manifest layer ordering
   (underlay → core → platforms → sensors → site). The sensors layer depends
   on core packages and should be built before site.

3. **Verify gitcloud repos exist and have `jazzy` branches** — this is a
   prerequisite noted in the issue; both repos are reported as already pushed.
   The plan includes a verification step but this may need to be done on
   gabby or a machine with gitcloud access.

## Files to Change

| File | Change |
|------|--------|
| `config/repos/sensors.repos` | **New file** — two entries: `unh_marine_perception` and `imagenex_deltat` |
| `config/layers.txt` | Add `sensors` between `platforms` and `site` |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Only what's needed | Scoping to two repos instead of the full six-repo sensors layer — matches issue scope |
| A change includes its consequences | `layers.txt` must be updated alongside the new `.repos` file so the layer is actually built |
| Improve incrementally | Small addition of one layer; more sensor repos can be added later |
| Workspace vs. project separation | This is a boat-specific manifest change in the project repo — correct location |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0003 (workspace is project-agnostic) | No | Change is in the boat manifest (project repo), not the workspace |
| ADR-0008 (ROS 2 conventions) | No | Standard `.repos` format used |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `config/layers.txt` adds sensors | `config/repos/sensors.repos` must exist | Yes |
| sensors layer added | `depthai` / `depthai_bridge` dependencies needed at build time | No — noted as follow-up (rosdep or manual install on gabby) |

## Open Questions

- **Gitcloud default branches**: Are `jazzy` branches set as default on gitcloud for both `unh_marine_perception` and `imagenex_deltat`? (Issue says repos are pushed but doesn't confirm default branch.)
- **External dependencies**: `depthai` and `depthai_bridge` are not ROS packages — how should they be installed on gabby? Separate issue for rosdep keys or manual install?
- **Optional layer?**: Should `sensors` be added to `config/optional_layers.txt` so setup doesn't fail on machines without gitcloud access, similar to `site`?

## Estimated Scope

Single PR — two file changes (one new, one modified).


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
