### PR TITLE
feat: gitcloud field fixes — operator tmux, zenoh, interface suppression

### DIFF
--- a/bizzyboat_project11/CMakeLists.txt
+++ b/bizzyboat_project11/CMakeLists.txt
@@ -9,7 +9,10 @@ install(DIRECTORY docs DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY meshes DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY urdf DESTINATION share/${PROJECT_NAME})
-install(PROGRAMS scripts/start_tmux_project11.bash DESTINATION lib/${PROJECT_NAME})
+install(PROGRAMS
+  scripts/start_tmux_project11.bash
+  scripts/start_tmux_operator_project11.bash
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_export_dependencies(
   xacro

--- a/bizzyboat_project11/CMakeLists.txt
+++ b/bizzyboat_project11/CMakeLists.txt
@@ -12,6 +12,7 @@ install(DIRECTORY urdf DESTINATION share/${PROJECT_NAME})
 install(PROGRAMS
   scripts/start_tmux_project11.bash
   scripts/start_tmux_operator_project11.bash
+  scripts/stop_tmux_project11.bash
   DESTINATION lib/${PROJECT_NAME})
 
 ament_export_dependencies(

--- a/bizzyboat_project11/config/network_monitor_boat.yaml
+++ b/bizzyboat_project11/config/network_monitor_boat.yaml
@@ -7,3 +7,4 @@ mikrotik_monitor:
     use_ssl: false
     poll_interval: 5.0
     hardware_id: 'wifi.bizzy'
+    ignored_interfaces: ['ether2', 'ether3', 'ether4', 'ether5']

--- a/bizzyboat_project11/config/teltonika_monitor_boat.yaml
+++ b/bizzyboat_project11/config/teltonika_monitor_boat.yaml
@@ -7,3 +7,4 @@ teltonika_monitor:
     use_ssl: true
     poll_interval: 5.0
     hardware_id: 'router.bizzy'
+    ignored_interfaces: ['mob1s2a1', 'wan1']

--- a/bizzyboat_project11/config/teltonika_monitor_operator.yaml
+++ b/bizzyboat_project11/config/teltonika_monitor_operator.yaml
@@ -8,3 +8,4 @@ teltonika_monitor:
     poll_interval: 5.0
     hardware_id: 'router.op'
     ignored_interfaces: ['mob1s1a1', 'mob1s2a1', 'wifi_bridge', 'mobile_lab']
+    publish_cellular: false

--- a/bizzyboat_project11/config/teltonika_monitor_operator.yaml
+++ b/bizzyboat_project11/config/teltonika_monitor_operator.yaml
@@ -7,3 +7,4 @@ teltonika_monitor:
     use_ssl: true
     poll_interval: 5.0
     hardware_id: 'router.op'
+    ignored_interfaces: ['mob1s1a1', 'mob1s2a1', 'wifi_bridge', 'mobile_lab']

--- a/bizzyboat_project11/launch/operator_core_launch.py
+++ b/bizzyboat_project11/launch/operator_core_launch.py
@@ -3,7 +3,6 @@ from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
 from launch.conditions import IfCondition
-from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
@@ -96,15 +95,6 @@ def generate_launch_description():
                 'enable_bridge': 'false',
                 'operator_joystick': 'true'
             }.items()
-        ),
-        IncludeLaunchDescription(
-            AnyLaunchDescriptionSource(
-                PathJoinSubstitution([
-                    FindPackageShare('foxglove_bridge'),
-                    'launch',
-                    'foxglove_bridge_launch.xml'
-                ])
-            ),
         ),
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>mru_transform</exec_depend>
   <exec_depend>network_tools</exec_depend>
   <depend>ntrip_client</depend>
+  <exec_depend>rmw_zenoh_cpp</exec_depend>
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>
   <exec_depend>starlink_stats</exec_depend>

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -1,19 +1,18 @@
 #!/bin/bash
 
-# called from cron @reboot using field's user crontab
+# called from cron @reboot (or by hand) on the operator station
 
 DAY=$(date "+%Y-%m-%d")
 NOW=$(date "+%Y-%m-%dT%H.%M.%S.%N")
-LOGDIR="${P11_LOG_DIR:-/home/field/data/logs/bizzyboat}"
+LOGDIR="${P11_LOG_DIR:-/home/field/data/logs/operator}"
 
 mkdir -p "$LOGDIR"
 LOG_FILE="${LOGDIR}/autostart_${NOW}.txt"
-LOGDIR_BAG="${LOGDIR}/${NOW}"
 {
 
 echo ""
 echo "#############################################"
-echo "Running start_tmux_project11.bash"
+echo "Running start_tmux_operator_project11.bash"
 date
 echo "#############################################"
 echo ""
@@ -35,19 +34,24 @@ export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 /usr/bin/tmux send-keys "ros2 run rmw_zenoh_cpp rmw_zenohd" C-m
 sleep 2
 
-# Core: mavros, mru_transform, UDP bridge, NTRIP
+# Core: UDP bridge, diagnostic aggregator, network monitor, operator core, state publisher
 /usr/bin/tmux new-window -t project11 -n core
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && export ROS_S57_ENC_ROOT=/home/field/data/ENC_ROOT" C-m
-/usr/bin/tmux send-keys "ros2 launch bizzyboat_project11 core_launch.py" C-m
+/usr/bin/tmux send-keys "ros2 launch bizzyboat_project11 operator_core_launch.py" C-m
 
-# Perception: cameras, sonar, logging
-/usr/bin/tmux new-window -t project11 -n perception
+# Foxglove bridge: isolated so its chatter doesn't drown the core pane
+/usr/bin/tmux new-window -t project11 -n foxglove
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp" C-m
-/usr/bin/tmux send-keys "ros2 launch bizzyboat_project11 perception_launch.py log_directory:=${LOGDIR_BAG}" C-m
+/usr/bin/tmux send-keys "ros2 launch foxglove_bridge foxglove_bridge_launch.xml" C-m
 
-# Nav: autonomy, helm, s57, nav2
-/usr/bin/tmux new-window -t project11 -n nav
+# UI: camp + rqt (bizzyboat perspective) + joystick, etc.
+/usr/bin/tmux new-window -t project11 -n ui
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && export ROS_S57_ENC_ROOT=/home/field/data/ENC_ROOT" C-m
-/usr/bin/tmux send-keys "ros2 launch bizzyboat_project11 nav_launch.py" C-m
+/usr/bin/tmux send-keys "ros2 launch bizzyboat_project11 operator_ui_launch.py" C-m
+
+# Second rqt with bizzyboat-diagnostics perspective
+/usr/bin/tmux new-window -t project11 -n rqt-diag
+/usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp" C-m
+/usr/bin/tmux send-keys "ros2 run rqt_gui rqt_gui -p bizzyboat-diagnostics" C-m
 
 } >> "${LOG_FILE}" 2>&1

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -44,6 +44,10 @@ sleep 2
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp" C-m
 /usr/bin/tmux send-keys "ros2 launch foxglove_bridge foxglove_bridge_launch.xml" C-m
 
+# Foxglove Studio: desktop client that connects to the bridge above
+/usr/bin/tmux new-window -t project11 -n studio
+/usr/bin/tmux send-keys "foxglove-studio" C-m
+
 # UI: camp + rqt (bizzyboat perspective) + joystick, etc.
 /usr/bin/tmux new-window -t project11 -n ui
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && export ROS_S57_ENC_ROOT=/home/field/data/ENC_ROOT" C-m

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -26,6 +26,12 @@ set -v
 export ROS_S57_ENC_ROOT=/home/field/data/ENC_ROOT
 export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
+if /usr/bin/tmux has-session -t project11 2>/dev/null; then
+    echo "WARNING: tmux session 'project11' already exists. Not starting a new one."
+    echo "Use 'tmux attach -t project11' to connect, or stop it first."
+    exit 0
+fi
+
 /usr/bin/tmux new -d -s project11
 /usr/bin/tmux rename-window -t project11 zenoh
 

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -58,4 +58,9 @@ sleep 2
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp" C-m
 /usr/bin/tmux send-keys "ros2 run rqt_gui rqt_gui -p bizzyboat-diagnostics" C-m
 
+# Johnny5 PTZ camera (axis) from molab_hardware
+/usr/bin/tmux new-window -t project11 -n johnny5
+/usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp" C-m
+/usr/bin/tmux send-keys "ros2 launch molab_hardware johnny5_launch.py" C-m
+
 } >> "${LOG_FILE}" 2>&1

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -28,7 +28,7 @@ export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
 if /usr/bin/tmux has-session -t project11 2>/dev/null; then
     echo "WARNING: tmux session 'project11' already exists. Not starting a new one."
