### PR TITLE
feat: annunciator config, DNS ping targets, and aggregator improvements

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -321,6 +321,7 @@
   ros__parameters:
     dish_address: '192.168.100.1:9200'
     poll_rate: 1.0
+    hardware_id: 'starlink.bizzy'
 
 /**/ping_monitor:
   ros__parameters:
@@ -330,6 +331,8 @@
       - "router_op_direct:router.op.p11.lan"
       - "router_op_vpn:router.vpn-op.bizzy.p11.lan"
       - "bencloud:bencloud.wg.p11.lan"
+      - "dns_google:8.8.8.8"
+      - "dns_cloudflare:1.1.1.1"
     poll_interval: 10.0
     ping_count: 3
     ping_timeout: 5.0

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -325,6 +325,7 @@
 
 /**/ping_monitor:
   ros__parameters:
+    hardware_id: 'ping.bizzy'
     targets:
       - "salmon_direct:salmon.op.p11.lan"
       - "salmon_vpn:salmon.vpn.bizzy.p11.lan"

--- a/bizzyboat_project11/config/bizzyboat_annunciator.yaml
+++ b/bizzyboat_project11/config/bizzyboat_annunciator.yaml
@@ -37,7 +37,7 @@ indicators:
 
   - name: Comms
     source: diagnostics
-    diagnostic_name: "Ping: salmon_direct"
+    diagnostic_name: "Ping: ping.bizzy: salmon_direct"
     format: "{}"
     stale_timeout: 30.0
 

--- a/bizzyboat_project11/config/bizzyboat_annunciator.yaml
+++ b/bizzyboat_project11/config/bizzyboat_annunciator.yaml
@@ -1,0 +1,55 @@
+diagnostics_topic: /diagnostics
+indicators:
+  # --- Link Quality ---
+  - name: WiFi Bridge
+    source: diagnostics
+    diagnostic_name: "MikroTik: wifi.bizzy: wireless/"
+    format: "{}"
+    stale_timeout: 15.0
+
+  - name: Cell Signal
+    source: diagnostics
+    diagnostic_name: "Teltonika: router.bizzy: cellular"
+    format: "{}"
+    stale_timeout: 15.0
+
+  - name: Starlink
+    source: diagnostics
+    diagnostic_name: "Starlink: starlink.bizzy"
+    format: "{}"
+    stale_timeout: 5.0
+
+  # --- Critical Systems ---
+  - name: Battery
+    source: diagnostics
+    diagnostic_name: "mavros: Battery"
+    format: "{}"
+
+  - name: GPS
+    source: diagnostics
+    diagnostic_name: "mavros: GPS"
+    format: "{}"
+
+  - name: FCU
+    source: diagnostics
+    diagnostic_name: "mavros: Heartbeat"
+    format: "{}"
+
+  - name: Comms
+    source: diagnostics
+    diagnostic_name: "Ping: salmon_direct"
+    format: "{}"
+    stale_timeout: 30.0
+
+  - name: Nav Stack
+    source: diagnostics
+    diagnostic_name: "lifecycle_manager_navigation"
+    format: "{}"
+    stale_timeout: 10.0
+
+  - name: Mission
+    source: diagnostics
+    diagnostic_name: "mission_manager"
+    match_mode: substring
+    format: "{}"
+    stale_timeout: 5.0

--- a/bizzyboat_project11/config/diagnostics.yaml
+++ b/bizzyboat_project11/config/diagnostics.yaml
@@ -18,6 +18,22 @@
             type: diagnostic_aggregator/GenericAnalyzer
             path: Navigation
             startswith: ["lifecycle_manager_navigation:"]
+          mikrotik:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: MikroTik
+            startswith: ["MikroTik: wifi.bizzy"]
+          teltonika:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Teltonika
+            startswith: ["Teltonika: router.bizzy"]
+          starlink:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Starlink
+            startswith: ["Starlink: starlink.bizzy"]
+          ping:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Ping
+            contains: ["Ping:"]
       operator:
         type: diagnostic_aggregator/AnalyzerGroup
         path: Operator
@@ -25,16 +41,12 @@
           mikrotik:
             type: diagnostic_aggregator/GenericAnalyzer
             path: MikroTik
-            startswith: ["MikroTik:"]
+            startswith: ["MikroTik: bizzy.wifi.op"]
           teltonika:
             type: diagnostic_aggregator/GenericAnalyzer
             path: Teltonika
-            startswith: ["Teltonika:"]
+            startswith: ["Teltonika: router.op"]
           starlink:
             type: diagnostic_aggregator/GenericAnalyzer
             path: Starlink
