### PR TITLE
feat: add RTK and NTRIP diagnostic nodes for annunciator

### DIFF
--- a/bizzyboat_project11/CMakeLists.txt
+++ b/bizzyboat_project11/CMakeLists.txt
@@ -10,6 +10,7 @@ install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY meshes DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY urdf DESTINATION share/${PROJECT_NAME})
 install(PROGRAMS scripts/start_tmux_project11.bash DESTINATION lib/${PROJECT_NAME})
+install(PROGRAMS scripts/gps_rtk_diagnostics_node.py DESTINATION lib/${PROJECT_NAME})
 
 ament_export_dependencies(
   xacro

--- a/bizzyboat_project11/CMakeLists.txt
+++ b/bizzyboat_project11/CMakeLists.txt
@@ -11,6 +11,7 @@ install(DIRECTORY meshes DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY urdf DESTINATION share/${PROJECT_NAME})
 install(PROGRAMS scripts/start_tmux_project11.bash DESTINATION lib/${PROJECT_NAME})
 install(PROGRAMS scripts/gps_rtk_diagnostics_node.py DESTINATION lib/${PROJECT_NAME})
+install(PROGRAMS scripts/ntrip_diagnostics_node.py DESTINATION lib/${PROJECT_NAME})
 
 ament_export_dependencies(
   xacro

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -252,7 +252,7 @@
       - /bizzy/mavros/gpsstatus/gps1/raw
       - /bizzy/mavros/imu/data
       - /bizzy/mavros/state
-      - /bizzy/sensors/ntrip/rtcm
+      - /bizzy/mavros/gps_rtk/send_rtcm
       - /bizzy/odom
       - /bizzy/marine/heartbeat
       - /bizzy/marine/status/mission_manager

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -252,6 +252,7 @@
       - /bizzy/mavros/gpsstatus/gps1/raw
       - /bizzy/mavros/imu/data
       - /bizzy/mavros/state
+      - /bizzy/sensors/ntrip/rtcm
       - /bizzy/odom
       - /bizzy/marine/heartbeat
       - /bizzy/marine/status/mission_manager

--- a/bizzyboat_project11/config/bizzyboat_annunciator.yaml
+++ b/bizzyboat_project11/config/bizzyboat_annunciator.yaml
@@ -47,6 +47,12 @@ indicators:
     diagnostic_name: "GPS: RTK"
     format: "{}"
 
+  - name: NTRIP
+    source: diagnostics
+    diagnostic_name: "NTRIP"
+    format: "{}"
+    stale_timeout: 10.0
+
   - name: FCU
     source: diagnostics
     diagnostic_name: "mavros: Heartbeat"

--- a/bizzyboat_project11/config/bizzyboat_annunciator.yaml
+++ b/bizzyboat_project11/config/bizzyboat_annunciator.yaml
@@ -42,6 +42,11 @@ indicators:
     diagnostic_name: "mavros: GPS"
     format: "{}"
 
+  - name: RTK
+    source: diagnostics
+    diagnostic_name: "GPS: RTK"
+    format: "{}"
+
   - name: FCU
     source: diagnostics
     diagnostic_name: "mavros: Heartbeat"

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -132,6 +132,20 @@ def generate_launch_description():
                     ]
                 ),
 
+                # GPS RTK diagnostics
+                Node(
+                    package='bizzyboat_project11',
+                    executable='gps_rtk_diagnostics_node.py',
+                    name='gps_rtk_diagnostics',
+                    parameters=[{
+                        'gps_raw_topic': 'mavros/gpsstatus/gps1/raw',
+                        'diagnostic_name': 'GPS: RTK',
+                        'ok_min_fix_type': 6,
+                        'warn_min_fix_type': 3,
+                    }],
+                    emulate_tty=True
+                ),
+
                 # UDP bridge
                 IncludeLaunchDescription(
                     PythonLaunchDescriptionSource(

--- a/bizzyboat_project11/launch/ntrip_launch.py
+++ b/bizzyboat_project11/launch/ntrip_launch.py
@@ -51,6 +51,20 @@ def generate_launch_description():
                         }
                     ],
                 ),
+
+                # NTRIP diagnostics (monitors RTCM flow)
+                Node(
+                    package='bizzyboat_project11',
+                    executable='ntrip_diagnostics_node.py',
+                    name='ntrip_diagnostics',
+                    parameters=[{
+                        'rtcm_topic': 'sensors/ntrip/rtcm',
+                        'diagnostic_name': 'NTRIP',
+                        'warn_timeout': 5.0,
+                        'error_timeout': 15.0,
+                    }],
+                    emulate_tty=True
+                ),
             ]
         )
     ])