-    echo "Use 'tmux attach -t project11' to connect, or stop it first."
+    echo "Use 'tmux attach -t project11' to connect, or run stop_tmux_project11.bash first."
     exit 0
 fi
 

--- a/bizzyboat_project11/scripts/start_tmux_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_project11.bash
@@ -29,7 +29,7 @@ export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
 if /usr/bin/tmux has-session -t project11 2>/dev/null; then
     echo "WARNING: tmux session 'project11' already exists. Not starting a new one."
-    echo "Use 'tmux attach -t project11' to connect, or stop it first."
+    echo "Use 'tmux attach -t project11' to connect, or run stop_tmux_project11.bash first."
     exit 0
 fi
 

--- a/bizzyboat_project11/scripts/start_tmux_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_project11.bash
@@ -27,6 +27,12 @@ set -v
 export ROS_S57_ENC_ROOT=/home/field/data/ENC_ROOT
 export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
+if /usr/bin/tmux has-session -t project11 2>/dev/null; then
+    echo "WARNING: tmux session 'project11' already exists. Not starting a new one."
+    echo "Use 'tmux attach -t project11' to connect, or stop it first."
+    exit 0
+fi
+
 /usr/bin/tmux new -d -s project11
 /usr/bin/tmux rename-window -t project11 zenoh
 

