### PR TITLE
feat: gitcloud field fixes — network monitoring, diagnostics, chart datum

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -296,3 +296,40 @@ chart_datum:
     map_frame: bizzy/map
     chart_datum_frame: bizzy/chart_datum
     base_frame: bizzy/base_link
+
+/**/mikrotik_monitor:
+  ros__parameters:
+    host: 'wifi.bizzy.p11.lan'
+    username: 'ros_monitor'
+    password: 'ros_monitor'
+    port: 80
+    use_ssl: false
+    poll_interval: 5.0
+    hardware_id: 'wifi.bizzy'
+
+/**/teltonika_monitor:
+  ros__parameters:
+    host: 'router.bizzy'
+    username: 'ros_monitor'
+    password: 'ROS2_monitor'
+    port: 443
+    use_ssl: true
+    poll_interval: 5.0
+    hardware_id: 'router.bizzy'
+
+/**/starlink_diagnostics:
+  ros__parameters:
+    dish_address: '192.168.100.1:9200'
+    poll_rate: 1.0
+
+/**/ping_monitor:
+  ros__parameters:
+    targets:
+      - "salmon_direct:salmon.op.p11.lan"
+      - "salmon_vpn:salmon.vpn.bizzy.p11.lan"
+      - "router_op_direct:router.op.p11.lan"
+      - "router_op_vpn:router.vpn-op.bizzy.p11.lan"
+      - "bencloud:bencloud.wg.p11.lan"
+    poll_interval: 10.0
+    ping_count: 3
+    ping_timeout: 5.0

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -118,13 +118,13 @@
               local_costmap: {source: local_costmap/costmap, period: 3.0}
               local_costmap_footprint: {source: local_costmap/published_footprint}
               odom: {source: odom}
-              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 1.0}
+              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
               oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
               oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}
               oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
               oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
-              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 1.0}
+              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 2.0}
               oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
               oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
               oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 0.5}
@@ -136,7 +136,7 @@
               oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 0.5}
               oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
               oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
-              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 1.0}
+              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 2.0}
               oak_port_info: {source: sensors/cameras/oak_port/camera_info}
               oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
               oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 0.5}
@@ -206,7 +206,7 @@
               heartbeat_nav: {source: marine/status/mission_manager}
               hover_viz: {source: hover_visualization}
               odom: {source: odom}
-              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 1.0}
+              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
               oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
               oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}
@@ -290,3 +290,9 @@
       uri: /home/field/project11/data/bizzyboat_sonar
       max_bagfile_duration: 300
       storage_preset_profile: zstd_fast
+
+chart_datum:
+  ros__parameters:
+    map_frame: bizzy/map
+    chart_datum_frame: bizzy/chart_datum
+    base_frame: bizzy/base_link

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -291,7 +291,7 @@
       max_bagfile_duration: 300
       storage_preset_profile: zstd_fast
 
-chart_datum:
+/**/chart_datum:
   ros__parameters:
     map_frame: bizzy/map
     chart_datum_frame: bizzy/chart_datum

