### PR TITLE
fix: add mru_transform config and segmentation streams to bizzyboat

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -75,15 +75,27 @@
             - oak_forward
             - oak_forward_info
             - oak_forward_raw
+            - oak_segmentation_forward
+            - oak_segmentation_forward_info
+            - oak_segmentation_forward_raw
             - oak_starboard
             - oak_starboard_info
             - oak_starboard_raw
+            - oak_segmentation_starboard
+            - oak_segmentation_starboard_info
+            - oak_segmentation_starboard_raw
             - oak_aft
             - oak_aft_info
             - oak_aft_raw
+            - oak_segmentation_aft
+            - oak_segmentation_aft_info
+            - oak_segmentation_aft_raw
             - oak_port
             - oak_port_info
             - oak_port_raw
+            - oak_segmentation_port
+            - oak_segmentation_port_info
+            - oak_segmentation_port_raw
             - odom
             - path_follower_visualization
             - plan
@@ -106,18 +118,30 @@
               local_costmap: {source: local_costmap/costmap, period: 3.0}
               local_costmap_footprint: {source: local_costmap/published_footprint}
               odom: {source: odom}
-              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
+              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 1.0}
               oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
               oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
-              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 2.0}
+              oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}
+              oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
+              oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
+              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 1.0}
               oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
               oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
+              oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 0.5}
+              oak_segmentation_starboard_info: {source: sensors/cameras/oak_starboard/segmentation/camera_info}
+              oak_segmentation_starboard_raw:    {source: sensors/cameras/oak_starboard/segmentation, period: -1.0}
               oak_aft:      {source: sensors/cameras/oak_aft/image_raw/compressed, period: 2.0}
               oak_aft_info: {source: sensors/cameras/oak_aft/camera_info}
               oak_aft_raw:  {source: sensors/cameras/oak_aft/image_raw, period: -1.0}
-              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 2.0}
+              oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 0.5}
+              oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
+              oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
+              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 1.0}
               oak_port_info: {source: sensors/cameras/oak_port/camera_info}
               oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
+              oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 0.5}
+              oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
+              oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0}
               path_follower_visualization: {source: path_follower_visualization}
               deltat: {source: sensors/deltat/soundings}
               deltat_grid: {source: sensors/deltat/grid}
@@ -142,6 +166,30 @@
             - heartbeat
             - heartbeat_nav
             - hover_viz
+            - oak_forward
+            - oak_forward_info
+            - oak_forward_raw
+            - oak_segmentation_forward
+            - oak_segmentation_forward_info
+            - oak_segmentation_forward_raw
+            # - oak_starboard
+            # - oak_starboard_info
+            # - oak_starboard_raw
+            # - oak_segmentation_starboard
+            # - oak_segmentation_starboard_info
+            # - oak_segmentation_starboard_raw
+            # - oak_aft
+            # - oak_aft_info
+            # - oak_aft_raw
+            # - oak_segmentation_aft
+            # - oak_segmentation_aft_info
+            # - oak_segmentation_aft_raw
+            # - oak_port
+            # - oak_port_info
+            # - oak_port_raw
+            # - oak_segmentation_port
+            # - oak_segmentation_port_info
+            # - oak_segmentation_port_raw
             - odom
             - plan
             - platforms
@@ -158,6 +206,30 @@
               heartbeat_nav: {source: marine/status/mission_manager}
               hover_viz: {source: hover_visualization}
               odom: {source: odom}
+              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 1.0}
+              oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
+              oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
+              oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}
+              oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
+              oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
+              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 1.0}
+              oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
+              oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
+              oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 0.5}
+              oak_segmentation_starboard_info: {source: sensors/cameras/oak_starboard/segmentation/camera_info}
+              oak_segmentation_starboard_raw:    {source: sensors/cameras/oak_starboard/segmentation, period: -1.0}
+              oak_aft:      {source: sensors/cameras/oak_aft/image_raw/compressed, period: 2.0}
+              oak_aft_info: {source: sensors/cameras/oak_aft/camera_info}
+              oak_aft_raw:  {source: sensors/cameras/oak_aft/image_raw, period: -1.0}
+              oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 0.5}
+              oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
+              oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
+              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 1.0}
+              oak_port_info: {source: sensors/cameras/oak_port/camera_info}
+              oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
+              oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 0.5}
+              oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
+              oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0}
               battery: {source: /bizzy/mavros/battery}
               plan: {source: plan}
               platforms: {source: /marine/platforms}

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -34,6 +34,17 @@
     map_frame: bizzy/map
     cell_size: 0.5
 
+/**/mru_transform:
+  ros__parameters:
+    sensors:
+      mru:
+        topics:
+          orientation: "mavros/imu/data"
+          position: "mavros/global_position/raw/fix"
+          velocity: "mavros/global_position/raw/gps_vel"
+    sensor_names:
+    - mru
+
 /**/udp_bridge:
   ros__parameters:
     name: bizzy


### PR DESCRIPTION
## Summary

Field fixes from 2026-04-08 BizzyBoat water test session:

- Add `mru_transform` sensor config to `bizzyboat.yaml` — was missing entirely, causing empty sensor topics (no odom output)
- Add segmentation streams to UDP bridge config

Part of #43.
