### PR TITLE
Record FCU servo output and nav controller output in bag

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -253,6 +253,11 @@
       - /bizzy/mavros/imu/data
       - /bizzy/mavros/state
       - /bizzy/mavros/gps_rtk/send_rtcm
+      # FCU control effort — see what the autopilot is actually commanding
+      # to the thrusters/servos (rc/out) and how hard its internal nav
+      # controller is working to follow cmd_vel (nav_controller_output).
+      - /bizzy/mavros/rc/out
+      - /bizzy/mavros/nav_controller_output
       - /bizzy/odom
       - /bizzy/marine/heartbeat
       - /bizzy/marine/status/mission_manager


### PR DESCRIPTION
Closes #69

## Summary

Adds two mavros topics to the recorded topic list in
`bizzyboat.yaml` to capture what the FCU is actually doing in
response to our `cmd_vel` inputs:

- `/bizzy/mavros/rc/out` — per-channel PWM to thrusters/servos
- `/bizzy/mavros/nav_controller_output` — ArduRover's internal
  desired-vs-actual tracking

Both are ~10 Hz at default mavros stream rates; negligible bag size
impact.

## Test plan

- Next session's bag should include the two new topics populated
  with data (verify with `ros2 bag info` or topic message counts).
- Bag replay should show coherent PWM trajectories correlated with
  throttle / yaw-rate command changes.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