--- a/bizzyboat_project11/config/diagnostics.yaml
+++ b/bizzyboat_project11/config/diagnostics.yaml
@@ -1,0 +1,40 @@
+/**:
+  ros__parameters:
+    path: ""
+    analyzers:
+      boat:
+        type: diagnostic_aggregator/AnalyzerGroup
+        path: Boat
+        analyzers:
+          mavros:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: MAVROS
+            startswith: ["mavros:"]
+          mavros_router:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: MAVROS Router
+            startswith: ["mavros_router:"]
+          navigation:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Navigation
+            startswith: ["lifecycle_manager_navigation:"]
+      operator:
+        type: diagnostic_aggregator/AnalyzerGroup
+        path: Operator
+        analyzers:
+          mikrotik:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: MikroTik
+            startswith: ["MikroTik:"]
+          teltonika:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Teltonika
+            startswith: ["Teltonika:"]
+          starlink:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Starlink
+            startswith: ["Starlink:"]
+          ping:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Ping
+            startswith: ["Ping:"]

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -83,6 +83,17 @@ def generate_launch_description():
                     }.items()
                 ),
 
+                # Chart datum (MLLW vertical datum transform)
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('mru_transform'),
+                            'launch',
+                            'chart_datum_launch.py'
+                        ])
+                    ),
+                ),
+
                 # MAVRos
                 GroupAction(
                     actions=[

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -188,6 +188,17 @@ def generate_launch_description():
                         )
                     ]
                 ),
+
+                # Network monitor (boat side)
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('bizzyboat_project11'),
+                            'launch',
+                            'network_monitor_boat_launch.py'
+                        ])
+                    ),
+                ),
             ]
         ),
 

--- a/bizzyboat_project11/launch/network_monitor_boat_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_boat_launch.py
@@ -5,22 +5,10 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    mikrotik_config = PathJoinSubstitution([
+    bizzyboat_config = PathJoinSubstitution([
         FindPackageShare('bizzyboat_project11'),
         'config',
-        'network_monitor_boat.yaml'
-    ])
-
-    teltonika_config = PathJoinSubstitution([
-        FindPackageShare('bizzyboat_project11'),
-        'config',
-        'teltonika_monitor_boat.yaml'
-    ])
-
-    ping_config = PathJoinSubstitution([
-        FindPackageShare('bizzyboat_project11'),
-        'config',
-        'ping_targets_boat.yaml'
+        'bizzyboat.yaml'
     ])
 
     return LaunchDescription([
@@ -28,31 +16,28 @@ def generate_launch_description():
             package='mikrotik_monitor',
             executable='mikrotik_monitor_node',
             name='mikrotik_monitor',
-            parameters=[mikrotik_config],
+            parameters=[bizzyboat_config],
             output='screen',
         ),
         Node(
             package='teltonika_monitor',
             executable='teltonika_monitor_node',
             name='teltonika_monitor',
-            parameters=[teltonika_config],
+            parameters=[bizzyboat_config],
             output='screen',
         ),
         Node(
             package='starlink_stats',
             executable='starlink_diagnostics_node',
             name='starlink_diagnostics',
-            parameters=[{
-                'dish_address': '192.168.100.1:9200',
-                'poll_rate': 1.0,
-            }],
+            parameters=[bizzyboat_config],
             output='screen',
         ),
         Node(
             package='network_tools',
             executable='ping_monitor_node',
             name='ping_monitor',
-            parameters=[ping_config],
+            parameters=[bizzyboat_config],
             output='screen',
         ),
     ])

--- a/bizzyboat_project11/launch/operator_core_launch.py
+++ b/bizzyboat_project11/launch/operator_core_launch.py
@@ -8,6 +8,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
 from launch_ros.actions import PushRosNamespace
 from launch_ros.actions import SetParametersFromFile
 from launch_ros.substitutions import FindPackageShare
@@ -51,8 +52,35 @@ def generate_launch_description():
                         ])
                     ),
                     condition=IfCondition(enable_bridge)
-                )
+                ),
+                Node(
+                    package='diagnostic_aggregator',
+                    executable='aggregator_node',
+                    name='diagnostic_aggregator',
+                    parameters=[
+                        PathJoinSubstitution([
+                            FindPackageShare('bizzyboat_project11'),
+                            'config',
+                            'diagnostics.yaml'
+                        ])
+                    ],
+                    remappings=[
+                        ('diagnostics', '/diagnostics'),
+                        ('diagnostics_agg', '/diagnostics_agg'),
+                        ('diagnostics_toplevel_state', '/diagnostics_toplevel_state'),
+                    ],
+                    output='screen',
+                ),
             ]
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([
+                    FindPackageShare('bizzyboat_project11'),
+                    'launch',
+                    'network_monitor_operator_launch.py'
+                ])
+            ),
         ),
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>
   <exec_depend>mikrotik_monitor</exec_depend>
+  <exec_depend>mru_transform</exec_depend>
   <exec_depend>network_tools</exec_depend>
   <depend>ntrip_client</depend>
   <depend>robot_state_publisher</depend>

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <exec_depend>depthai_ros_driver</exec_depend>
+  <exec_depend>diagnostic_aggregator</exec_depend>
   <depend>joint_state_publisher</depend>
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>


### PR DESCRIPTION
## Summary

Field changes from BizzyBoat deployment (2026-04-14), cherry-picked from gitcloud:

- **Network monitor integration**: merge per-node YAML configs into `bizzyboat.yaml` using `/**/<node_name>:` wildcard keys; include network monitor in core launch
- **Diagnostic aggregator**: added to operator core launch with analyzers for MAVROS, navigation, and operator-side network equipment (MikroTik, Teltonika, Starlink, Ping)
- **Chart datum config**: add chart datum transform to core launch and reduce camera UDP bridge bandwidth defaults

## Commits

- `32cc023` feat: add chart datum transform and reduce camera bridge rates
- `ed7301b` feat(bizzyboat): include network monitor in core launch
- `1de8751` fix(bizzyboat): merge network monitor params into bizzyboat.yaml
- `9f87e17` add chart datum config
- `ad80a86` feat: add diagnostic aggregator to operator launch

## Test plan

- [ ] Build `bizzyboat_project11` package
- [ ] Verify core_launch.py includes network monitors
- [ ] Verify operator_core_launch.py includes diagnostic aggregator
- [ ] Verify `bizzyboat.yaml` has wildcard params for all monitor nodes

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
