### PR TITLE
feat(bizzyboat): roll out H.265 on all four OAKs over wifi + vpn (#78)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -73,6 +73,7 @@
             - local_costmap_footprint
             - global_costmap
             - oak_forward
+            - oak_forward_ffmpeg
             - oak_forward_info
             - oak_forward_raw
             - oak_segmentation_forward
@@ -119,6 +120,7 @@
               local_costmap_footprint: {source: local_costmap/published_footprint}
               odom: {source: odom}
               oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
+              oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg}
               oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
               oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -175,27 +175,31 @@
             - heartbeat_nav
             - hover_viz
             - oak_forward
+            - oak_forward_ffmpeg
             - oak_forward_info
             - oak_forward_raw
             - oak_segmentation_forward
             - oak_segmentation_forward_info
             - oak_segmentation_forward_raw
             # - oak_starboard
+            - oak_starboard_ffmpeg
             # - oak_starboard_info
             # - oak_starboard_raw
-            # - oak_segmentation_starboard
+            - oak_segmentation_starboard
             # - oak_segmentation_starboard_info
             # - oak_segmentation_starboard_raw
             # - oak_aft
+            - oak_aft_ffmpeg
             # - oak_aft_info
             # - oak_aft_raw
-            # - oak_segmentation_aft
+            - oak_segmentation_aft
             # - oak_segmentation_aft_info
             # - oak_segmentation_aft_raw
             # - oak_port
+            - oak_port_ffmpeg
             # - oak_port_info
             # - oak_port_raw
-            # - oak_segmentation_port
+            - oak_segmentation_port
             # - oak_segmentation_port_info
             # - oak_segmentation_port_raw
             - odom
@@ -215,27 +219,31 @@
               hover_viz: {source: hover_visualization}
               odom: {source: odom}
               oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
+              oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg}
               oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
               oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
-              oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}
+              oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 1.0}
               oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
               oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
               oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 1.0}
+              oak_starboard_ffmpeg: {source: sensors/cameras/oak_starboard/image_raw/ffmpeg}
               oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
               oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
-              oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 0.5}
+              oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 1.0}
               oak_segmentation_starboard_info: {source: sensors/cameras/oak_starboard/segmentation/camera_info}
               oak_segmentation_starboard_raw:    {source: sensors/cameras/oak_starboard/segmentation, period: -1.0}
               oak_aft:      {source: sensors/cameras/oak_aft/image_raw/compressed, period: 2.0}
+              oak_aft_ffmpeg: {source: sensors/cameras/oak_aft/image_raw/ffmpeg}
               oak_aft_info: {source: sensors/cameras/oak_aft/camera_info}
               oak_aft_raw:  {source: sensors/cameras/oak_aft/image_raw, period: -1.0}
-              oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 0.5}
+              oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 1.0}
               oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
               oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
               oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 1.0}
+              oak_port_ffmpeg: {source: sensors/cameras/oak_port/image_raw/ffmpeg}
               oak_port_info: {source: sensors/cameras/oak_port/camera_info}
               oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
-              oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 0.5}
+              oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 1.0}
               oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
               oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0}
               battery: {source: /bizzy/mavros/battery}

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -72,31 +72,19 @@
             - local_costmap
             - local_costmap_footprint
             - global_costmap
-            - oak_forward
             - oak_forward_ffmpeg
-            - oak_forward_info
-            - oak_forward_raw
             - oak_segmentation_forward
             - oak_segmentation_forward_info
             - oak_segmentation_forward_raw
-            - oak_starboard
             - oak_starboard_ffmpeg
-            - oak_starboard_info
-            - oak_starboard_raw
             - oak_segmentation_starboard
             - oak_segmentation_starboard_info
             - oak_segmentation_starboard_raw
-            - oak_aft
             - oak_aft_ffmpeg
-            - oak_aft_info
-            - oak_aft_raw
             - oak_segmentation_aft
             - oak_segmentation_aft_info
             - oak_segmentation_aft_raw
-            - oak_port
             - oak_port_ffmpeg
-            - oak_port_info
-            - oak_port_raw
             - oak_segmentation_port
             - oak_segmentation_port_info
             - oak_segmentation_port_raw