-            startswith: ["Starlink:"]
-          ping:
-            type: diagnostic_aggregator/GenericAnalyzer
-            path: Ping
-            startswith: ["Ping:"]
+            startswith: ["Starlink: starlink.op"]

--- a/bizzyboat_project11/config/diagnostics.yaml
+++ b/bizzyboat_project11/config/diagnostics.yaml
@@ -33,7 +33,7 @@
           ping:
             type: diagnostic_aggregator/GenericAnalyzer
             path: Ping
-            contains: ["Ping:"]
+            startswith: ["Ping: ping.bizzy"]
       operator:
         type: diagnostic_aggregator/AnalyzerGroup
         path: Operator
@@ -50,3 +50,7 @@
             type: diagnostic_aggregator/GenericAnalyzer
             path: Starlink
             startswith: ["Starlink: starlink.op"]
+          ping:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: Ping
+            startswith: ["Ping: ping.op"]

--- a/bizzyboat_project11/config/ping_targets_boat.yaml
+++ b/bizzyboat_project11/config/ping_targets_boat.yaml
@@ -6,6 +6,8 @@ ping_monitor:
       - "router_op_direct:router.op.p11.lan"
       - "router_op_vpn:router.vpn-op.bizzy.p11.lan"
       - "bencloud:bencloud.wg.p11.lan"
+      - "dns_google:8.8.8.8"
+      - "dns_cloudflare:1.1.1.1"
     poll_interval: 10.0
     ping_count: 3
     ping_timeout: 5.0

--- a/bizzyboat_project11/config/ping_targets_boat.yaml
+++ b/bizzyboat_project11/config/ping_targets_boat.yaml
@@ -1,5 +1,6 @@
 ping_monitor:
   ros__parameters:
+    hardware_id: 'ping.bizzy'
     targets:
       - "salmon_direct:salmon.op.p11.lan"
       - "salmon_vpn:salmon.vpn.bizzy.p11.lan"

--- a/bizzyboat_project11/config/ping_targets_operator.yaml
+++ b/bizzyboat_project11/config/ping_targets_operator.yaml
@@ -1,5 +1,6 @@
 ping_monitor:
   ros__parameters:
+    hardware_id: 'ping.op'
     targets:
       - "gabby_direct:gabby.bizzy.p11.lan"
       - "gabby_vpn:gabby.vpn.bizzy.p11.lan"

--- a/bizzyboat_project11/config/ping_targets_operator.yaml
+++ b/bizzyboat_project11/config/ping_targets_operator.yaml
@@ -6,6 +6,8 @@ ping_monitor:
       - "router_bizzy_direct:router.bizzy.p11.lan"
       - "router_bizzy_vpn:router.vpn.bizzy.p11.lan"
       - "bencloud:bencloud.wg.p11.lan"
+      - "dns_google:8.8.8.8"
+      - "dns_cloudflare:1.1.1.1"
     poll_interval: 10.0
     ping_count: 3
     ping_timeout: 5.0

--- a/bizzyboat_project11/launch/network_monitor_operator_launch.py
+++ b/bizzyboat_project11/launch/network_monitor_operator_launch.py
@@ -45,6 +45,7 @@ def generate_launch_description():
             parameters=[{
                 'dish_address': '192.168.100.1:9200',
                 'poll_rate': 1.0,
+                'hardware_id': 'starlink.op',
             }],
             output='screen',
         ),


### PR DESCRIPTION
## Summary

- **Annunciator config** (`bizzyboat_annunciator.yaml`): 9 indicators for at-a-glance operator awareness — WiFi bridge, cell signal, Starlink link quality; battery, GPS, FCU, comms, nav stack, mission manager
- **DNS ping targets**: added 8.8.8.8 and 1.1.1.1 to boat, operator, and merged ping configs — would have caught the recurring mwan3/dnsmasq DNS failure
- **Starlink hardware_id**: boat (`starlink.bizzy`) and operator (`starlink.op`) instances now distinguishable in diagnostics
- **Aggregator config**: restructured to include boat-side network devices (MikroTik, Teltonika, Starlink, Ping) using hardware_id prefixes to separate boat vs operator

Depends on [rolker/starlink_stats_ros#3](https://github.com/rolker/starlink_stats_ros/pull/3) (merged) for the hardware_id parameter.

Closes #52

## Test plan

- [ ] Build `bizzyboat_project11`
- [ ] Verify annunciator loads `bizzyboat_annunciator.yaml` and displays indicators
- [ ] Verify ping monitor targets include DNS servers
- [ ] Verify diagnostic aggregator groups boat and operator devices separately

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
