### PR TITLE
fix(bizzyboat): re-add camera_info topics to record_camera_topics.sh

### DIFF
--- a/bizzyboat_project11/scripts/record_camera_topics.sh
+++ b/bizzyboat_project11/scripts/record_camera_topics.sh
@@ -37,6 +37,10 @@ TOPICS=(
     /bizzy/sensors/cameras/oak_starboard/segmentation/compressed
     /bizzy/sensors/cameras/oak_aft/segmentation/compressed
     /bizzy/sensors/cameras/oak_port/segmentation/compressed
+    /bizzy/sensors/cameras/oak_forward/segmentation/camera_info
+    /bizzy/sensors/cameras/oak_starboard/segmentation/camera_info
+    /bizzy/sensors/cameras/oak_aft/segmentation/camera_info
+    /bizzy/sensors/cameras/oak_port/segmentation/camera_info
 )
 
 echo "=== Recording for ${DURATION}s to ${OUT_DIR} ==="

--- a/bizzyboat_project11/scripts/record_camera_topics.sh
+++ b/bizzyboat_project11/scripts/record_camera_topics.sh
@@ -29,6 +29,10 @@ TOPICS=(
     /bizzy/sensors/cameras/oak_starboard/image_raw/ffmpeg
     /bizzy/sensors/cameras/oak_aft/image_raw/ffmpeg
     /bizzy/sensors/cameras/oak_port/image_raw/ffmpeg
+    /bizzy/sensors/cameras/oak_forward/camera_info
+    /bizzy/sensors/cameras/oak_starboard/camera_info
+    /bizzy/sensors/cameras/oak_aft/camera_info
+    /bizzy/sensors/cameras/oak_port/camera_info
     /bizzy/sensors/cameras/oak_forward/segmentation/compressed
     /bizzy/sensors/cameras/oak_starboard/segmentation/compressed
     /bizzy/sensors/cameras/oak_aft/segmentation/compressed


### PR DESCRIPTION
## Summary

- Re-add the four `oak_<X>/camera_info` topics to the `TOPICS` array in `bizzyboat_project11/scripts/record_camera_topics.sh`.
- They were unintentionally dropped when moving from ad-hoc bag captures to the scripted helper introduced on `feature/issue-81` (PR #82). Without `camera_info`, bag-replay rectification / calibration-aware projection / `image_pipeline`-style processing can't run from these bags alone.
- `CameraInfo` is `sensor_msgs/msg/CameraInfo` at ~5 Hz per camera (a few hundred bytes/msg), so bag-size impact is negligible.

## Test plan

- [ ] On gabby (or any host running the OAK pipeline), run `bizzyboat_project11/scripts/record_camera_topics.sh 30` and inspect the resulting bag with `ros2 bag info` — confirm all four `/bizzy/sensors/cameras/oak_<port|forward|starboard|aft>/camera_info` topics are present alongside the existing image / segmentation / diagnostics / TF set.
- [ ] Confirm message rate on the `camera_info` topics matches the camera publish rate (~5 Hz).

Closes #84. Part of #81.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
