### PR TITLE
feat: add UDP bridge link status to annunciator

### DIFF
--- a/bizzyboat_project11/config/bizzyboat_annunciator.yaml
+++ b/bizzyboat_project11/config/bizzyboat_annunciator.yaml
@@ -19,6 +19,18 @@ indicators:
     format: "{}"
     stale_timeout: 5.0
 
+  - name: UDP WiFi
+    source: diagnostics
+    diagnostic_name: "udp_bridge operator: bizzy: wifi"
+    format: "{}"
+    stale_timeout: 5.0
+
+  - name: UDP VPN
+    source: diagnostics
+    diagnostic_name: "udp_bridge operator: bizzy: vpn"
+    format: "{}"
+    stale_timeout: 5.0
+
   # --- Critical Systems ---
   - name: Battery
     source: diagnostics


### PR DESCRIPTION
## Summary

- Add UDP WiFi and UDP VPN indicators to the BizzyBoat annunciator config
- Sources diagnostics from the operator-side `udp_bridge` node (merged in rolker/udp_bridge#8)
- Shows per-connection tx/rx rates and silence detection at a glance

## Prerequisites

- rolker/udp_bridge#8 must be deployed on the operator station (provides the `/diagnostics` messages)

Closes #62

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
