### PR TITLE
logger: add Nav2/BT action-status and planning topics to rosbag config

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -272,6 +272,19 @@
       - /bizzy/cmd_vel_smoothed
       - /bizzy/piloting_mode/autonomous/cmd_vel
       - /bizzy/mavros/setpoint_velocity/cmd_vel
+      # Nav2 / BT action status and planning (issue #58)
+      - /bizzy/run_tasks/_action/status
+      - /bizzy/run_tasks/_action/send_goal
+      - /bizzy/compute_path_through_poses/_action/status
+      - /bizzy/follow_path/_action/status
+      - /bizzy/hover/_action/status
+      - /bizzy/plan
+      - /bizzy/path_follower_visualization
+      - /bizzy/hover_visualization
+      - /bizzy/behavior_tree_log
+      - /bizzy/collision_monitor_state
+      - /bizzy/local_costmap/published_footprint
+      - /bizzy/marine/response
       - /marine/platforms
       - /rosout
       - /tf


### PR DESCRIPTION
## Summary

Adds 12 topics to the BizzyBoat rosbag logger config for
post-deployment debrief of autonomy decisions.

Closes #58

## Topics added

**Action lifecycle** (tiny bandwidth — a few bytes per state transition):
- `/bizzy/run_tasks/_action/status` — task lifecycle (primary)
- `/bizzy/run_tasks/_action/send_goal` — what mission was commanded
- `/bizzy/compute_path_through_poses/_action/status` — planner success/abort
- `/bizzy/follow_path/_action/status` — controller success/abort
- `/bizzy/hover/_action/status` — hover engage/disengage

**Planning and visualization** (small):
- `/bizzy/plan` — planned path (already bridged to operator)
- `/bizzy/path_follower_visualization` — CrabbingPathFollower viz (already bridged)
- `/bizzy/hover_visualization` — hover behavior viz (already bridged)

**Other** (tiny):
- `/bizzy/behavior_tree_log` — BT node state transitions; topic does
  not exist yet, pending [unh_marine_navigation#16](https://github.com/rolker/unh_marine_navigation/issues/16).
  Config added now so we're ready when the publisher lands.
- `/bizzy/collision_monitor_state`
- `/bizzy/local_costmap/published_footprint`
- `/bizzy/marine/response` — command responses

## Motivation

2026-04-16 field test bags showed 20× planner aborts and 9× BT task
aborts in `/rosout`, but couldn't reconstruct what was commanded, what
path was planned, or what the BT decided. These topics were already
bridged to the operator station live but not recorded.

## Test plan

- [ ] Deploy to gabby via gitcloud pull + rebuild
- [ ] Run a survey mission and verify the new topics appear in the bag
- [ ] Confirm no measurable impact on bag size (all tiny/small topics)

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6[1m]`

Generated with [Claude Code](https://claude.com/claude-code)
