### PR TITLE
docs: 2026-04-24 pier session log + hydro-payload SBG/M3/QINSy/1PPS wiring + AML SVS

### DIFF
--- a/bizzyboat_project11/docs/hydro_payload_install_log.md
+++ b/bizzyboat_project11/docs/hydro_payload_install_log.md
@@ -51,12 +51,83 @@ add session notes inline under "Session: YYYY-MM-DD" below once done
       mercat.  Capture rationale under the "Open questions" section
       below.
 
-**QINSy setup — M3 sonar**:
+**QINSy setup — SBG message set on COM4** (`#76` follow-up):
 
-- [ ] Configure M3 in QINSy acquisition template.
-- [ ] Verify first pings in QINSy with SBG attitude applied.
+- [ ] Confirm sbgCenter is closed on mercat before launching QINSy
+      (sbgCenter holds the unit and blocks the QINSy serial driver).
+- [ ] Enable the required SBG_ECOM logs on the COM4 output: `STATUS`
+      (1 Hz / new data), `UTC_TIME` (new data), `EKF_NAV` (50 Hz),
+      `EKF_EULER` (50 Hz), `SHIP_MOTION` (50 Hz). Heave lives in
+      SHIP_MOTION, not EULER — both must be on for vertical-motion
+      correction.
+- [ ] Enable recommended GPS logs for dual-antenna QC: `GPS1_POS`,
+      `GPS1_VEL`, `GPS1_HDT` (GNSS-native rate, 5–10 Hz).
+- [ ] In QINSy, instantiate the `SBG Systems (R-P-H) – 03` serial
+      driver — one driver feeding Position Navigation, Gyro Compass,
+      and Pitch-Roll-Heave systems. Lever arms reference Vessel CoG;
+      do **not** re-enter the SBG-side lever arms in QINSy.
+- [ ] Sanity-check the COM4 baud budget — full required+GPS set fits
+      well under 115200; only adding `IMU_DATA` at 50 Hz pushes near
+      the ceiling. Drop IMU rate or bump baud if we add it later.
+
+**QINSy setup — M3 sonar** (`#76` follow-up):
+
+- [ ] On M3 software: `File → Exporting Format → Profile Point (.all)`
+      (Kongsberg EM datagram standard; the only format the QINSy M3
+      driver decodes).
+- [ ] On M3 software: `Setup → Preferences → UDP Data Export` — set
+      `Port for .ALL format = 20002` (record exact port chosen),
+      `Remote IP Address = 127.0.0.1` (QINSy is co-located on
+      mercat), `Export to File` unchecked.
+- [ ] On M3 software: `Setup → System Configuration → Devices → Sonar
+      Setup → Override Network Link Speed = 125 Mbps`.
+- [ ] Feed the AML SVS into the M3 in parallel with QINSy (M3 uses it
+      for its own refraction model; QINSy still consumes the same
+      stream for soundings). Most SVS tools support multi-port output.
+- [ ] In QINSy, instantiate the `Kongsberg Mesotech M3 – 20` driver on
+      the matching UDP port. Verify the **Clock datagram** is in the
+      stream via QINSy's port monitor — without it, the driver decodes
+      nothing.
+- [ ] Enter the M3 mounting offsets in QINSy (from `#77` measurements:
+      x = -0.23, y = 0, z = -0.145, transducer face Down). Do **not**
+      duplicate offsets in the M3 software's Deployment dialog.
+- [ ] Verify first pings in QINSy with SBG attitude + heave applied.
 - [ ] Capture a short QINSy log at the dock and save an index entry in
       the photo / data log below.
