### PR TITLE
Add network monitoring repos to BizzyBoat sensors manifest

### DIFF
--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -11,3 +11,11 @@ repositories:
     type: git
     url: git@gitcloud:field/imagenex_deltat.git
     version: jazzy
+  starlink_stats_ros:
+    type: git
+    url: git@gitcloud:field/starlink_stats_ros.git
+    version: jazzy
+  ros2_network_monitor:
+    type: git
+    url: git@gitcloud:field/ros2_network_monitor.git
+    version: jazzy


### PR DESCRIPTION
## Summary

- Add `starlink_stats_ros` and `ros2_network_monitor` to `config/repos/sensors.repos` with gitcloud URLs
- Repos not yet on gitcloud — will need `push_remote.py` once packages are ready

Part of #47 (launch file and remaining integration will follow in separate commits).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
