### PR TITLE
fix(bizzyboat): enable S57 grid precompute on s57_grids

### DIFF
--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -191,6 +191,20 @@ def generate_launch_description():
                             name='map_frame',
                             value=[frame_prefix, 'map']
                         ),
+                        # Eager chart precompute: when TF (map → robot_base_frame)
+                        # first becomes available, queue all charts within
+                        # precompute_radius for std::async processing so the
+                        # costmap layer's first get_datasets call finds them
+                        # already cached or close to ready. Cuts cold-cache
+                        # startup latency. Requires rolker/s57_tools#19.
+                        SetParameter(
+                            name='robot_base_frame',
+                            value=[frame_prefix, 'base_link']
+                        ),
+                        SetParameter(
+                            name='precompute_radius',
+                            value=5000.0
+                        ),
                         IncludeLaunchDescription(
                             PythonLaunchDescriptionSource(
                                 PathJoinSubstitution([


### PR DESCRIPTION
## Summary

Add two `SetParameter` calls (`robot_base_frame`, `precompute_radius`) next to the existing `map_frame` setup in `bizzyboat_project11/launch/core_launch.py`'s s57 `GroupAction`. Enables eager chart precompute on first TF availability, eliminating most of the cold-cache startup wait for the first plan.

`frame_prefix` resolves to `bizzy/`, so `robot_base_frame` becomes `bizzy/base_link`. 5 km radius matches typical Portsmouth Harbor survey area.

Closes #73. **Requires** rolker/s57_tools#19 / PR #20 (which adds the parameters to `s57_grids_node`). No effect / no harm before that lands; unknown parameters are silently ignored.

## Test plan

- [x] Launch-file change only.
- [ ] Field validation on next BizzyBoat outing: log shows `Precompute enabled` and `Precompute: queued N of M charts within 5000 m of (lat, lon).` from `s57_grids_node` shortly after node activation. Compare first-plan time vs current baseline.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