+
+**1PPS time-sync wiring — M3 head from SBG** (`#76` follow-up):
+
+Background: the M3 head requires a 0–5 V 50%-duty 1PPS pulse on its
+breakout box plus NMEA ZDA over UDP 31100 @ 1 Hz to its IP. The
+TM2000B has no physical PPS output, so the SBG Ellipse-D's `SYNC OUT
+A` (main connector pin 6, LVTTL) is our 1PPS source.
+
+- [ ] **Confirm the M3 breakout box has the 4-pin Sync/1PPS connector**
+      (the manual lists a stripped-down variant without it). Photo of
+      the breakout settles it. Block — without this connector we
+      either order the sync-capable variant or run 1PPS through the
+      main 10-pin underwater cable, which means re-terminating the
+      wet-end on a through-hull install.
+- [ ] **Confirm M3 head firmware ≥ 1.5** before relying on 1PPS time
+      sync mode (hard prerequisite per install manual).
+- [ ] **Set SBG Sync Out A to PPS / pulse mode** in sbgCenter (Output
+      → Sync Out → pulse mode); record configured pulse width.
+- [ ] **Fabricate the PPS cable**: SEA CON MIND-4 connector on the
+      breakout-box end (Pin 1 DGND, Pin 3 DRAIN/shield, Pin 4
+      1PPS_SYNC); shielded twisted pair to the SBG's SYNC OUT A pin 6
+      and ground; keep < 1 m. Scope the pulse at the M3 end before
+      committing (SBG high-level is 3.2 V light-load / 2.6 V at 16 mA
+      — well above TTL Vih but worth verifying after the cable run).
+- [ ] **Set M3 Time Sync Mode to 1PPS**: `Sonar Setup → Time Sync
+      Mode → 1PPS`.
+- [ ] **Decide ZDA bridge mechanism** for ZDA → M3 head IP:31100.
+      Options: QINSy NMEA pass-through (cleanest if supported), tiny
+      Python/PowerShell forwarder on mercat reading SBG NMEA off
+      COM4, or other. Ellipse-D is serial-only — no native UDP ZDA
+      from the SBG. Capture chosen path and rationale below.
+- [ ] **Verify 1PPS lock**: M3 log should show
+      `INF 1PPS: 10 pulses received in 10s`. If fewer than 10, the
+      pulse isn't reaching the head.
 
 **ROS side (optional, time permitting)**:
 

--- a/bizzyboat_project11/docs/hydro_payload_install_log.md
+++ b/bizzyboat_project11/docs/hydro_payload_install_log.md
@@ -175,6 +175,95 @@ Checklist:
       information tab should show RTK fixed once corrections are
       flowing from gabby's NTRIP client.
 
+**AML SVS via gabby — proposed architecture** (`#76` follow-up):
+
+Current install has the AML on mercat COM3. **Proposed change**:
+move the AML serial cable to one of gabby's free MezIO RS-232 ports
+and let gabby be the SV data hub. gabby publishes a ROS topic, sends
+the raw `$AML…*<cs>` line to mercat as UDP for QINSy, and emits a
+**Valeport-format** copy out a second MezIO port that connects
+back to mercat (now-free COM3) via a null-modem cable for the M3.
+
+```
+AML SVS ──serial──► gabby (Nuvo-9160GC, MezIO RS-232 #1)
+                     │
+                     ├── sv_bridge ROS 2 node ──┐
+                     │   ├─► /sound_speed (ROS topic)
+                     │   ├─► UDP datagram → mercat:port  (raw $AML line)
+                     │   └─► Valeport string → MezIO RS-232 #2
+                     │
+                     └── null-modem cable to mercat free COM3 → M3 software
+                                                                (Sensors Setup,
+                                                                 native Valeport
+                                                                 SVS protocol)
+
+QINSy on mercat
+  Network - Depth SV Temp (AML or EM1000) - 34   ← UDP from gabby
+                                                   (auto-detects format)
+```
+
+Why: clean separation between data hub (gabby) and acquisition
+machines (mercat). M3 gets native Valeport — no custom-sensor
+definition needed. SV becomes a first-class ROS signal (logging,
+operator UI, future autonomy use). Pairs with the SBG↔gabby PORT E
+plan; gabby is the consistent boat-side data integration point.
+Future AML winch SVP plugs into the same architecture.
+
+Trade-offs: introduces a software hop (bridge service), so M3 and
+QINSy now depend on gabby being up. Mitigations: run bridge as
+`systemd` service with `Restart=always`; configure a sane SV default
+(~1490 m/s) in M3's `Sound Speed Preference` so the M3 isn't
+dead-on-arrival if the bridge is late on boot. Cable reroute (AML
+mercat→gabby) is a few feet of shuffling in the same enclosure.
+
+Valeport "standard" output format (per Valeport miniSVS manual):
+leading space + 7-digit mm/s integer + CR/LF — e.g. `_1510123\r\n`
+for 1510.123 m/s. Two alternative m/s formats (2 / 3 decimals) also
+M3-acceptable.
+
+Open prerequisites:
+
+- [ ] **Capture 5 lines of the live AML stream** via TeraTerm on
+      mercat COM3 and paste below under "AML stream sample
+      (YYYY-MM-DD)". The QINSy network driver auto-detects, but the
+      bridge needs to know which field is SV — exact format also
+      pins down the AML model.
+- [ ] **Confirm M3 boot tolerance for late SV**: bench-test starting
+      M3 software with no SV stream, then start the SV stream, and
+      confirm the M3 picks it up cleanly (vs. needing a restart).
+      Decide whether a "stale-SV warning" watchdog is needed.
+- [ ] **Decide ROS message convention**: existing workspace SV
+      message type vs. `std_msgs/Float32` with frame_id vs. add a
+      new `marine_msgs/SoundSpeed`. Coordinate with `marine_tools#1`
+      (QINSy → ROS bridge) so both publish a consistent type.
+- [ ] **Decide bridge package home**: `marine_tools` (alongside the
+      QINSy → ROS bridge) vs. new `aml_sv_bridge` package. Open a
+      separate issue to track implementation once decided.
+- [ ] **Reroute AML serial cable** from mercat COM3 to a free gabby
+      MezIO RS-232 port. Record port assignment.
+- [ ] **Fabricate / source null-modem cable** for gabby MezIO #2 →
+      mercat COM3 (both ends female DB-9, pin 2/3 cross). Standard
+      off-the-shelf part.
+- [ ] **Configure M3 Sensors Setup** with the native Valeport
+      protocol on the new mercat COM port; mark as Master Reference
+      for sound speed (`Deployment → Master Reference → Sound
+      Speed`).
+- [ ] **Configure QINSy** with the `Network - Depth SV Temp (AML or
+      EM1000) - 34` driver on the matching UDP port; observation
+      type Sound Velocity at the SVS tip position
+      (x = -0.455, y = +0.25, z = -0.055).
+- [ ] **Set M3 Sound Speed Preference fallback** to ~1490 m/s for
+      the operating area so the M3 has a sane default if the SV
+      stream is late.
+- [ ] **Verify all three consumers** get matching SV values within
+      tolerance: ROS topic (`ros2 topic echo /sound_speed`), QINSy
+      Generic Display, M3 Sensors page.
+
+Fallback if architecture is rejected: AML stays on mercat COM3,
+QINSy uses serial driver `Sound Velocity - Smart SV (AML, ASCII)
+(Active) - 31`, M3 either gets a Y-cable + custom sensor definition
+or relies on a fixed Sound Speed Preference default.
+
 **ROS side (optional, time permitting)**:
 
 - [ ] Scope the QINSy → ROS bridge approach (`marine_tools#1`) — watch

--- a/bizzyboat_project11/docs/hydro_payload_install_log.md
+++ b/bizzyboat_project11/docs/hydro_payload_install_log.md
@@ -38,6 +38,18 @@ add session notes inline under "Session: YYYY-MM-DD" below once done
 - [ ] Ping M3 on its factory IP (point-to-point via the spare mercat
       Ethernet port).  Record IP in "Hardware inventory" above if not
       already captured.
+- [ ] **Capture the Trimble antenna case label** (model / part number)
+      via phone photo of forward and aft pucks. Existing 2026-04-22
+      photos may already show it — check `~/bizzyboat/2026-04-22_GPS_
+      antennas_*.jpg` first. Without the model number we can't look up
+      the antenna phase-center offset above the mount base, leaving a
+      ~3–5 cm absolute Z bias in soundings (constant, not a
+      repeatability issue, but eats into the IHO Special Order TVU
+      budget). Once the model is identified, look up the phase center
+      in the Trimble datasheet or NGS antenna calibration database
+      (`https://geodesy.noaa.gov/ANTCAL/`) and update both the
+      install-log antenna z entries and the SBG lever-arm config in
+      sbgCenter.
 
 **QINSy setup — SBG IO driver**:
 

--- a/bizzyboat_project11/docs/hydro_payload_install_log.md
+++ b/bizzyboat_project11/docs/hydro_payload_install_log.md
@@ -95,39 +95,85 @@ add session notes inline under "Session: YYYY-MM-DD" below once done
 - [ ] Capture a short QINSy log at the dock and save an index entry in
       the photo / data log below.
 
-**1PPS time-sync wiring — M3 head from SBG** (`#76` follow-up):
+**SBG ↔ gabby + M3 1PPS wiring via DB-9 #2** (`#76` follow-up):
 
 Background: the M3 head requires a 0–5 V 50%-duty 1PPS pulse on its
 breakout box plus NMEA ZDA over UDP 31100 @ 1 Hz to its IP. The
 TM2000B has no physical PPS output, so the SBG Ellipse-D's `SYNC OUT