@@ -122,31 +110,19 @@
               local_costmap: {source: local_costmap/costmap, period: 3.0}
               local_costmap_footprint: {source: local_costmap/published_footprint}
               odom: {source: odom}
-              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg}
-              oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
-              oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed}
               oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
               oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
-              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 2.0}
               oak_starboard_ffmpeg: {source: sensors/cameras/oak_starboard/image_raw/ffmpeg}
-              oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
-              oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
               oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed}
               oak_segmentation_starboard_info: {source: sensors/cameras/oak_starboard/segmentation/camera_info}
               oak_segmentation_starboard_raw:    {source: sensors/cameras/oak_starboard/segmentation, period: -1.0}
-              oak_aft:      {source: sensors/cameras/oak_aft/image_raw/compressed, period: 2.0}
               oak_aft_ffmpeg: {source: sensors/cameras/oak_aft/image_raw/ffmpeg}
-              oak_aft_info: {source: sensors/cameras/oak_aft/camera_info}
-              oak_aft_raw:  {source: sensors/cameras/oak_aft/image_raw, period: -1.0}
               oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed}
               oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
               oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
-              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 2.0}
               oak_port_ffmpeg: {source: sensors/cameras/oak_port/image_raw/ffmpeg}
-              oak_port_info: {source: sensors/cameras/oak_port/camera_info}
-              oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
               oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed}
               oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
               oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0}
@@ -174,34 +150,16 @@
             - heartbeat
             - heartbeat_nav
             - hover_viz
-            - oak_forward
             - oak_forward_ffmpeg
-            - oak_forward_info
-            - oak_forward_raw
             - oak_segmentation_forward
             - oak_segmentation_forward_info
             - oak_segmentation_forward_raw
-            # - oak_starboard
             - oak_starboard_ffmpeg
-            # - oak_starboard_info
-            # - oak_starboard_raw
             - oak_segmentation_starboard
-            # - oak_segmentation_starboard_info
-            # - oak_segmentation_starboard_raw
-            # - oak_aft
             - oak_aft_ffmpeg
-            # - oak_aft_info
-            # - oak_aft_raw
             - oak_segmentation_aft
-            # - oak_segmentation_aft_info
-            # - oak_segmentation_aft_raw
-            # - oak_port
             - oak_port_ffmpeg
-            # - oak_port_info
-            # - oak_port_raw
             - oak_segmentation_port
-            # - oak_segmentation_port_info
-            # - oak_segmentation_port_raw
             - odom
             - plan
             - platforms
@@ -218,31 +176,19 @@
               heartbeat_nav: {source: marine/status/mission_manager}
               hover_viz: {source: hover_visualization}
               odom: {source: odom}
-              oak_forward:      {source: sensors/cameras/oak_forward/image_raw/compressed, period: 2.0}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg}
-              oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
-              oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 1.0}
               oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
               oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
-              oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 1.0}
               oak_starboard_ffmpeg: {source: sensors/cameras/oak_starboard/image_raw/ffmpeg}
-              oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
-              oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
               oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 1.0}
               oak_segmentation_starboard_info: {source: sensors/cameras/oak_starboard/segmentation/camera_info}
               oak_segmentation_starboard_raw:    {source: sensors/cameras/oak_starboard/segmentation, period: -1.0}
-              oak_aft:      {source: sensors/cameras/oak_aft/image_raw/compressed, period: 2.0}
               oak_aft_ffmpeg: {source: sensors/cameras/oak_aft/image_raw/ffmpeg}
-              oak_aft_info: {source: sensors/cameras/oak_aft/camera_info}
-              oak_aft_raw:  {source: sensors/cameras/oak_aft/image_raw, period: -1.0}
               oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 1.0}
               oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
               oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
-              oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 1.0}
               oak_port_ffmpeg: {source: sensors/cameras/oak_port/image_raw/ffmpeg}
-              oak_port_info: {source: sensors/cameras/oak_port/camera_info}
-              oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
               oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 1.0}
               oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
               oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0}

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -80,18 +80,21 @@
             - oak_segmentation_forward_info
             - oak_segmentation_forward_raw
             - oak_starboard
