### PR TITLE
feat: add MikroTik network monitoring launch files

### DIFF
--- a/bizzyboat_project11/config/network_monitor_boat.yaml
+++ b/bizzyboat_project11/config/network_monitor_boat.yaml
@@ -1,0 +1,9 @@
+mikrotik_monitor:
+  ros__parameters:
+    host: 'wifi.bizzy.p11.lan'
+    username: 'ros_monitor'
+    password: 'ros_monitor'
+    port: 80
+    use_ssl: false
+    poll_interval: 5.0
+    hardware_id: 'wifi.bizzy'

--- a/bizzyboat_project11/config/network_monitor_operator.yaml
+++ b/bizzyboat_project11/config/network_monitor_operator.yaml
@@ -1,0 +1,9 @@
+mikrotik_monitor:
+  ros__parameters:
+    host: 'bizzy.wifi.op.p11.lan'
+    username: 'ros_monitor'
+    password: 'ros_monitor'
+    port: 80
+    use_ssl: false
+    poll_interval: 5.0
+    hardware_id: 'bizzy.wifi.op'

--- a/bizzyboat_project11/config/ping_targets_boat.yaml
+++ b/bizzyboat_project11/config/ping_targets_boat.yaml
@@ -1,0 +1,11 @@
+ping_monitor:
+  ros__parameters:
+    targets:
+      - "salmon_direct:salmon.op.p11.lan"
+      - "salmon_vpn:salmon.vpn.bizzy.p11.lan"
+      - "router_op_direct:router.op.p11.lan"
+      - "router_op_vpn:router.vpn-op.bizzy.p11.lan"
+      - "bencloud:bencloud.wg.p11.lan"
+    poll_interval: 10.0
+    ping_count: 3
+    ping_timeout: 5.0

--- a/bizzyboat_project11/config/ping_targets_operator.yaml
+++ b/bizzyboat_project11/config/ping_targets_operator.yaml
@@ -1,0 +1,11 @@
+ping_monitor:
+  ros__parameters:
+    targets:
+      - "gabby_direct:gabby.bizzy.p11.lan"
+      - "gabby_vpn:gabby.vpn.bizzy.p11.lan"
+      - "router_bizzy_direct:router.bizzy.p11.lan"
+      - "router_bizzy_vpn:router.vpn.bizzy.p11.lan"
+      - "bencloud:bencloud.wg.p11.lan"
+    poll_interval: 10.0
+    ping_count: 3
+    ping_timeout: 5.0

--- a/bizzyboat_project11/config/teltonika_monitor_boat.yaml
+++ b/bizzyboat_project11/config/teltonika_monitor_boat.yaml
@@ -1,0 +1,9 @@
+teltonika_monitor:
+  ros__parameters:
+    host: 'router.bizzy'
+    username: 'ros_monitor'
+    password: 'ROS2_monitor'
+    port: 443
+    use_ssl: true
+    poll_interval: 5.0
+    hardware_id: 'router.bizzy'

--- a/bizzyboat_project11/config/teltonika_monitor_operator.yaml
+++ b/bizzyboat_project11/config/teltonika_monitor_operator.yaml
@@ -1,0 +1,9 @@
+teltonika_monitor:
+  ros__parameters:
+    host: 'router.op'
+    username: 'ros_monitor'
+    password: 'ROS2_monitor'
+    port: 443
+    use_ssl: true
+    poll_interval: 5.0
+    hardware_id: 'router.op'

--- a/bizzyboat_project11/launch/network_monitor_boat_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_boat_launch.py
@@ -5,10 +5,16 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    config_file = PathJoinSubstitution([
+    mikrotik_config = PathJoinSubstitution([
         FindPackageShare('bizzyboat_project11'),
         'config',
         'network_monitor_boat.yaml'
+    ])
+
+    teltonika_config = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'teltonika_monitor_boat.yaml'
     ])
 
     return LaunchDescription([
@@ -16,7 +22,14 @@ def generate_launch_description():
             package='mikrotik_monitor',
             executable='mikrotik_monitor_node',
             name='mikrotik_monitor',
-            parameters=[config_file],
+            parameters=[mikrotik_config],
+            output='screen',
+        ),
+        Node(
+            package='teltonika_monitor',
+            executable='teltonika_monitor_node',
+            name='teltonika_monitor',
+            parameters=[teltonika_config],
             output='screen',
         ),
         Node(

--- a/bizzyboat_project11/launch/network_monitor_boat_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_boat_launch.py
@@ -19,4 +19,14 @@ def generate_launch_description():
             parameters=[config_file],
             output='screen',
         ),
+        Node(
+            package='starlink_stats',
+            executable='starlink_diagnostics_node',
+            name='starlink_diagnostics',
+            parameters=[{
+                'dish_address': '192.168.100.1:9200',
+                'poll_rate': 1.0,
+            }],
+            output='screen',
+        ),
     ])

--- a/bizzyboat_project11/launch/network_monitor_boat_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_boat_launch.py
@@ -1,0 +1,22 @@
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    config_file = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'network_monitor_boat.yaml'
+    ])
+
+    return LaunchDescription([
+        Node(
+            package='mikrotik_monitor',
+            executable='mikrotik_monitor_node',
+            name='mikrotik_monitor',
+            parameters=[config_file],
+            output='screen',
+        ),
+    ])