-A` (main connector pin 6, LVTTL) is our 1PPS source.
+A` (Fischer pin 6, surfaced on DB-9 #2 pin 4 of the splitter cable)
+is our 1PPS source. The M3 stays on its isolated mercat link;
+**QINSy on mercat sources the ZDA-over-UDP feed** to the M3.
 
-- [ ] **Confirm the M3 breakout box has the 4-pin Sync/1PPS connector**
-      (the manual lists a stripped-down variant without it). Photo of
-      the breakout settles it. Block — without this connector we
-      either order the sync-capable variant or run 1PPS through the
-      main 10-pin underwater cable, which means re-terminating the
-      wet-end on a through-hull install.
+The same DB-9 #2 also gives gabby a full-duplex RS-232 link to the
+SBG via PORT E. gabby's MezIO add-in provides 4 native rear-panel
+RS-232 DB-9 (male DTE) ports, all currently free — no USB-serial
+dongle needed. PORT E carries **NMEA out + RTCM in on the same RS-232
+line** (sbgCenter Input/Output tab → PORT E mode = RS-232 → enable
+"Forward Corrections"), collapsing what would have been two cables
+into one. PORT B (DB-9 #2 pin 8) stays unused.
+
+Side benefits: gabby gets a direct SBG NMEA feed for ROS-side
+ingestion (parallel to the QINSy → ROS bridge in `marine_tools#1`),
+and gabby owns the NTRIP client for the SBG's RTK chain (independent
+of the Cube's NTRIP).
+
+**Cable plan** — single fab cable from SBG splitter's DB-9 #2,
+fanning into a DB-9 for gabby and a MIND-4 for the M3 breakout:
+
+- SBG end: **female DB-9** (mates with the splitter's male DB-9 #2)
+- gabby end: **female DB-9** (mates with gabby's male rear-panel
+  DTE port)
+- Both DB-9s are DTE → DTE; cable wiring is **null-modem** between
+  the two: SBG pin 2 ↔ gabby pin 3, SBG pin 3 ↔ gabby pin 2,
+  pin 5 ↔ pin 5 (signal ground)
+- M3 end: **SEA CON MIND-4** plug — gender depends on which variant
+  the breakout takes (MIND-4-CCP cable plug = male contacts /
+  breakout receptacle female; MIND-4-FCR cable receptacle = female
+  contacts / breakout plug male). Confirm by inspection before
+  ordering the connector
+- 1PPS leg taps SBG pin 4 (SYNC OUT A) → MIND-4 pin 4 (1PPS_SYNC);
+  SBG pin 5 (GND) → MIND-4 pin 1 (DGND); cable shield → MIND-4
+  pin 3 (DRAIN). Keep this leg < 1 m
+- gabby leg can be longer (RS-232 good to ~15 m); use shielded
+  twisted pair if running near AC or motor wiring
+
+Checklist:
+
+- [x] M3 breakout box variant confirmed sync-capable (non-triangular
+      variant — has the 4-pin Sync/1PPS connector). 2026-04-24.
+- [ ] Identify M3 breakout 4-pin connector variant (MIND-4-CCP vs
+      MIND-4-FCR) by inspection — determines the gender of the
+      MIND-4 end of the fab cable.
 - [ ] **Confirm M3 head firmware ≥ 1.5** before relying on 1PPS time
       sync mode (hard prerequisite per install manual).
 - [ ] **Set SBG Sync Out A to PPS / pulse mode** in sbgCenter (Output
       → Sync Out → pulse mode); record configured pulse width.
-- [ ] **Fabricate the PPS cable**: SEA CON MIND-4 connector on the
-      breakout-box end (Pin 1 DGND, Pin 3 DRAIN/shield, Pin 4
-      1PPS_SYNC); shielded twisted pair to the SBG's SYNC OUT A pin 6
-      and ground; keep < 1 m. Scope the pulse at the M3 end before
-      committing (SBG high-level is 3.2 V light-load / 2.6 V at 16 mA
-      — well above TTL Vih but worth verifying after the cable run).
+- [ ] **Configure SBG PORT E in sbgCenter**: mode = RS-232; NMEA out
+      enabled (GGA, ZDA, RMC, HDT at chosen rate); "Forward
+      Corrections" enabled to accept incoming RTCM on the same port.
+- [ ] **Fabricate the dual-purpose cable** per the spec above
+      (female DB-9 on SBG end, female DB-9 on gabby end with
+      null-modem wiring between them, MIND-4 on M3 end with
+      identified gender). Scope the SBG PPS pulse at the M3 end
+      before connecting (SBG high level is 3.2 V light-load / 2.6 V
+      at 16 mA — well above TTL Vih but worth verifying).
 - [ ] **Set M3 Time Sync Mode to 1PPS**: `Sonar Setup → Time Sync
       Mode → 1PPS`.
-- [ ] **Decide ZDA bridge mechanism** for ZDA → M3 head IP:31100.
-      Options: QINSy NMEA pass-through (cleanest if supported), tiny
-      Python/PowerShell forwarder on mercat reading SBG NMEA off
-      COM4, or other. Ellipse-D is serial-only — no native UDP ZDA
-      from the SBG. Capture chosen path and rationale below.
-- [ ] **Verify 1PPS lock**: M3 log should show
+- [ ] **Configure QINSy NMEA ZDA (Network) output driver** to emit
+      ZDA over UDP at 1 Hz to the M3 head IP on port 31100. QINSy
+      path: `Settings → Input/Output Ports → Output Select = NMEA →
+      enable $--ZDA at 1 Hz`. Driver: `Network NMEA ZDA (UDP) - 18`.
+- [ ] **Configure gabby NTRIP client** to forward RTCM out the
+      chosen rear-panel RS-232 port (which is wired as DTE male →
+      cable swaps it null-modem to the SBG side, so gabby's "TX"
+      pin 3 maps to SBG PORT E RX). Decide MACORS mountpoint and
+      credentials.
+- [ ] **Verify 1PPS lock** at the M3: log should show
       `INF 1PPS: 10 pulses received in 10s`. If fewer than 10, the
       pulse isn't reaching the head.
+- [ ] **Verify RTK lock on the SBG**: sbgCenter → GNSS raw
+      information tab should show RTK fixed once corrections are
+      flowing from gabby's NTRIP client.
 
 **ROS side (optional, time permitting)**:
 

--- a/bizzyboat_project11/docs/hydro_payload_install_log.md
+++ b/bizzyboat_project11/docs/hydro_payload_install_log.md
@@ -40,15 +40,16 @@ add session notes inline under "Session: YYYY-MM-DD" below once done
       already captured.
 - [ ] **Capture the Trimble antenna case label** (model / part number)
       via phone photo of forward and aft pucks. Existing 2026-04-22
-      photos may already show it — check `~/bizzyboat/2026-04-22_GPS_
-      antennas_*.jpg` first. Without the model number we can't look up
-      the antenna phase-center offset above the mount base, leaving a
-      ~3–5 cm absolute Z bias in soundings (constant, not a
-      repeatability issue, but eats into the IHO Special Order TVU
-      budget). Once the model is identified, look up the phase center
-      in the Trimble datasheet or NGS antenna calibration database
-      (`https://geodesy.noaa.gov/ANTCAL/`) and update both the
-      install-log antenna z entries and the SBG lever-arm config in
+      photos may already show it — check
+      `~/bizzyboat/2026-04-22_GPS_antennas_*.jpg` first.
+      Without the model number we can't look up the antenna
+      phase-center offset above the mount base, leaving a ~3–5 cm
+      absolute Z bias in soundings (constant, not a repeatability
+      issue, but eats into the IHO Special Order TVU budget). Once the
+      model is identified, look up the phase center in the Trimble
+      datasheet or NGS antenna calibration database
+      ([NOAA ANTCAL](https://geodesy.noaa.gov/ANTCAL/)) and update both
+      the install-log antenna z entries and the SBG lever-arm config in
       sbgCenter.
 
 **QINSy setup — SBG IO driver**:
@@ -229,9 +230,10 @@ dead-on-arrival if the bridge is late on boot. Cable reroute (AML
 mercat→gabby) is a few feet of shuffling in the same enclosure.
 
 Valeport "standard" output format (per Valeport miniSVS manual):
-leading space + 7-digit mm/s integer + CR/LF — e.g. `_1510123\r\n`
-for 1510.123 m/s. Two alternative m/s formats (2 / 3 decimals) also
-M3-acceptable.
+leading space + 7-digit mm/s integer + CR/LF — e.g. `␠1510123\r\n`
+for 1510.123 m/s, where `␠` denotes a literal ASCII space (0x20),
+**not** an underscore. Two alternative m/s formats (2 / 3 decimals)
+also M3-acceptable.
 
 Open prerequisites:
 
@@ -373,11 +375,12 @@ BizzyBoat-side prep (separate from the ROS-side implementation):
       destination = gabby's boat-LAN IP, chosen UDP port.
 - [ ] **Generic Layout**: create a layout with Time, transducer-
       node Lat/Lon/Depth, Horizontal TPU (THU), Vertical TPU (TVU);
-      save XML to `C:\Users\Public\Documents\QPS\QINSy\Drivers\
-      Definitions\Output\`. Verify TPU sub-items are available in a
-      "driver" purpose layout (open question on the issue — driver
-      purpose layouts may differ from export-purpose ones; check
-      against the deployed QINSy version).
+      save XML to
+      `C:\Users\Public\Documents\QPS\QINSy\Drivers\Definitions\Output\`.
+      Verify TPU sub-items are available in a "driver" purpose layout
+      (open question on the issue — driver purpose layouts may differ
+      from export-purpose ones; check against the deployed QINSy
+      version).
 - [ ] **Decide vertical reference output** — ellipsoid heights
       (matches `map` frame z directly) vs. chart datum (needs
       `chart_datum → map` inverse from `mru_transform`'s

--- a/bizzyboat_project11/docs/hydro_payload_install_log.md
+++ b/bizzyboat_project11/docs/hydro_payload_install_log.md
@@ -276,12 +276,128 @@ QINSy uses serial driver `Sound Velocity - Smart SV (AML, ASCII)
 (Active) - 31`, M3 either gets a Y-cable + custom sensor definition
 or relies on a fixed Sound Speed Preference default.
 
-**ROS side (optional, time permitting)**:
+**AML-3 SVP via SmartCast winch** (`#76` follow-up):
 
-- [ ] Scope the QINSy → ROS bridge approach (`marine_tools#1`) — watch
-      QINSy's external output options (broadcast, file tail, DB
-      connection?) and decide which is cheapest to consume from ROS.
-      No code expected this session — observation only.
+Two complementary SV streams are wanted for the class:
+
+- **AML at the M3 head** (already discussed above) — continuous,
+  real-time near-transducer SV. Goes into QINSy for refraction at
+  the transducer face.
+- **AML-3 LGR profiler on the SmartCast winch** — periodic full
+  water-column profiles (30 m max rope, 90% rule → ~27 m practical
+  cast depth). WiFi comms; the AML-3 logs internally during the
+  cast and is downloaded over WiFi after.
+
+Workflow (mirrors last year's IzzyBoat / blaze pattern):
+
+```
+SmartCast winch (Seafloor App on mercat) → AML-3 cast (logs internally)
+                                                ↓
+                                       AML-3 WiFi AP
+                                                ↓
+                                cast host downloads via WiFi
+                                                ↓
+                          AML SailFish or HydrOffice Sound Speed Manager
+                                                ↓
+                                profile file (.asvp / .vel / .pro / .aml)
+                                                ↓
+                                  QINSy SVP correction (file or watch)
+```
+
+The "cast host" is whatever machine has WiFi to the AML-3's SSID. On
+IzzyBoat last year that was blaze (Windows, on the boat LAN via
+ethernet, free WiFi for the AML). For BizzyBoat, mercat plays the
+same role *if* it has WiFi hardware — otherwise the simplest
+fallback is a USB WiFi dongle on mercat (~$20). Other options
+considered: router bridging via the RUTX11, gabby as cast host (if
+it has WiFi), or an operator-side laptop. None match blaze's
+simplicity.
+
+Class pedagogy: students design the cast cadence and tooling
+choice. SailFish is the AML-bundled tool; HydrOffice Sound Speed
+Manager (CCOM's own) is a common alternative — students may pick
+either.
+
+Open prerequisites:
+
+- [ ] **Verify mercat WiFi hardware**:
+      `Get-NetAdapter | Where-Object {$_.InterfaceDescription -like
+      "*Wireless*"}` in PowerShell, or just check Network
+      Connections. If absent, source a USB WiFi dongle for mercat.
+- [ ] **Bench-test the SmartCast winch end-to-end**: power up,
+      connect Seafloor SmartCast App, verify automated cast (descend
+      → pause → ascend → home), confirm the AML-3 spins up and logs.
+      Catch winch / pipeline issues before the class.
+- [ ] **Confirm AML-3 WiFi connectivity** from the cast host —
+      identify the AML-3 SSID and successfully download a test cast.
+- [ ] **Verify QINSy SVP ingestion path** — file watch folder vs.
+      manual import. Confirm the file format SailFish or SSM
+      produces is recognized by the current QINSy version.
+
+**M3 mode / range / ping-rate baseline** (`#76` follow-up):
+
+Last year used a Norbit and students chose their own settings;
+matching pedagogy this year. Our prep is just to enable that:
+
+- [ ] Confirm M3 software accessible on mercat from the operator
+      account students will use (no admin restrictions on
+      Setup → System Configuration).
+- [ ] After bench shakedown, save a known-good M3 config (Save
+      Settings in the M3 software UI) as a class-baseline restore
+      point. Store both on mercat and in this repo
+      (`bizzyboat_project11/config/m3_baseline.cfg` or similar).
+- [ ] Link / mirror the M3 reference manual from `~/m3_sonar/` into
+      the bizzyboat operator-docs area so students can find it
+      without root access.
+
+**`marine_tools#1` (QINSy → ROS bridge) — critical path for June** (`#76` follow-up):
+
+Architecture is sonar-agnostic: QINSy emits processed soundings via
+its `Network - Generic Output (User-defined ASCII) (UDP) - 15`
+driver, including TPU; a ROS 2 node on gabby parses that stream and
+publishes `sensor_msgs/PointCloud2` with TPU into the existing
+`cube_bathymetry_node` → `grid_map` → CAMP coverage / rviz
+pipeline. See [`marine_tools#1`](https://github.com/rolker/marine_tools/issues/1)
+for full scope.
+
+Why QINSy bridge over per-sonar `.all` parser: works for **any**
+QINSy-supported sonar, and inherits QINSy's real-time TPU rather
+than re-implementing uncertainty propagation in ROS. Supersedes the
+"`.all` parser on gabby" plan from `project_kongsberg_m3.md`
+memory (Stream 2).
+
+BizzyBoat-side prep (separate from the ROS-side implementation):
+
+- [ ] **In QINSy DbSetup**: add a system of type Output, driver
+      `Network - Generic Output (User-defined ASCII) (UDP) - 15`,
+      destination = gabby's boat-LAN IP, chosen UDP port.
+- [ ] **Generic Layout**: create a layout with Time, transducer-
+      node Lat/Lon/Depth, Horizontal TPU (THU), Vertical TPU (TVU);
+      save XML to `C:\Users\Public\Documents\QPS\QINSy\Drivers\
+      Definitions\Output\`. Verify TPU sub-items are available in a
+      "driver" purpose layout (open question on the issue — driver
+      purpose layouts may differ from export-purpose ones; check
+      against the deployed QINSy version).
+- [ ] **Decide vertical reference output** — ellipsoid heights
+      (matches `map` frame z directly) vs. chart datum (needs
+      `chart_datum → map` inverse from `mru_transform`'s
+      `chart_datum_node`). ERS workflow → ellipsoid. Make this an
+      explicit ROS parameter on the bridge node.
+- [ ] **Confidence-level conversion**: QINSy emits TPU at 95%
+      (~1.96σ); `cube_bathymetry_node` likely expects 1σ. Scale or
+      configure on the bridge.
+- [ ] **End-to-end smoke test before class**: simulated soundings
+      from QINSy → bridge → cube_bathymetry → CAMP coverage
+      visible. Critical-path verification that the data path works
+      independent of any actual M3 pings.
+
+**Recurring checks (post-update / pre-deployment)**:
+
+- [ ] Confirm Windows Firewall on mercat is still **off** (or that
+      the boat LAN is still classified Private with a permissive
+      profile). Windows updates can silently re-enable. UDP exports
+      from M3, UDP receives from QINSy bridge, and ZDA send to M3
+      all silently fail if firewall comes back up.
 
 **Stretch — only if above is solid**:
 
@@ -289,6 +405,14 @@ or relies on a fixed Sound Speed Preference default.
       position, SVS tip).  Tracked under `#77`.
 - [ ] Refine rail-top `z` with a proper measurement (currently
       `[EST] 0.89 m`).
+- [ ] **Patch-test prep** (for student-led patch test during class):
+      ensure all measured install offsets (M3 transducer, SBG IMU,
+      Trimble antennas, SVS tip) are committed in the QINSy template
+      and the SBG sbgCenter config **before** students walk up.
+      If offsets are unapplied, students chase phantom misalignments
+      that are really just unconverted measurements. Students design
+      and run the patch test itself (cod rock as the pingable
+      feature).
 
 **End of session**:
 
@@ -309,6 +433,16 @@ or relies on a fixed Sound Speed Preference default.
 
 **Related existing hardware (for reference, not part of this work):**
 - Cube FCU dual-antenna system: **CUAV C-RTK 2HP**, antennas at x = ±0.835 m (baseline 1.67 m). Already in `bizzyboat_reference_geometry.md`. Confirmed 2026-04-22 that these are separate from the SBG's Trimble pucks, though all four antennas share the same center rail.
+
+### Network endpoints
+
+| Host / device | Network | IP | Notes |
+|---|---|---|---|
+| mercat | boat LAN | **192.168.20.8** | Per `reference_mercat_remote_power.md`; DHCP reservation. |
+| mercat | M3-isolated link | **192.168.1.8** | Dedicated second NIC. |
+| M3 head | M3-isolated link | **192.168.1.234** | Kongsberg factory default. |
+| TM2000B (`time.bizzy.p11.lan`) | boat LAN | 192.168.20.123 | Stratum-1 GPS NTP source. |
+| gabby | boat LAN | 192.168.20.5 | DHCP reservation per `bizzyboat_network.md`. Used as destination for QINSy Generic Output UDP feed → `marine_tools#1`. |
 
 ## Install photo index (local-only)
 

--- a/docs/bizzyboat_deployment_log.md
+++ b/docs/bizzyboat_deployment_log.md
@@ -3670,9 +3670,86 @@ or fix the underlying config:
   startup transient should be filtered out of any
   alerting/aggregation that summarizes "ever-failed" status.
 
-#### Discussing each item
+#### Per-item triage
 
-Pulling these out of the deployment log so it doesn't grow into a
-running design discussion — see the chat thread following this entry
-for per-item triage / issue creation.
+**Item 2 (Nav2 lifecycle ERROR)** — already addressed in the field;
+not chasing.
+
+**Item 3 (udp_bridge VPN/WiFi failures)** — already under
+investigation; not opening a new thread.
+
+**Item 5 (all VPN ping endpoints unreachable)** — downstream of
+item 3; folded into that investigation.
+
+**Items 4 (Starlink ~27 min degradation) and 1 (mavros Sensor health
+GPS=Fail)** — discussed below.
+
+##### Item 1 deep dive — `mavros: System "Sensor health"` GPS=Fail
+
+**Bottom line: this is diagnostic noise, not an actual GPS problem.**
+No action for now; logged so future readers don't burn cycles
+re-deriving it. Scripts used:
+`/tmp/gps_fail_timeline.py`, `/tmp/gps_rtk_correlation.py`
+(transient — not committed).
+
+The earlier "2319 s active span" framing was misleading; that was
+just first-to-last-event distance. **Each event is a 1-second blip**
+(one diagnostic publish cycle). Bag 16:47 (51 min) had 17 such blips
+scattered through the bag, including a clustered burst of 7 blips at
+~3 s spacing near the end. Bag 17:39 (37 min) had 4 blips.
+
+Receiver state during every single blip (across both bags):
+
+| Metric                | Value during GPS=Fail |
+| --------------------- | --------------------- |
+| `fix_type` (GPS_RAW)  | **6 (RTK_FIXED)**     |
+| Satellites visible    | 31–37                 |
+| Horizontal accuracy   | **19–25 mm**          |
+| Vertical accuracy     | 25–39 mm              |
+| `GPS: RTK` diagnostic | **stayed `RTK Fixed`** — never transitioned during a blip |
+
+So when the Cube briefly flags GPS unhealthy in the
+`SYS_STATUS.onboard_control_sensors_health` bitmask, the receiver
+itself is at peak performance: RTK-fixed with sub-cm accuracy.
+
+What's actually flipping: only **bit 5 (GPS) clears in `health`** for
+one cycle while staying set in `enabled`. Bitmask-triple counts in
+the 17:39 bag:
+
+```
+1617× : enabled=0x0220DC2B  health=0x0230DD2B  (normal — GPS healthy)
+ 583× : enabled=0x0220802B  health=0x0230812B  (passive control mode — GPS healthy)
+   4× : enabled=0x0220DC2B  health=0x0230DD0B  (the blip — GPS unhealthy bit clears)
+```
+
+(The two distinct `enabled` masks differ in bits 10, 11, 12, 14 — the
+position/attitude **control** loops. Those are on when the FCU is
+actively guiding, off when it's passive. Independent from the GPS
+blip and not a concern.)
+
+Likely Cube-internal causes for a one-cycle `GPS_HEALTHY=false` while
+the receiver itself stays locked:
+
+- one MAVLink GPS message timeout (a single missed packet)
+- GPS-vs-compass heading disagreement check fired briefly
+- EKF GPS innovation gate fired briefly (e.g., during a turn or
+  dynamic motion)
+- RTCM correction-delivery hiccup the EKF noticed but the receiver
+  rode through without losing fix
+
+**Three separate "GPS" diagnostics — easy to confuse.** Future
+readers, before chasing any GPS-flagged diagnostic, identify which
+one is firing:
+
+| Diagnostic                        | Watches                          | Apr 24 behavior                             |
+| --------------------------------- | -------------------------------- | ------------------------------------------- |
+| `mavros: System` "Sensor health"  | Cube `SYS_STATUS` health bitmask | 1-s blips, ~17/h, no actual receiver issue  |
+| `mavros: GPS` "No satellites"     | NavSatFix-derived sat count      | single-shot ERROR at boot only              |
+| `GPS: RTK`                        | RTK fix quality                  | mostly `RTK Fixed`; rare "3D Fix"/"RTK Float" — separate signal |
+
+If/when we want to silence the noise: add hysteresis (only ERROR if
+GPS unhealthy persists ≥3–5 s) or cross-check with receiver state
+(suppress the bit-flip when `gps1/raw.fix_type ≥ 3` and `eph` is
+small). Both would be upstream changes to the mavros diagnostic
+plugin or a wrapper. Not pursuing now.
 

--- a/docs/bizzyboat_deployment_log.md
+++ b/docs/bizzyboat_deployment_log.md
@@ -3593,3 +3593,86 @@ stamps (zero or >60 s in the future) force Error + `[no stamp]` label
 marker; pane label shows both ages (`rx Xs | hdr Ys`) so the operator
 can see which side is driving. 19 gtests passing. **PR held open** to
 batch with additional pier-session bug fixes before merging.
+
+### Post-session diagnostic-bag analysis (2026-04-25)
+
+Walked all five Apr 24 bizzyboat bags
+(`~/data/logs/bizzyboat/2026-04-24T{12.56,16.17,16.34,16.47,17.39}*`,
+covering ~5.6 h cumulative) and aggregated `/diagnostics` by
+`(name, level)`. Quantitative grounding for the "VPN not working" and
+"Nav stack not healthy" notes from the pier session above, plus
+several other concerns the in-session log didn't capture. Aggregation
+script saved at `/tmp/dump_diagnostics.py`; per-bag table at
+`/tmp/diagnostics_apr24.txt` (transient — will not survive reboot).
+
+#### Real concerns
+
+1. **`mavros: System "Sensor health"` ERROR — root cause `GPS=Fail`.**
+   Bitmasks `Sensor present=0x1230DC2B`, `Sensor enabled=0x0220DC2B`,
+   `Sensor health=0x0230DD0B`; key/value breakdown shows 3D gyro,
+   accelerometer, absolute pressure, and 3D angular rate control all
+   `Ok` — only **GPS=Fail**. Intermittent: 22 events / 2319 s span in
+   16:47 bag; 6 events / 1153 s span in 17:39 bag; also present in
+   12:56 morning bag. The Cube is marking GPS unhealthy in bursts
+   throughout the day. Likely the same upstream cause as
+   `GPS: RTK` degraded-to-`3D Fix` / `RTK Float` observed in the
+   same bags.
+
+2. **`lifecycle_manager_navigation: Nav2 Health` ERROR — "An error has
+   occurred during a node state transition".** In the 12:56 morning
+   bag: **10,827 ERROR samples (99 % of 10,950) over 10,897 s** —
+   Nav2 was effectively broken for the entire 3-hour morning session.
+   Then **completely absent from the 16:17+ bags** — the lifecycle
+   manager either never came back up for the field session, or was
+   intentionally not started. This is the quantitative version of
+   the "Nav stack not healthy — mission rejected" observation above.
+
+3. **`udp_bridge: bizzy: operator: vpn` and `wifi` — degraded
+   reliability.** 16:34 bag: ERROR `no rx for 100s` escalating to
+   `no rx for 134s+`, 49 % of samples non-OK over a 336 s active span.
+   17:39 bag: WARN `tx failures/drops` 78 % of WiFi samples, 55 % of
+   VPN samples; latest VPN sample showed
+   `tx_failed_bytes_per_sec=56,031.8` vs
+   `tx_ok_bytes_per_sec=49.5` — the VPN leg was effectively
+   non-functional (>99.9 % failure rate). Quantitative grounding for
+   "VPN not working" above.
+
+4. **`starlink_diagnostics: starlink.bizzy: link` — sustained ERROR
+   window.** 17:39 bag: 15 ERROR samples spanning ~27 min with
+   pop-ping drop rates of 10–40 %. Specifically at 18:10:29–18:10:49:
+   10 % → 40 % → 28 % → 25 % drops back-to-back; throughput collapses
+   into the single-digit kbps in places. Was not surfaced in the
+   in-session pier-log at all.
+
+5. **All VPN-routed endpoints unreachable from the boat for the full
+   day.** `bencloud`, `router_op_vpn`, and `salmon_vpn` all
+   `Unreachable (100 % packet loss)` across all 5 bags. By contrast,
+   `dns_cloudflare`, `dns_google`, `router_op_direct`,
+   `salmon_direct` only saw ~25 % packet loss. Direct (non-VPN)
+   routing works partially; the VPN tunnel is down or misrouted from
+   the boat side. Same root cause as item 3 (udp_bridge VPN failures).
+
+#### Diagnostic-stream noise to suppress
+
+These statuses are stuck non-OK at ~100 % across every bag and are
+drowning out real signals in `/diagnostics_agg`. Either silence them
+or fix the underlying config:
+
+- `mavros: Mount` — `Can not diagnose in this targeting mode`. No
+  mount/gimbal on bizzyboat; this is a stuck WARN.
+- `mikrotik: wifi.bizzy: interface/ether2-5` — `Not running`. Unused
+  wired ports on the WiFi router.
+- `teltonika: router.bizzy: interface/mob1s2a1`, `mwan3/mob1s2a1`,
+  `mwan3/wan1` — `Down` / `notracking`. Cellular not provisioned.
+- `mavros: Heartbeat`, `MAVROS UAS`, `Battery`, `GPS` — single-shot
+  ERROR at boot ("No events recorded", "disconnected", "No data",
+  "No satellites"). These flip to OK within a second of startup; the
+  startup transient should be filtered out of any
+  alerting/aggregation that summarizes "ever-failed" status.
+
+#### Discussing each item
+
+Pulling these out of the deployment log so it doesn't grow into a
+running design discussion — see the chat thread following this entry
+for per-item triage / issue creation.
+

--- a/docs/bizzyboat_deployment_log.md
+++ b/docs/bizzyboat_deployment_log.md
@@ -3753,3 +3753,95 @@ GPS unhealthy persists ≥3–5 s) or cross-check with receiver state
 small). Both would be upstream changes to the mavros diagnostic
 plugin or a wrapper. Not pursuing now.
 
+##### Item 4 deep dive — `starlink.bizzy: link` ERROR window + cumulative usage
+
+**Bottom line: the link itself was fine; the puzzling Starlink-portal
+usage is from short multi-Mbps download spikes that don't match the
+boat's expected workload.** No action for now; log so future readers
+have the timeline and methodology if the pattern recurs. Script used:
+`/tmp/starlink_timeline.py` (transient).
+
+**Which Starlink:** the diagnostic name is
+`starlink_diagnostics: Starlink: starlink.bizzy: link` — the boat-side
+dish. No second Starlink appears in any of the Apr 24 bags.
+
+**The "27 min ERROR window" framing in the parent entry was wrong.**
+Same misleading first-to-last-event framing as item 1. There were 22
+ERROR segments across the day, but **each was 1–7 seconds long**;
+**cumulative ERROR time = ~50 seconds total** — the link was fine for
+~99.997 % of the 5.34 h span. Drops are isolated brief blips, not a
+sustained outage. Atmospheric / positional / scheduled-handoff jitter,
+not load-induced (see "spikes don't correlate" below).
+
+**Cumulative transfer for the day** (trapezoid integration of
+per-second `downlink_throughput_bps` / `uplink_throughput_bps`,
+12:56:13 – 18:16:22 UTC, ignoring inter-bag gaps >30 s):
+
+| Direction | Total      | Average    |
+| --------- | ---------- | ---------- |
+| Downlink  | **346 MB** | 144 kbps   |
+| Uplink    | **64 MB**  | 27 kbps    |
+
+**The puzzling part: multi-Mbps download spikes.** Probably what
+showed up as elevated usage on the Starlink portal. Peak instantaneous
+`max_dl_kbps` per minute, only listing >1 Mbps:
+
+| UTC      | Peak DL       | Peak UL  | Notes                          |
+| -------- | ------------- | -------- | ------------------------------ |
+| 13:32:13 | 6.4 Mbps      | 17 kbps  |                                |
+| 13:34:13 | 3.1 Mbps      | 24 kbps  |                                |
+| 14:00:13 | 2.0 Mbps      | 19 kbps  |                                |
+| 14:11:13 | **224.0 Mbps**| 206 kbps | 🚩 single-second monster spike  |
+| 14:14:13 | 13.9 Mbps     | 15 kbps  |                                |
+| 14:33:13 | 1.4 Mbps      | 17 kbps  |                                |
+| 14:37:13 | 1.0 Mbps      | 45 kbps  |                                |
+| 15:20:13 | 1.1 Mbps      | 13 kbps  |                                |
+| 15:35:13 | 16.6 Mbps     | 60 kbps  |                                |
+| 15:37:13 | 1.5 Mbps      | 65 kbps  |                                |
+| 15:38:13 | 1.0 Mbps      | 157 kbps |                                |
+| 15:49:13 | 1.1 Mbps      | 17 kbps  |                                |
+| 16:57:13 | 3.7 Mbps      | 24 kbps  |                                |
+| 17:18:13 | **73.8 Mbps** | 25 kbps  | 🚩 second monster spike         |
+| 17:40:13 | 9.3 Mbps      | 22 kbps  |                                |
+| 18:15:13 | 2.2 Mbps      | 15 kbps  |                                |
+
+The 14:11:13 spike alone is roughly **28 MB in one second** — about
+8 % of the day's downlink in a single sample window. The 17:18:13
+spike is another ~9 MB burst.
+
+**Spikes are not correlated with drops.** ERROR segment timestamps
+(`13:42:29–36`, `13:44:58–05:04`, etc.) and the throughput-spike
+timestamps in the table are at different times. The link handled the
+spikes cleanly; drops are a separate phenomenon, not load-induced.
+
+**What's actually consuming this on a boat that's supposed to be
+sending only telemetry?** The bag can't tell us — `/diagnostics` only
+sees aggregate Starlink throughput, not which host or process. The
+boat's expected workload is:
+
+- udp_bridge VPN to operator: rate-capped at 1 Mbps tx (and that
+  day's tx_failed numbers in the parent entry show it was barely
+  working anyway, ~50 B/s ok)
+- ROS-internal traffic (DDS heartbeats, control messages)
+- NTP, system telemetry — all should be sub-100 kbps
+
+Multi-Mbps download bursts don't fit any of those. Plausible
+suspects to chase if/when this recurs:
+
+1. **Unattended OS updates on gabby** — `unattended-upgrades`,
+   `snap refresh`, kernel images. Easily explains tens-of-MB bursts.
+2. **Container/image pulls** — `docker pull`, `apt install` triggered
+   by some background service.
+3. **Starlink dish firmware update** — Starlink pushes hundreds of MB
+   during firmware upgrades.
+4. **A speedtest** — someone running `speedtest-cli` mid-session
+   would produce one giant burst.
+5. **Background sync** — rsync, syncthing, anything that wakes up.
+
+**To pin it down next time** (when we feel the need): drop a
+periodic `iftop -t -s 60 -L 10` or `nethogs -t -c 60` sampler running
+on gabby into a log file. Then the next time the boat shows a
+multi-Mbps spike we'll know which interface and which process. For
+now: not pursuing — revisit if the pattern recurs and the data usage
+becomes a billing or operational concern.
+

--- a/docs/bizzyboat_deployment_log.md
+++ b/docs/bizzyboat_deployment_log.md
@@ -3445,3 +3445,151 @@ will pull today's changes including the merged rqt_camera_grid.
 operator-side / workflow-side. The verification happens when gabby
 and salmon sync and we exercise the camera pipeline with the boat
 powered up.
+
+### 2026-04-24 — Pier session (actual)
+
+Boat deployed at the pier, station-keeping next to it for sonar and
+operator-station testing.
+
+**VPN**: not working. (Details TBD — logging the fact now, diagnosis
+pending.)
+
+**ffmpeg image_transport**: looking great. The operator-side
+verification queued yesterday is passing — `rqt_camera_grid`
+subscribes to the `ffmpeg` transport directly and the video comes
+through cleanly.
+
+**`rqt_camera_grid`: crashed a few times while configuring the
+layout.** Could not complete the intended 3x3 grid. Intended config:
+
+| Row        | Pane 1        | Pane 2       | Pane 3        |
+| ---------- | ------------- | ------------ | ------------- |
+| Top        | port video    | fwd video    | starboard video |
+| Middle     | port seg      | fwd seg      | starboard seg |
+| Bottom     | johnny5       | aft video    | aft seg       |
+
+The **port-seg and starboard-seg panes were the two that couldn't be
+added** before the plugin crashed. Fwd seg + all three video streams +
+johnny5 + aft pair apparently could be added. Repro details (sequence
+of clicks, crash stack, ROS log) not yet captured — flagged for a
+follow-up issue on `rqt_operator_tools` once we can get a stack /
+console tail from salmon.
+
+**Config dialog is a fixed size**, which clipped the topic dropdown
+narrower than the actual topic names. Operator couldn't read full
+topic paths while picking them — directly contributed to the
+configuration difficulty and likely made the layout fight worse than
+it had to be. Dialog should resize (and the combo's popup should be
+as wide as the longest topic name, not capped to the combo's own
+width). Separate bug from the crash; candidate for the same batched
+PR.
+
+#### Kongsberg M3 sonar — first-light config
+
+M3 software up, **sonar is pinging** (first confirmed pings from the
+loaner). Configuration is proving non-trivial:
+
+- **Custom sensor flow is under-instrumented.** Trying to specify the
+  sound-speed-sensor data format and the config UI is not surfacing
+  enough debug info to tell whether a given format string is being
+  accepted, rejected, or silently mis-parsed. Operator is flying
+  blind on whether the SV input is actually landing.
+- Actionable follow-up: capture which sensor flow / format paths
+  were tried and which error (or silence) each produced, so we can
+  either file with Kongsberg or, if the tooling is ours to extend,
+  add the debug surface ourselves. (See workspace memory
+  `project_kongsberg_m3.md` — M3 is Mesotech-lineage, not EM; no
+  existing ROS driver applies yet.)
+
+#### Hatch inspection at the floating dock
+
+Broke off from station-keeping to run BizzyBoat down to the floating
+dock. Tied up alongside **Ruby** (the support RHIB at the floating
+dock) and opened the hatch to eyeball the bilge — **sanity check on
+the sonar cable glands**, no specific leak suspected, just verifying
+the new penetrations are sealing under use. (Water check result not
+yet called out — if nothing further is said, assume dry.)
+
+Returned to loiter afterward — currently **FCU-controlled loiter**,
+not project11 autonomy.
+
+#### Nav stack unhealthy — mission rejected
+
+Tried to send a mission from project11 and the **nav stack is not
+healthy at the moment**, so the mission didn't take. No diagnosis
+yet — logging the fact. Follow-ups when we can look:
+
+- Is this related to the earlier VPN issue (i.e. something upstream
+  that couldn't reach gabby / the operator station), or is gabby's
+  nav stack itself in a bad state?
+- Which nav nodes are missing / faulted? (lifecycle states, TF
+  health, costmap status — whichever tooling is on hand.)
+- Does the FCU-loiter path still work cleanly while the project11
+  nav side is down? (If so, good fallback; if not, that's a
+  separate alarm.)
+
+#### Manual control sanity check
+
+Tested direct manual control with the **USB controller** — worked
+fine. Returned the boat to loiter via the **RC controller**. So the
+teleop path and the RC → FCU-loiter path are both healthy; the failure
+is scoped to the project11 autonomy / nav stack, not to the underlying
+vehicle control chain.
+
+#### Screenshooter running on salmon
+
+Activated the screenshooter on salmon to start capturing
+operator-station state for the rest of the session.
+
+#### Bag capture on gabby
+
+Recording **2-minute bags on gabby** with video data included. Will
+be useful for post-session playback to reproduce the `rqt_camera_grid`
+crash offline on salmon and to have a reference sample of the ffmpeg
+transport working end-to-end.
+
+#### Recovery
+
+Boat recovered. Session wrap-up.
+
+**Outstanding from today — pick up post-session:**
+
+- **VPN not working** — logged, no diagnosis yet.
+- **Nav stack not healthy** — project11 mission dispatch rejected;
+  FCU loiter and manual (USB/RC) paths are both clean, so the fault
+  is scoped to the project11 autonomy side. No diagnosis yet.
+- **`rqt_camera_grid` crashes during config** — port-seg and
+  starboard-seg panes were the two that couldn't be added before the
+  crash. Today's gabby bags should let us reproduce offline on salmon.
+  Candidate for a follow-up issue on `rolker/rqt_operator_tools`.
+- **`rqt_camera_grid` config dialog fixed size / narrow topic combo**
+  — operator couldn't read full topic paths while configuring.
+  Candidate for the same batched PR as the staleness fix (PR #26).
+- **Kongsberg M3 custom sensor flow** under-instrumented for
+  specifying the sound-speed-sensor data format. First pings
+  successful; capture specific format attempts + errors next
+  session so we can file with Kongsberg or extend our own tooling.
+- **Staleness PR ([rolker/rqt_operator_tools#26](https://github.com/rolker/rqt_operator_tools/pull/26))**
+  held in draft to batch with the other `rqt_camera_grid` fixes
+  above.
+
+**gitcloud push from gabby**: the on-boat agent pushed today's logs
+to gitcloud at wrap-up, so `make sync` on salmon (and any other
+gitcloud-connected machine) will pick them up.
+
+**Staleness-tracker oversight — pre-deploy**: surfaced earlier today
+that the new `rqt_camera_grid` staleness border was measuring arrival
+time only, not `header.stamp`. That means a stream whose frames get
+buffered upstream and arrive 15–30 s late would show a green/neutral
+border while the image on screen reflects what the camera saw half a
+minute ago — exactly the "trust this image or not" question the
+border is supposed to answer, and it would have answered wrong.
+Tracked in
+[rolker/rqt_operator_tools#25](https://github.com/rolker/rqt_operator_tools/issues/25).
+Fix implemented on branch `feature/issue-25`
+([draft PR #26](https://github.com/rolker/rqt_operator_tools/pull/26)):
+worst-of-both `max(arrival_age, stamp_age)` drives the border; invalid
+stamps (zero or >60 s in the future) force Error + `[no stamp]` label
+marker; pane label shows both ages (`rx Xs | hdr Ys`) so the operator
+can see which side is driving. 19 gtests passing. **PR held open** to
+batch with additional pier-session bug fixes before merging.


### PR DESCRIPTION
Docs-only catch-up for the BizzyBoat deployment log + hydro payload install log after the 2026-04-24 pier session. Issue stays open — branch keeps accumulating session entries (third iterative PR against `feature/issue-57` after [#67](https://github.com/rolker/unh_echoboats_project11/pull/67) / [#75](https://github.com/rolker/unh_echoboats_project11/pull/75) / [#80](https://github.com/rolker/unh_echoboats_project11/pull/80)).

## Summary

- **`6c220b9` 2026-04-24 pier session log entry** in `docs/bizzyboat_deployment_log.md` — captures: VPN broken on the boat, ffmpeg streams looking great, `rqt_camera_grid` config-time crashes (port + starboard segmentation panes wouldn't add), staleness-border using arrival-time (issue [rolker/rqt_operator_tools#25](https://github.com/rolker/rqt_operator_tools/issues/25), fix [PR #26](https://github.com/rolker/rqt_operator_tools/pull/26)), and the on-water sea trial: dock trip → tie-up → hatch sanity check → FCU loiter → mission rejected with nav stack unhealthy.
- **`9e86dfa` hydro-payload pier-session checklist expansion** — full SBG / M3 / QINSy / 1PPS wiring details added to `bizzyboat_project11/docs/hydro_payload_install_log.md`.
- **`e83caae` 1PPS / SBG-gabby wiring refinement** — confirmed details after on-pier verification.
- **`c263f47` AML SVS via gabby architecture proposal** — design for the SVS data path through gabby.

## Scope

Docs only. Two files: `docs/bizzyboat_deployment_log.md` (+148) and `bizzyboat_project11/docs/hydro_payload_install_log.md` (+214/-4). No code changes.

## Follow-ups not in this PR

The 2026-04-24 entry references several items that should become their own issues (will be filed separately):

- `rqt_camera_grid` config-time crash (port/starb seg panes wouldn't add).
- `rqt_camera_grid` fixed-size dialog / narrow combo popup.
- VPN broken on the boat — investigation needed.
- FCU mission rejected — nav stack unhealthy.

Field commits from gabby (today's H.265 bitrate tuning, TF-frame prefix fix, gabby field log, etc.) come back via the [`/import-field-changes`](https://github.com/rolker/ros2_agent_workspace/blob/main/.claude/skills/import-field-changes/SKILL.md) batch — sibling PR [#82](https://github.com/rolker/unh_echoboats_project11/pull/82) (DIVERGED, merge required).

Part of #57 (not "Closes" — this PR intentionally leaves #57 open so future sessions keep using the same worktree and branch for deployment-log + hydro-payload-install-log updates).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