+            - oak_starboard_ffmpeg
             - oak_starboard_info
             - oak_starboard_raw
             - oak_segmentation_starboard
             - oak_segmentation_starboard_info
             - oak_segmentation_starboard_raw
             - oak_aft
+            - oak_aft_ffmpeg
             - oak_aft_info
             - oak_aft_raw
             - oak_segmentation_aft
             - oak_segmentation_aft_info
             - oak_segmentation_aft_raw
             - oak_port
+            - oak_port_ffmpeg
             - oak_port_info
             - oak_port_raw
             - oak_segmentation_port
@@ -123,25 +126,28 @@
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg}
               oak_forward_info: {source: sensors/cameras/oak_forward/camera_info}
               oak_forward_raw:    {source: sensors/cameras/oak_forward/image_raw, period: -1.0}
-              oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 0.5}
+              oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed}
               oak_segmentation_forward_info: {source: sensors/cameras/oak_forward/segmentation/camera_info}
               oak_segmentation_forward_raw:    {source: sensors/cameras/oak_forward/segmentation, period: -1.0}
               oak_starboard:      {source: sensors/cameras/oak_starboard/image_raw/compressed, period: 2.0}
+              oak_starboard_ffmpeg: {source: sensors/cameras/oak_starboard/image_raw/ffmpeg}
               oak_starboard_info: {source: sensors/cameras/oak_starboard/camera_info}
               oak_starboard_raw:  {source: sensors/cameras/oak_starboard/image_raw, period: -1.0}
-              oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed, period: 0.5}
+              oak_segmentation_starboard:      {source: sensors/cameras/oak_starboard/segmentation/compressed}
               oak_segmentation_starboard_info: {source: sensors/cameras/oak_starboard/segmentation/camera_info}
               oak_segmentation_starboard_raw:    {source: sensors/cameras/oak_starboard/segmentation, period: -1.0}
               oak_aft:      {source: sensors/cameras/oak_aft/image_raw/compressed, period: 2.0}
+              oak_aft_ffmpeg: {source: sensors/cameras/oak_aft/image_raw/ffmpeg}
               oak_aft_info: {source: sensors/cameras/oak_aft/camera_info}
               oak_aft_raw:  {source: sensors/cameras/oak_aft/image_raw, period: -1.0}
-              oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed, period: 0.5}
+              oak_segmentation_aft:      {source: sensors/cameras/oak_aft/segmentation/compressed}
               oak_segmentation_aft_info: {source: sensors/cameras/oak_aft/segmentation/camera_info}
               oak_segmentation_aft_raw:    {source: sensors/cameras/oak_aft/segmentation, period: -1.0}
               oak_port:      {source: sensors/cameras/oak_port/image_raw/compressed, period: 2.0}
+              oak_port_ffmpeg: {source: sensors/cameras/oak_port/image_raw/ffmpeg}
               oak_port_info: {source: sensors/cameras/oak_port/camera_info}
               oak_port_raw:  {source: sensors/cameras/oak_port/image_raw, period: -1.0}
-              oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed, period: 0.5}
+              oak_segmentation_port:      {source: sensors/cameras/oak_port/segmentation/compressed}
               oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
               oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0}
               path_follower_visualization: {source: path_follower_visualization}

--- a/bizzyboat_project11/launch/oak_cameras_launch.py
+++ b/bizzyboat_project11/launch/oak_cameras_launch.py
@@ -7,11 +7,14 @@ from launch_ros.substitutions import FindPackageShare
 # BizzyBoat OAK camera MXIDs (verified 2026-03-30). Each entry may carry
 # optional flags; absent flags fall back to sea_surface_segmentation defaults.
 CAMERAS = {
-    'oak_forward':   {'mx_id': '19443010D117872D00', 'h265_enable': True,
-                      'h265_bitrate_kbps': 2000},
-    'oak_starboard': {'mx_id': '19443010E11A872D00'},
-    'oak_aft':       {'mx_id': '14442C10917D8DD700'},
-    'oak_port':      {'mx_id': '194430106121872D00'},
+    'oak_forward':   {'mx_id': '19443010D117872D00', 'enable_video': False,
+                      'h265_enable': True, 'h265_bitrate_kbps': 1000},
+    'oak_starboard': {'mx_id': '19443010E11A872D00', 'enable_video': False,
+                      'h265_enable': True, 'h265_bitrate_kbps': 1000},
+    'oak_aft':       {'mx_id': '14442C10917D8DD700', 'enable_video': False,
+                      'h265_enable': True, 'h265_bitrate_kbps': 1000},
+    'oak_port':      {'mx_id': '194430106121872D00', 'enable_video': False,
+                      'h265_enable': True, 'h265_bitrate_kbps': 1000},
 }
 
 
