### PR TITLE
Configure BizzyBoat FCU GPS antenna offsets

### DIFF
--- a/bizzyboat_project11/config/fcu/bizzyboat_fcu_custom.param
+++ b/bizzyboat_project11/config/fcu/bizzyboat_fcu_custom.param
@@ -1,0 +1,35 @@
+# BizzyBoat FCU parameter customizations (diffs from baseline)
+#
+# These parameters override the factory baseline. Apply with:
+#   mavproxy: param load bizzyboat_fcu_custom.param
+#   or set individually via mavros param service
+#
+# ArduPilot body frame: X = forward, Y = right, Z = down
+
+# GPS antenna offsets (applied 2026-04-02)
+# GPS1 (CAN 124) = forward antenna, GPS2 = aft antenna
+GPS_POS1_X       0.835000
+GPS_POS1_Y       0.000000
+GPS_POS1_Z       -0.890000
+GPS_POS2_X       -0.835000
+GPS_POS2_Y       0.000000
+GPS_POS2_Z       -0.890000
+
+# Moving baseline RTK (dual-antenna heading)
+GPS_MB1_TYPE     1
+GPS_MB1_OFS_X    1.670000
+GPS_MB1_OFS_Y    0.000000
+GPS_MB1_OFS_Z    0.000000
+
+# IMU position offsets (applied 2026-04-07)
+# Cube Orange in AutoNav box, ~0.99m aft and ~0.05m above base_link
+# Measured from IzzyBoat AutoNav photos (same model)
+INS_POS1_X       -0.990000
+INS_POS1_Y       0.000000
+INS_POS1_Z       -0.050000
+INS_POS2_X       -0.990000
+INS_POS2_Y       0.000000
+INS_POS2_Z       -0.050000
+INS_POS3_X       -0.990000
+INS_POS3_Y       0.000000
+INS_POS3_Z       -0.050000

--- a/bizzyboat_project11/docs/bizzyboat_reference_geometry.md
+++ b/bizzyboat_project11/docs/bizzyboat_reference_geometry.md
@@ -137,13 +137,17 @@ main hatch area.
 | Component | x | y | z | Status |
 |-----------|---|---|---|--------|
 | Box front-bottom | -0.875 | 0.0 | -0.01 | [MEAS] rough |
-| IMU (est. center of box) | -0.975 | 0.0 | 0.065 | [EST] |
+| Box dimensions (x × y × z) | 0.23 × 0.28 × 0.14 | | | [MEAS] from IzzyBoat photos |
+| IMU (Cube Orange center) | -0.99 | 0.0 | 0.05 | [MEAS] from IzzyBoat photos |
 
 **Notes**:
-- Front-bottom of the box is the measured reference point.
-- Box dimensions ~0.20 x 0.15 x 0.15m estimated from photos. The mechanical
-  diagrams (Fig 137) may provide better dimensions — needs closer inspection.
-- The Cube Orange IMU position within the box needs refinement.
+- Front-bottom of the box is the measured reference point on BizzyBoat.
+- Box dimensions measured from IzzyBoat AutoNav photos (2024-06-14) with tape
+  measure — same model (Seafloor Systems AutoNav) used on both boats.
+  X=0.23m depth (fore-aft, ~9"), Y=0.28m width (~11"), Z=0.14m height (~5.5").
+- Cube Orange is in the lower compartment, roughly centered fore-aft and laterally,
+  ~0.06m above box bottom. IMU is at center of Cube Orange (~65mm cube).
+- IMU position in base_link frame: (-0.875 - 0.115, 0.0, -0.01 + 0.06) = (-0.99, 0.0, 0.05).
 - The IMU orientation relative to base_link needs verification.
 
 ## Coordinate Frame Conventions
@@ -205,8 +209,8 @@ N is at PDF page N+5). Key diagrams stored in `~/bizzyboat/pages/doc-page-NNN.pn
 | GNSS height (z) | 0.89m [MEAS] rough | Refine with tape measure from hull floor to puck top |
 | GNSS fore-aft (x) | ±0.835m [MEAS] rough | Refine from base_link screw hole to each puck |
 | DeltaT position (x, z) | -0.23, -0.18 [MEAS] rough | Refine from screw hole; depth below hull |
-| AutoNav box dimensions | ~0.20 x 0.15 x 0.15 [EST] | Measure box length, width, height |
-| IMU position within AutoNav box | center [EST] | Locate Cube Orange inside box, measure offset from front-bottom |
+| AutoNav box dimensions | 0.23 x 0.28 x 0.14 [MEAS] from IzzyBoat photos | Confirm on BizzyBoat |
+| IMU position within AutoNav box | -0.115, 0.0, 0.06 from box front-bottom [MEAS] from IzzyBoat photos | Confirm on BizzyBoat |
 | IMU orientation | identity [EST] | Verify Cube Orange axes align with boat frame |
 | USB camera position | 1.05, 0, 0.89 [EST] | At forward end of center rail — refine with measurement |
 | Frame upright fwd x | 0.30 [EST] | Measure from base_link to forward upright pair |

--- a/bizzyboat_project11/launch/ntrip_launch.py
+++ b/bizzyboat_project11/launch/ntrip_launch.py
@@ -1,10 +1,9 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
 from launch_ros.actions import PushRosNamespace
 from launch_ros.actions import SetRemap
 from launch_ros.substitutions import FindPackageShare
@@ -16,6 +15,12 @@ def generate_launch_description():
         'namespace', default_value='bizzy'
     )
 
+    ntrip_credentials = PathJoinSubstitution([
+        FindPackageShare('ccomjhc_project11'),
+        'configuration',
+        'bizzyboat_ntrip.yaml'
+    ])
+
     return LaunchDescription([
         namespace_arg,
         GroupAction(
@@ -25,23 +30,26 @@ def generate_launch_description():
                     src='rtcm',
                     dst=['/', namespace, '/mavros/gps_rtk/send_rtcm']
                 ),
-                IncludeLaunchDescription(
-                    PythonLaunchDescriptionSource(
-                        PathJoinSubstitution([
-                            FindPackageShare('bizzyboat_project11'),
-                            'launch',
-                            'ntrip_client_launch.py'
-                        ])
-                    ),
-                    launch_arguments={
-                        'namespace': 'sensors/ntrip',
-                        'host': 'macorsrtk.massdot.state.ma.us',
-                        'port': '31000',
-                        'mountpoint': 'RTCM3_MASA',
-                        'username': 'bizzyboat',
-                        'password': 'bizzyboat',
-                        'rtcm_message_package': 'mavros_msgs',
-                    }.items()
+                Node(
+                    name='ntrip_client',
+                    namespace='sensors/ntrip',
+                    package='ntrip_client',
+                    executable='ntrip_ros.py',
+                    respawn=True,
+                    respawn_delay=5,
+                    emulate_tty=True,
+                    parameters=[
+                        ntrip_credentials,
+                        {
+                            'rtcm_message_package': 'mavros_msgs',
+                            'rtcm_frame_id': 'odom',
+                            'nmea_max_length': 128,
+                            'nmea_min_length': 3,
+                            'reconnect_attempt_max': 10,
+                            'reconnect_attempt_wait_seconds': 5,
+                            'rtcm_timeout_seconds': 4,
+                        }
+                    ],
                 ),
             ]
         )

--- a/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
+++ b/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
@@ -196,15 +196,16 @@
 
   <!-- ========== AutoNav Box (contains Cube Orange FCU + IMU) ========== -->
   <!-- Front bottom of box at (-0.875, 0, -0.01) from base_link.
-       Box dimensions ~0.20 x 0.15 x 0.15 estimated from photos.
-       IMU is inside the Cube Orange, position within box is approximate. -->
+       Box dimensions 0.23 x 0.28 x 0.14 measured from IzzyBoat AutoNav photos
+       (same model used on BizzyBoat). X=depth(fore-aft), Y=width, Z=height.
+       IMU is inside the Cube Orange in the lower compartment. -->
 
   <link name="bizzy/autonav_box">
     <visual>
       <geometry>
-        <box size="0.20 0.15 0.15"/>
+        <box size="0.23 0.28 0.14"/>
       </geometry>
-      <origin xyz="-0.10 0 0.075"/>
+      <origin xyz="-0.115 0 0.07"/>
       <material name="bumper_black"/>
     </visual>
   </link>
@@ -215,13 +216,15 @@
     <origin xyz="-0.875 0.0 -0.01" rpy="0 0 0"/>
   </joint>
 
-  <!-- IMU frame at estimated center of Cube Orange inside the box -->
+  <!-- IMU frame at Cube Orange center in the lower compartment.
+       Position from IzzyBoat AutoNav measurement photos (2024-06-14):
+       ~0.115m aft of box front, centered laterally, ~0.06m above box bottom. -->
   <link name="bizzy/imu"/>
 
   <joint name="autonav_box_to_imu" type="fixed">
     <parent link="bizzy/autonav_box"/>
     <child link="bizzy/imu"/>
-    <origin xyz="-0.10 0.0 0.075" rpy="0 0 0"/>
+    <origin xyz="-0.115 0.0 0.06" rpy="0 0 0"/>
   </joint>
 
 

--- a/docs/bizzyboat_gps_config_2026-04-02.md
+++ b/docs/bizzyboat_gps_config_2026-04-02.md
@@ -1,0 +1,89 @@
+# BizzyBoat GPS Antenna Offset Configuration
+
+**Date**: 2026-04-02
+**Issue**: #37
+**Hardware**: 2x CUAV C-RTK 2HP (DroneCAN, dual-antenna moving baseline RTK)
+
+## Reference
+
+- ArduPilot GPS-for-Yaw: https://ardupilot.org/rover/docs/common-gps-for-yaw.html
+- CUAV C-RTK 2HP: https://ardupilot.org/rover/docs/common-cuav-c-rtk2-hp.html
+- BizzyBoat reference geometry: `bizzyboat_project11/docs/bizzyboat_reference_geometry.md`
+- IzzyBoat live params (working reference): `docs/izzyboat_fcu_params_live.txt`
+
+## ArduPilot Body Frame Convention
+
+- X = forward, Y = right, Z = down
+- `GPS_POS1_X/Y/Z` — GPS1 antenna offset from vehicle CG
+- `GPS_POS2_X/Y/Z` — GPS2 antenna offset from vehicle CG
+- `GPS_MB1_OFS_X/Y/Z` — vector from rover antenna to base antenna
+  (equals the sum of the two POS offsets along each axis, negated)
+
+## Antenna Positions (from reference geometry, rough measurements)
+
+BizzyBoat origin is at the CG. Antennas are fore and aft on the centerline.
+
+| Antenna | URDF (x, y, z-up) | ArduPilot (X fwd, Y right, Z down) |
+|---------|-------------------|-------------------------------------|
+| Forward | 0.835, 0.0, 0.89 | 0.835, 0.0, -0.89 |
+| Aft     | -0.835, 0.0, 0.89 | -0.835, 0.0, -0.89 |
+
+Baseline (antenna-to-antenna): ~1.67 m
+
+## Planned FCU Parameter Changes
+
+Assumption: GPS1 = aft antenna, GPS2 = forward antenna (same as IzzyBoat).
+To be verified during testing — if heading is 180 degrees off, swap the assignment.
+
+| Parameter | Current | New | Notes |
+|-----------|---------|-----|-------|
+| `GPS_POS1_X` | 0.0 | -0.835 | Aft antenna, behind CG |
+| `GPS_POS1_Y` | 0.0 | 0.0 | Centerline |
+| `GPS_POS1_Z` | 0.0 | -0.89 | Above CG (negative = up) |
+| `GPS_POS2_X` | 0.0 | 0.835 | Forward antenna, ahead of CG |
+| `GPS_POS2_Y` | 0.0 | 0.0 | Centerline |
+| `GPS_POS2_Z` | 0.0 | -0.89 | Same height as GPS1 |
+| `GPS_MB1_TYPE` | 0 | 1 | Enable moving baseline |
+| `GPS_MB1_OFS_X` | 0.0 | -1.67 | Rover-to-base vector (aft) |
+| `GPS_MB1_OFS_Y` | 0.0 | 0.0 | No lateral offset |
+| `GPS_MB1_OFS_Z` | 0.0 | 0.0 | Same height |
+
+### Sanity check against IzzyBoat
+
+IzzyBoat's working values for comparison:
+
+| Parameter | IzzyBoat | BizzyBoat | Ratio | Makes sense? |
+|-----------|----------|-----------|-------|-------------|
+| `GPS_POS1_X` | -0.341 | -0.835 | 2.4x | Yes — BizzyBoat (EchoBoat 240) is bigger than IzzyBoat (EchoBoat 160) |
+| `GPS_POS1_Z` | -0.616 | -0.89 | 1.4x | Yes — BizzyBoat has taller mast/mounting |
+| `GPS_MB1_OFS_X` | -0.794 | -1.67 | 2.1x | Yes — wider antenna separation on larger boat |
+
+IzzyBoat MB offset math: -(0.341 + 0.360) = -0.701 ≈ -0.794 (close, measured values)
+BizzyBoat MB offset math: -(0.835 + 0.835) = -1.67 (symmetric, from rough geometry)
+
+## Parameters Already Correct
+
+These are already set correctly in the baseline dump:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `GPS_TYPE` | 9 | DroneCAN |
+| `GPS_CAN_NODEID1` | 124 | CAN node ID |
+| `GPS_AUTO_CONFIG` | 2 | AutoConfig DroneCAN |
+| `EK3_SRC1_YAW` | 2 | GPS heading |
+| `COMPASS_ENABLE` | 0 | Compass disabled |
+
+## Testing Plan
+
+1. SSH to gabby, connect to FCU via MAVProxy or QGroundControl
+2. Set parameters listed above
+3. Power cycle FCU
+4. Check `mavros/global_position/raw/fix` for GPS fix
+5. Verify heading is correct (not 180 degrees off)
+6. If heading is reversed, swap GPS1/GPS2 assignments or negate MB_OFS_X
+
+## NTRIP (deferred)
+
+NTRIP RTK corrections are commented out in `bizzyboat_project11/launch/core_launch.py`.
+Assess after basic GPS fix is confirmed. IzzyBoat uses MassDOT CORS
+(`macorsrtk.massdot.state.ma.us:31000`, mountpoint `RTCM3_MASA`).

--- a/docs/bizzyboat_gps_config_2026-04-02.md
+++ b/docs/bizzyboat_gps_config_2026-04-02.md
@@ -30,36 +30,43 @@ BizzyBoat origin is at the CG. Antennas are fore and aft on the centerline.
 
 Baseline (antenna-to-antenna): ~1.67 m
 
-## Planned FCU Parameter Changes
+## FCU Parameter Changes (applied 2026-04-02)
 
-Assumption: GPS1 = aft antenna, GPS2 = forward antenna (same as IzzyBoat).
-To be verified during testing — if heading is 180 degrees off, swap the assignment.
+**Key finding**: GPS1 (CAN node 124) is the **forward** antenna on BizzyBoat.
+This differs from IzzyBoat where GPS1 (CAN node 125) is the aft antenna.
+Discovered during testing — initial assumption of GPS1=aft gave heading 180° off.
 
-| Parameter | Current | New | Notes |
-|-----------|---------|-----|-------|
-| `GPS_POS1_X` | 0.0 | -0.835 | Aft antenna, behind CG |
+| Parameter | Before | After | Notes |
+|-----------|--------|-------|-------|
+| `GPS_POS1_X` | 0.0 | 0.835 | Forward antenna, ahead of CG |
 | `GPS_POS1_Y` | 0.0 | 0.0 | Centerline |
 | `GPS_POS1_Z` | 0.0 | -0.89 | Above CG (negative = up) |
-| `GPS_POS2_X` | 0.0 | 0.835 | Forward antenna, ahead of CG |
+| `GPS_POS2_X` | 0.0 | -0.835 | Aft antenna, behind CG |
 | `GPS_POS2_Y` | 0.0 | 0.0 | Centerline |
 | `GPS_POS2_Z` | 0.0 | -0.89 | Same height as GPS1 |
 | `GPS_MB1_TYPE` | 0 | 1 | Enable moving baseline |
-| `GPS_MB1_OFS_X` | 0.0 | -1.67 | Rover-to-base vector (aft) |
+| `GPS_MB1_OFS_X` | 0.0 | 1.67 | Base-to-rover vector (positive = forward) |
 | `GPS_MB1_OFS_Y` | 0.0 | 0.0 | No lateral offset |
 | `GPS_MB1_OFS_Z` | 0.0 | 0.0 | Same height |
 
-### Sanity check against IzzyBoat
+### Comparison with IzzyBoat
 
-IzzyBoat's working values for comparison:
-
-| Parameter | IzzyBoat | BizzyBoat | Ratio | Makes sense? |
-|-----------|----------|-----------|-------|-------------|
-| `GPS_POS1_X` | -0.341 | -0.835 | 2.4x | Yes — BizzyBoat (EchoBoat 240) is bigger than IzzyBoat (EchoBoat 160) |
-| `GPS_POS1_Z` | -0.616 | -0.89 | 1.4x | Yes — BizzyBoat has taller mast/mounting |
-| `GPS_MB1_OFS_X` | -0.794 | -1.67 | 2.1x | Yes — wider antenna separation on larger boat |
+| Parameter | IzzyBoat | BizzyBoat | Notes |
+|-----------|----------|-----------|-------|
+| `GPS_POS1_X` | -0.341 (aft) | 0.835 (fwd) | GPS1 is opposite end on each boat |
+| `GPS_POS1_Z` | -0.616 | -0.89 | BizzyBoat has taller mounting |
+| `GPS_MB1_OFS_X` | -0.794 | 1.67 | Sign differs (GPS1 assignment differs) |
+| `GPS_CAN_NODEID1` | 125 | 124 | Different CAN node IDs |
 
 IzzyBoat MB offset math: -(0.341 + 0.360) = -0.701 ≈ -0.794 (close, measured values)
-BizzyBoat MB offset math: -(0.835 + 0.835) = -1.67 (symmetric, from rough geometry)
+BizzyBoat MB offset math: (0.835 + 0.835) = 1.67 (symmetric, from rough geometry)
+
+### Test results
+
+- **GPS fix type**: 3 (3D fix)
+- **Satellites**: 28
+- **Heading**: ~74° (ENE) — confirmed correct for boat orientation at pier
+- **Position**: 43.072°N, 70.712°W (UNH pier area)
 
 ## Parameters Already Correct
 
@@ -73,14 +80,14 @@ These are already set correctly in the baseline dump:
 | `EK3_SRC1_YAW` | 2 | GPS heading |
 | `COMPASS_ENABLE` | 0 | Compass disabled |
 
-## Testing Plan
+## Testing Log
 
-1. SSH to gabby, connect to FCU via MAVProxy or QGroundControl
-2. Set parameters listed above
-3. Power cycle FCU
-4. Check `mavros/global_position/raw/fix` for GPS fix
-5. Verify heading is correct (not 180 degrees off)
-6. If heading is reversed, swap GPS1/GPS2 assignments or negate MB_OFS_X
+1. Connected to FCU via MAVProxy on gabby (`~/project11/.venv/bin/mavproxy.py --master=/dev/fcu,57600`)
+2. Set GPS position offsets and enabled moving baseline
+3. Rebooted FCU — `GPS_MB1_OFS` params only appear after reboot with `GPS_MB1_TYPE=1`
+4. Initial heading was ~254° (WSW) — 180° off from actual ENE orientation
+5. Negated `GPS_MB1_OFS_X` (-1.67 → +1.67) and swapped POS1/POS2 X values
+6. Heading corrected to ~74° (ENE) — matches boat orientation at pier
 
 ## NTRIP (deferred)
 

--- a/docs/bizzyboat_gps_config_2026-04-02.md
+++ b/docs/bizzyboat_gps_config_2026-04-02.md
@@ -89,8 +89,26 @@ These are already set correctly in the baseline dump:
 5. Negated `GPS_MB1_OFS_X` (-1.67 → +1.67) and swapped POS1/POS2 X values
 6. Heading corrected to ~74° (ENE) — matches boat orientation at pier
 
-## NTRIP (deferred)
+## NTRIP / RTK (verified 2026-04-06)
 
-NTRIP RTK corrections are commented out in `bizzyboat_project11/launch/core_launch.py`.
-Assess after basic GPS fix is confirmed. IzzyBoat uses MassDOT CORS
-(`macorsrtk.massdot.state.ma.us:31000`, mountpoint `RTCM3_MASA`).
+NTRIP RTK corrections verified working on BizzyBoat.
+
+### MACORS Setup
+
+1. Registered at https://macors.massdot.state.ma.us/
+2. Created device account (convention: one account per device)
+3. Subscribed to real-time GPS corrections service (free, activated same day)
+4. Credentials stored in `ccomjhc_project11/configuration/bizzyboat_ntrip.yaml`
+   (private repo, loaded at launch via `FindPackageShare`)
+
+### Connection Details
+
+- Host: `macorsrtk.massdot.state.ma.us`
+- Port: `31000`
+- Mountpoint: `RTCM3_MASA`
+- Same CORS network as IzzyBoat (MassDOT MACORS)
+
+### Activation
+
+- Uncommented NTRIP in `core_launch.py`, relaunched on gabby
+- RTK fix confirmed — position visibly tighter and more stable in CAMP

--- a/izzyboat_project11/launch/ntrip_launch.py
+++ b/izzyboat_project11/launch/ntrip_launch.py
@@ -1,64 +1,56 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
 from launch_ros.actions import PushRosNamespace
 from launch_ros.actions import SetRemap
 from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
-  namespace = LaunchConfiguration('namespace')
+    namespace = LaunchConfiguration('namespace')
 
-  namespace_arg = DeclareLaunchArgument(
-    "namespace", default_value="izzy"
-  )
-
-  return LaunchDescription([
-    namespace_arg,
-    GroupAction(
-      actions = [
-        PushRosNamespace(namespace),
-        SetRemap(
-          src = 'rtcm',
-          dst = ['/',namespace,'/mavros/gps_rtk/send_rtcm']
-        ),
-        IncludeLaunchDescription(
-          PythonLaunchDescriptionSource(
-            PathJoinSubstitution([
-              FindPackageShare('izzyboat_project11'),
-              'launch',
-              'ntrip_client_launch.py'
-            ])
-          ),
-          launch_arguments={
-            'namespace': 'sensors/ntrip',
-            'host': 'macorsrtk.massdot.state.ma.us',
-            'port': '31000',
-            'mountpoint': 'RTCM3_MASA',
-            'username': 'izzyboat',
-            'password': 'izzyboat',
-            'rtcm_message_package': 'mavros_msgs',
-          }.items()
-        ),
-      ]
+    namespace_arg = DeclareLaunchArgument(
+        'namespace', default_value='izzy'
     )
-  ])
 
+    ntrip_credentials = PathJoinSubstitution([
+        FindPackageShare('ccomjhc_project11'),
+        'configuration',
+        'izzyboat_ntrip.yaml'
+    ])
 
-
-# <launch>
-#   <arg name="namespace" default="izzy"/>
-
-#   <include file="$(find ntrip_client)/launch/ntrip_client.launch">
-#     <arg name="namespace" value="$(arg namespace)/sensors/ntrip"/>
-#     <arg name="host" value="macorsrtk.massdot.state.ma.us"/>
-#     <arg name="port" value="31000"/>
-#     <arg name="mountpoint" value="RTCM3_MASA"/>
-#     <arg name="username" value="izzyboat"/>
-#     <arg name="password" value="izzyboat"/>
-#     <arg name="rtcm_message_package" value="mavros_msgs"/>
-#   </include>
-# </launch>
+    return LaunchDescription([
+        namespace_arg,
+        GroupAction(
+            actions=[
+                PushRosNamespace(namespace),
+                SetRemap(
+                    src='rtcm',
+                    dst=['/', namespace, '/mavros/gps_rtk/send_rtcm']
+                ),
+                Node(
+                    name='ntrip_client',
+                    namespace='sensors/ntrip',
+                    package='ntrip_client',
+                    executable='ntrip_ros.py',
+                    respawn=True,
+                    respawn_delay=5,
+                    emulate_tty=True,
+                    parameters=[
+                        ntrip_credentials,
+                        {
+                            'rtcm_message_package': 'mavros_msgs',
+                            'rtcm_frame_id': 'odom',
+                            'nmea_max_length': 128,
+                            'nmea_min_length': 3,
+                            'reconnect_attempt_max': 10,
+                            'reconnect_attempt_wait_seconds': 5,
+                            'rtcm_timeout_seconds': 4,
+                        }
+                    ],
+                ),
+            ]
+        )
+    ])


### PR DESCRIPTION
## Summary

- Configured BizzyBoat FCU GPS antenna offsets for dual-antenna moving baseline RTK heading
- Documented parameter values, testing process, and key finding: GPS1 (CAN node 124) is the **forward** antenna on BizzyBoat (opposite to IzzyBoat)
- GPS heading verified correct (~74° ENE) matching boat orientation at pier
- NTRIP RTK corrections verified working via MACORS (2026-04-06)
- Moved NTRIP credentials from hardcoded launch files to private config in `ccomjhc_project11`

## What was done

Parameters applied to FCU via MAVProxy on gabby:
- `GPS_POS1_X/Y/Z` and `GPS_POS2_X/Y/Z` — antenna position offsets
- `GPS_MB1_TYPE=1` — enabled moving baseline
- `GPS_MB1_OFS_X=1.67` — antenna baseline vector

NTRIP / RTK:
- Registered BizzyBoat on MACORS (macorsrtk.massdot.state.ma.us)
- RTK fix confirmed — position tighter and more stable in CAMP
- Launch files now load credentials from `ccomjhc_project11/configuration/bizzyboat_ntrip.yaml` (private repo) via `FindPackageShare`
- IzzyBoat launch updated similarly (credentials in `izzyboat_ntrip.yaml`)

## Remaining work

- [x] NTRIP RTK corrections — verified working (2026-04-06)
- [ ] Refine antenna measurements (currently rough estimates from reference geometry)
- [ ] Configure IMU offsets (`INS_POS1_X/Y/Z`) — currently all zeros; IzzyBoat has measured values for reference

Companion PRs: [CCOMJHC/ccomjhc_project11#24](https://github.com/CCOMJHC/ccomjhc_project11/pull/24), [#26](https://github.com/CCOMJHC/ccomjhc_project11/pull/26), [#28](https://github.com/CCOMJHC/ccomjhc_project11/pull/28) (credential config files, all merged)

Closes #37

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`