--- a/bizzyboat_project11/scripts/stop_tmux_project11.bash
+++ b/bizzyboat_project11/scripts/stop_tmux_project11.bash
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Gracefully stop the project11 tmux session.
+# Works for both boat-side and operator-side sessions.
+# Sends SIGINT to each window, verifies exit, then kills the session.
+
+SESSION="project11"
+SHUTDOWN_TIMEOUT=10  # seconds to wait per window after Ctrl-C
+
+if ! /usr/bin/tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "No tmux session '$SESSION' is running."
+    exit 0
+fi
+
+echo "Stopping tmux session '$SESSION'..."
+
+# Get list of windows (excluding zenoh — stopped last)
+WINDOWS=$(/usr/bin/tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -v '^zenoh$')
+
+# Stop all non-zenoh windows first
+for window in $WINDOWS; do
+    echo "  Stopping window: $window"
+    /usr/bin/tmux send-keys -t "${SESSION}:${window}" C-c 2>/dev/null
+done
+
+# Wait for non-zenoh processes to exit
+echo "  Waiting for processes to exit (up to ${SHUTDOWN_TIMEOUT}s)..."
+for window in $WINDOWS; do
+    elapsed=0
+    while [ $elapsed -lt $SHUTDOWN_TIMEOUT ]; do
+        # Check if pane still has a running foreground process (not just a shell prompt)
+        pane_pid=$(/usr/bin/tmux list-panes -t "${SESSION}:${window}" -F '#{pane_pid}' 2>/dev/null | head -1)
+        if [ -z "$pane_pid" ]; then
+            break  # window gone
+        fi
+        # Count children of the shell — if only the shell remains, process exited
+        children=$(pgrep -P "$pane_pid" 2>/dev/null | wc -l)
+        if [ "$children" -eq 0 ]; then
+            break
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    if [ $elapsed -ge $SHUTDOWN_TIMEOUT ]; then
+        echo "    WARNING: $window did not stop within ${SHUTDOWN_TIMEOUT}s"
+    fi
+done
+
+# Now stop zenoh router
+if /usr/bin/tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -q '^zenoh$'; then
+    echo "  Stopping zenoh router..."
+    /usr/bin/tmux send-keys -t "${SESSION}:zenoh" C-c 2>/dev/null
+    elapsed=0
+    while [ $elapsed -lt $SHUTDOWN_TIMEOUT ]; do
+        pane_pid=$(/usr/bin/tmux list-panes -t "${SESSION}:zenoh" -F '#{pane_pid}' 2>/dev/null | head -1)
+        if [ -z "$pane_pid" ]; then
+            break
+        fi
+        children=$(pgrep -P "$pane_pid" 2>/dev/null | wc -l)
+        if [ "$children" -eq 0 ]; then
+            break
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    if [ $elapsed -ge $SHUTDOWN_TIMEOUT ]; then
+        echo "    WARNING: zenoh did not stop within ${SHUTDOWN_TIMEOUT}s"
+    fi
+fi
+
+# Kill the tmux session
+echo "  Killing tmux session..."
+/usr/bin/tmux kill-session -t "$SESSION"
+echo "Done. Session '$SESSION' stopped."


### PR DESCRIPTION
## Summary

Field fixes from gitcloud deployment sessions:

- Switch to `rmw_zenoh_cpp` and add operator tmux startup script
- Add foxglove-studio pane to operator tmux startup
- Suppress expected-inoperative interface warnings in network monitor config
- Suppress cellular WARN on operator-side Teltonika (no modem)
- Add johnny5 PTZ camera pane to operator tmux startup

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