@@ -25,6 +28,8 @@ def _oak_camera_node(name, cfg):
             'ewasr_resnet18.blob'
         ]),
     }
+    if 'enable_video' in cfg:
+        params['enable_video'] = cfg['enable_video']
     if cfg.get('h265_enable'):
         params['h265_enable'] = True
         for opt in ('h265_bitrate_kbps', 'h265_keyframe_frequency_frames', 'h265_profile'):

--- a/bizzyboat_project11/launch/oak_cameras_launch.py
+++ b/bizzyboat_project11/launch/oak_cameras_launch.py
@@ -7,7 +7,8 @@ from launch_ros.substitutions import FindPackageShare
 # BizzyBoat OAK camera MXIDs (verified 2026-03-30). Each entry may carry
 # optional flags; absent flags fall back to sea_surface_segmentation defaults.
 CAMERAS = {
-    'oak_forward':   {'mx_id': '19443010D117872D00', 'h265_enable': True},
+    'oak_forward':   {'mx_id': '19443010D117872D00', 'h265_enable': True,
+                      'h265_bitrate_kbps': 2000},
     'oak_starboard': {'mx_id': '19443010E11A872D00'},
     'oak_aft':       {'mx_id': '14442C10917D8DD700'},
     'oak_port':      {'mx_id': '194430106121872D00'},
@@ -26,6 +27,9 @@ def _oak_camera_node(name, cfg):
     }
     if cfg.get('h265_enable'):
         params['h265_enable'] = True