--- a/bizzyboat_project11/launch/ntrip_launch.py
+++ b/bizzyboat_project11/launch/ntrip_launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
                     executable='ntrip_diagnostics_node.py',
                     name='ntrip_diagnostics',
                     parameters=[{
-                        'rtcm_topic': 'sensors/ntrip/rtcm',
+                        'rtcm_topic': 'mavros/gps_rtk/send_rtcm',
                         'diagnostic_name': 'NTRIP',
                         'warn_timeout': 5.0,
                         'error_timeout': 15.0,

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -15,8 +15,10 @@
   <exec_depend>depthai_ros_driver</exec_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
   <depend>joint_state_publisher</depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>
+  <exec_depend>mavros_msgs</exec_depend>
   <exec_depend>mikrotik_monitor</exec_depend>
   <exec_depend>mru_transform</exec_depend>
   <exec_depend>network_tools</exec_depend>

--- a/bizzyboat_project11/scripts/gps_rtk_diagnostics_node.py
+++ b/bizzyboat_project11/scripts/gps_rtk_diagnostics_node.py
@@ -44,8 +44,11 @@ class GpsRtkDiagnosticsNode(Node):
         self._ok_min = self.get_parameter('ok_min_fix_type').value
         self._warn_min = self.get_parameter('warn_min_fix_type').value
 
+        self._last_msg = None
+
         self._pub = self.create_publisher(DiagnosticArray, '/diagnostics', 10)
         self._sub = self.create_subscription(GPSRAW, topic, self._on_gps_raw, 10)
+        self._timer = self.create_timer(1.0, self._publish_diagnostic)
 
         self.get_logger().info(
             f'Publishing RTK diagnostics from "{topic}" as "{self._diagnostic_name}" '
@@ -53,6 +56,13 @@ class GpsRtkDiagnosticsNode(Node):
         )
 
     def _on_gps_raw(self, msg: GPSRAW):
+        self._last_msg = msg
+
+    def _publish_diagnostic(self):
+        if self._last_msg is None:
+            return
+
+        msg = self._last_msg
         fix_type = msg.fix_type
         label = FIX_TYPE_LABELS.get(fix_type, f'Unknown ({fix_type})')
 

--- a/bizzyboat_project11/scripts/gps_rtk_diagnostics_node.py
+++ b/bizzyboat_project11/scripts/gps_rtk_diagnostics_node.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Publish GPS RTK fix type as a ROS diagnostic.
+
+Subscribes to a mavros GPSRAW topic and publishes a DiagnosticStatus
+with human-readable fix type and configurable severity thresholds.
+"""
+
+import rclpy
+from rclpy.node import Node
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from mavros_msgs.msg import GPSRAW
+
+
+# Map fix_type integer to human-readable label.
+FIX_TYPE_LABELS = {
+    0: 'No GPS',
+    1: 'No Fix',
+    2: '2D Fix',
+    3: '3D Fix',
+    4: 'DGPS',
+    5: 'RTK Float',
+    6: 'RTK Fixed',
+    7: 'Static',
+    8: 'PPP',
+}
+
+
+class GpsRtkDiagnosticsNode(Node):
+
+    def __init__(self):
+        super().__init__('gps_rtk_diagnostics')
+
+        self.declare_parameter('gps_raw_topic', 'mavros/gpsstatus/gps1/raw')
+        self.declare_parameter('diagnostic_name', 'GPS: RTK')
+        self.declare_parameter('hardware_id', '')
+        # Minimum fix_type for OK level (default: RTK Fixed = 6)
+        self.declare_parameter('ok_min_fix_type', 6)
+        # Minimum fix_type for WARN level (default: 3D Fix = 3)
+        self.declare_parameter('warn_min_fix_type', 3)
+
+        topic = self.get_parameter('gps_raw_topic').value
+        self._diagnostic_name = self.get_parameter('diagnostic_name').value
+        self._hardware_id = self.get_parameter('hardware_id').value
+        self._ok_min = self.get_parameter('ok_min_fix_type').value
+        self._warn_min = self.get_parameter('warn_min_fix_type').value
+
+        self._pub = self.create_publisher(DiagnosticArray, '/diagnostics', 10)
+        self._sub = self.create_subscription(GPSRAW, topic, self._on_gps_raw, 10)
+
+        self.get_logger().info(
+            f'Publishing RTK diagnostics from "{topic}" as "{self._diagnostic_name}" '
+            f'(OK >= {self._ok_min}, WARN >= {self._warn_min})'
+        )
+
+    def _on_gps_raw(self, msg: GPSRAW):
+        fix_type = msg.fix_type
+        label = FIX_TYPE_LABELS.get(fix_type, f'Unknown ({fix_type})')
+
+        if fix_type >= self._ok_min:
+            level = DiagnosticStatus.OK
+        elif fix_type >= self._warn_min:
+            level = DiagnosticStatus.WARN
+        else:
+            level = DiagnosticStatus.ERROR
+
+        status = DiagnosticStatus()
+        status.level = level
+        status.name = self._diagnostic_name
+        status.message = label
+        status.hardware_id = self._hardware_id
+        status.values = [
+            KeyValue(key='fix_type', value=str(fix_type)),
+            KeyValue(key='satellites_visible', value=str(msg.satellites_visible)),
+            KeyValue(key='eph', value=str(msg.eph)),
+        ]
+
+        array = DiagnosticArray()
+        array.header.stamp = self.get_clock().now().to_msg()
+        array.status = [status]
+        self._pub.publish(array)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = GpsRtkDiagnosticsNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/bizzyboat_project11/scripts/ntrip_diagnostics_node.py
+++ b/bizzyboat_project11/scripts/ntrip_diagnostics_node.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Publish NTRIP connection status as a ROS diagnostic.
+
+Monitors the RTCM topic from the NTRIP client. If messages stop
+arriving, escalates from OK to WARN to ERROR based on configurable
+timeouts.
+"""
+
+import rclpy
+from rclpy.node import Node
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from mavros_msgs.msg import RTCM
+
+
+class NtripDiagnosticsNode(Node):
+
+    def __init__(self):
+        super().__init__('ntrip_diagnostics')
+
+        self.declare_parameter('rtcm_topic', 'sensors/ntrip/rtcm')
+        self.declare_parameter('diagnostic_name', 'NTRIP')
+        self.declare_parameter('hardware_id', '')
+        # Seconds without RTCM before WARN
+        self.declare_parameter('warn_timeout', 5.0)
+        # Seconds without RTCM before ERROR
+        self.declare_parameter('error_timeout', 15.0)
+        # Diagnostic publish rate (Hz)
+        self.declare_parameter('publish_rate', 1.0)
+
+        topic = self.get_parameter('rtcm_topic').value
+        self._diagnostic_name = self.get_parameter('diagnostic_name').value
+        self._hardware_id = self.get_parameter('hardware_id').value
+        self._warn_timeout = self.get_parameter('warn_timeout').value
+        self._error_timeout = self.get_parameter('error_timeout').value
+        rate = self.get_parameter('publish_rate').value
+
+        self._last_rtcm_time = None
+        self._msg_count = 0
+
+        self._pub = self.create_publisher(DiagnosticArray, '/diagnostics', 10)
+        self._sub = self.create_subscription(RTCM, topic, self._on_rtcm, 10)
+        self._timer = self.create_timer(1.0 / rate, self._publish_diagnostic)
+
+        self.get_logger().info(
+            f'Monitoring NTRIP via "{topic}" as "{self._diagnostic_name}" '
+            f'(WARN after {self._warn_timeout}s, ERROR after {self._error_timeout}s)'
+        )
+
+    def _on_rtcm(self, msg: RTCM):
+        self._last_rtcm_time = self.get_clock().now()
+        self._msg_count += 1
+
+    def _publish_diagnostic(self):
+        now = self.get_clock().now()
+
+        if self._last_rtcm_time is None:
+            age = -1.0
+            level = DiagnosticStatus.ERROR
+            message = 'no data received'
+        else:
+            age = (now - self._last_rtcm_time).nanoseconds / 1e9
+            if age > self._error_timeout:
+                level = DiagnosticStatus.ERROR
+                message = f'no data for {age:.0f}s'
+            elif age > self._warn_timeout:
+                level = DiagnosticStatus.WARN
+                message = f'no data for {age:.0f}s'
+            else:
+                level = DiagnosticStatus.OK
+                message = 'receiving corrections'
+
+        status = DiagnosticStatus()
+        status.level = level
+        status.name = self._diagnostic_name
+        status.message = message
+        status.hardware_id = self._hardware_id
+        status.values = [
+            KeyValue(key='messages_received', value=str(self._msg_count)),
+            KeyValue(key='last_rtcm_age_s', value=f'{age:.1f}'),
+        ]
+
+        array = DiagnosticArray()
+        array.header.stamp = now.to_msg()
+        array.status = [status]
+        self._pub.publish(array)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = NtripDiagnosticsNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Remaining annunciator commits from #63 that were pushed after the PR was merged.

- **RTK diagnostic node** — `gps_rtk_diagnostics_node.py` subscribes to mavros GPSRAW, publishes human-readable fix status with configurable thresholds
- **NTRIP diagnostic node** — `ntrip_diagnostics_node.py` monitors RTCM flow, escalates to WARN/ERROR on configurable timeouts
- **RTCM bag recording** — adds `/bizzy/sensors/ntrip/rtcm` to logger topic list (~1.5-3 MB/hr)

## Test plan

- [ ] Verify RTK indicator shows correct fix type with appropriate colors
- [ ] Verify NTRIP indicator detects correction stream loss
- [ ] Verify RTCM data appears in bag files

Closes #61, closes #60

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