--- a/bizzyboat_project11/launch/network_monitor_boat_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_boat_launch.py
@@ -17,6 +17,12 @@ def generate_launch_description():
         'teltonika_monitor_boat.yaml'
     ])
 
+    ping_config = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'ping_targets_boat.yaml'
+    ])
+
     return LaunchDescription([
         Node(
             package='mikrotik_monitor',
@@ -40,6 +46,13 @@ def generate_launch_description():
                 'dish_address': '192.168.100.1:9200',
                 'poll_rate': 1.0,
             }],
+            output='screen',
+        ),
+        Node(
+            package='network_tools',
+            executable='ping_monitor_node',
+            name='ping_monitor',
+            parameters=[ping_config],
             output='screen',
         ),
     ])

--- a/bizzyboat_project11/launch/network_monitor_operator_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_operator_launch.py
@@ -17,6 +17,12 @@ def generate_launch_description():
         'teltonika_monitor_operator.yaml'
     ])
 
+    ping_config = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'ping_targets_operator.yaml'
+    ])
+
     return LaunchDescription([
         Node(
             package='mikrotik_monitor',
@@ -40,6 +46,13 @@ def generate_launch_description():
                 'dish_address': '192.168.100.1:9200',
                 'poll_rate': 1.0,
             }],
+            output='screen',
+        ),
+        Node(
+            package='network_tools',
+            executable='ping_monitor_node',
+            name='ping_monitor',
+            parameters=[ping_config],
             output='screen',
         ),
     ])

--- a/bizzyboat_project11/launch/network_monitor_operator_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_operator_launch.py
@@ -5,10 +5,16 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    config_file = PathJoinSubstitution([
+    mikrotik_config = PathJoinSubstitution([
         FindPackageShare('bizzyboat_project11'),
         'config',
         'network_monitor_operator.yaml'
+    ])
+
+    teltonika_config = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'teltonika_monitor_operator.yaml'
     ])
 
     return LaunchDescription([
@@ -16,7 +22,14 @@ def generate_launch_description():
             package='mikrotik_monitor',
             executable='mikrotik_monitor_node',
             name='mikrotik_monitor',
-            parameters=[config_file],
+            parameters=[mikrotik_config],
+            output='screen',
+        ),
+        Node(
+            package='teltonika_monitor',
+            executable='teltonika_monitor_node',
+            name='teltonika_monitor',
+            parameters=[teltonika_config],
             output='screen',
         ),
         Node(

--- a/bizzyboat_project11/launch/network_monitor_operator_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_operator_launch.py
@@ -19,4 +19,14 @@ def generate_launch_description():
             parameters=[config_file],
             output='screen',
         ),
+        Node(
+            package='starlink_stats',
+            executable='starlink_diagnostics_node',
+            name='starlink_diagnostics',
+            parameters=[{
+                'dish_address': '192.168.100.1:9200',
+                'poll_rate': 1.0,
+            }],
+            output='screen',
+        ),
     ])

--- a/bizzyboat_project11/launch/network_monitor_operator_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_operator_launch.py
@@ -1,0 +1,22 @@
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    config_file = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'network_monitor_operator.yaml'
+    ])
+
+    return LaunchDescription([
+        Node(
+            package='mikrotik_monitor',
+            executable='mikrotik_monitor_node',
+            name='mikrotik_monitor',
+            parameters=[config_file],
+            output='screen',
+        ),
+    ])

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -21,6 +21,7 @@
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>
   <exec_depend>starlink_stats</exec_depend>
+  <exec_depend>teltonika_monitor</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>usb_cam</exec_depend>
   <depend>xacro</depend>

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>
   <exec_depend>mikrotik_monitor</exec_depend>
+  <exec_depend>network_tools</exec_depend>
   <depend>ntrip_client</depend>
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -16,6 +16,7 @@
   <depend>joint_state_publisher</depend>
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>
+  <exec_depend>mikrotik_monitor</exec_depend>
   <depend>ntrip_client</depend>
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -20,6 +20,7 @@
   <depend>ntrip_client</depend>
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>
+  <exec_depend>starlink_stats</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>usb_cam</exec_depend>
   <depend>xacro</depend>


### PR DESCRIPTION
Closes #47 (partial — MikroTik monitoring only; other nodes pending their packages)

## Summary

- Adds boat-side launch (`network_monitor_boat_launch.py`) → monitors `wifi.bizzy.p11.lan`
- Adds operator-side launch (`network_monitor_operator_launch.py`) → monitors `bizzy.wifi.op.p11.lan`
- Each side monitors only its local MikroTik device to avoid duplicate diagnostics over udp_bridge
- Config files with device-specific credentials and hardware IDs
- Adds `mikrotik_monitor` as exec_depend

## Test plan

- [ ] `ros2 launch bizzyboat_project11 network_monitor_boat_launch.py` on gabby
- [ ] `ros2 launch bizzyboat_project11 network_monitor_operator_launch.py` on salmon
- [ ] Verify diagnostics appear on `/diagnostics` from both sides

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