+        for opt in ('h265_bitrate_kbps', 'h265_keyframe_frequency_frames', 'h265_profile'):
+            if opt in cfg:
+                params[opt] = cfg[opt]
     return Node(
         package='sea_surface_segmentation',
         executable='sea_surface_segmentation',

--- a/bizzyboat_project11/launch/oak_cameras_launch.py
+++ b/bizzyboat_project11/launch/oak_cameras_launch.py
@@ -4,29 +4,33 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
-# BizzyBoat OAK camera MXIDs (verified 2026-03-30)
+# BizzyBoat OAK camera MXIDs (verified 2026-03-30). Each entry may carry
+# optional flags; absent flags fall back to sea_surface_segmentation defaults.
 CAMERAS = {
-    'oak_forward':   '19443010D117872D00',
-    'oak_starboard': '19443010E11A872D00',
-    'oak_aft':       '14442C10917D8DD700',
-    'oak_port':      '194430106121872D00',
+    'oak_forward':   {'mx_id': '19443010D117872D00', 'h265_enable': True},
+    'oak_starboard': {'mx_id': '19443010E11A872D00'},
+    'oak_aft':       {'mx_id': '14442C10917D8DD700'},
+    'oak_port':      {'mx_id': '194430106121872D00'},
 }
 
 
-def _oak_camera_node(name, mx_id):
+def _oak_camera_node(name, cfg):
+    params = {
+        'camera_ids': [cfg['mx_id']],
+        'camera_names': [name],
+        'neural_network': PathJoinSubstitution([
+            FindPackageShare('sea_surface_segmentation'),
+            'config',
+            'ewasr_resnet18.blob'
+        ]),
+    }
+    if cfg.get('h265_enable'):
+        params['h265_enable'] = True
     return Node(
         package='sea_surface_segmentation',
         executable='sea_surface_segmentation',
         name=name,
-        parameters=[{
-            'camera_ids': [mx_id],
-            'camera_names': [name],
-            'neural_network': PathJoinSubstitution([
-                FindPackageShare('sea_surface_segmentation'),
-                'config',
-                'ewasr_resnet18.blob'
-            ]),
-        }],
+        parameters=[params],
         respawn=True,
         respawn_delay=5,
         emulate_tty=True
@@ -35,6 +39,6 @@ def _oak_camera_node(name, mx_id):
 
 def generate_launch_description():
     return LaunchDescription([
-        _oak_camera_node(name, mx_id)
-        for name, mx_id in CAMERAS.items()
+        _oak_camera_node(name, cfg)
+        for name, cfg in CAMERAS.items()
     ])


### PR DESCRIPTION
Closes #78

## Summary

Field-validated H.265 transport rollout on bizzyboat. Started as the
"oak_forward only, wifi only, JPEG fallback" step described in the
original PR text; expanded across five commits during a single
field session on 2026-04-23 as each step was tested at the pier.

End state: all four OAK cameras stream H.265 over both `wifi` and
`vpn` udp_bridge connections at 1000 kbps. JPEG / raw / camera_info
preview paths are off (`enable_video: False` on the cameras, and
their `oak_<name>` / `_info` / `_raw` udp_bridge entries removed).
Segmentation is forwarded on every connection (un-throttled on
wifi, 1 Hz on vpn).

## Commit-by-commit

| Commit | Change |
|---|---|
| `b00f4ad` | Initial: H.265 on `oak_forward`, wifi only, defaults (4000 kbps) |
| `0b7a558` | Drop `oak_forward` 4000 → 2000 kbps after observing block artifacts on wifi UDP drops |
| `3c4aaec` | All four OAKs at H.265 1000 kbps; `enable_video: False` to free Myriad X resources; drop wifi segmentation throttle |
| `7ee3947` | Mirror H.265 + segmentation onto vpn (segmentation throttled at 1 Hz to fit the 1 MB/s vpn budget) |
| `e5af89f` | Drop `oak_<name>` / `oak_<name>_info` / `oak_<name>_raw` udp_bridge entries orphaned by `enable_video: False` (the `_raw` "wake-up" trick was for `depthai_bridge`'s lazy compressed publisher and is moot for the non-lazy `FFMPEGPublisher`) |

## Dependency

Depends on [`unh_marine_perception#5`](https://github.com/rolker/unh_marine_perception/pull/5)
being deployed on bizzyboat. The `h265_enable` / `h265_bitrate_kbps`
/ `enable_video` parameters are no-ops without it.

For this run, both branches were pushed to `gitcloud/jazzy` and
pulled directly onto bizzyboat.

## Field validation (2026-04-23)

- 4000 kbps default → visible block artifacts during wifi UDP drops.
- 2000 kbps → much better, occasional hiccups.
- 1000 kbps + `enable_video: False` (preview/JPEG/raw + camera_info
  publishers off) on all four OAKs, plus segmentation throttle
  (`period: 0.5`) removed from the wifi `udp_bridge` map → solid
  front image, no more block artifacts observed on `oak_forward`.
- Decode on salmon: `ros-jazzy-ffmpeg-image-transport` installed
  manually (no operator-side package declares it as a rosdep yet —
  tracked in [`rolker/rqt_operator_tools#20`](https://github.com/rolker/rqt_operator_tools/issues/20)).
  `rqt_image_view` does not list `image_raw/ffmpeg` topics directly
  (it only knows `Image`/`CompressedImage`), so an
  `image_transport republish ffmpeg raw` node converts the stream
  for `rqt_image_view`. Full deployment-log writeup in
  `bizzyboat_project11/docs/bizzyboat_deployment_log.md` (issue #57
  worktree).

## Out of scope (deferred)

- **Adaptive bitrate** (LTE vs Starlink). Static 1000 kbps is the
  starting point; revisit once a cellular run has numbers.
- **Calibration writeup** vs the [#4 software benchmark matrix](https://github.com/rolker/unh_marine_perception/issues/4) —
  to land in `unh_marine_perception` once a clean comparison run is
  recorded.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
