### PR TITLE
docs: per-deployment logs convention + close out #57 umbrella

### DIFF
--- a/docs/bizzyboat_deployment_log.md
+++ b/docs/bizzyboat_deployment_log.md
@@ -1,5 +1,16 @@
 # BizzyBoat Deployment Log
 
+> **Frozen as of 2026-04-25.** New per-deployment, per-host logs live
+> under [`docs/logs/<year>/`](logs/). Convention: see
+> [`docs/logs/README.md`](logs/README.md). Roadmap of long-term
+> direction: [`docs/roadmap.md`](roadmap.md). Close-out rationale:
+> [`unh_echoboats_project11#92`](https://github.com/rolker/unh_echoboats_project11/issues/92).
+>
+> The Apr 24 deployment is still being wrapped up — those entries
+> will continue landing at the bottom of this file rather than being
+> migrated. Everything from the next deployment onward goes in the
+> new structure.
+
 Tracking the deployment of ros2_agent_workspace on gabby (BizzyBoat robot computer).
 
 Parent issue: [unh_echoboats_project11#14](https://github.com/rolker/unh_echoboats_project11/issues/14)

--- a/docs/logs/2026/2026-04-24_gabby_logs.md
+++ b/docs/logs/2026/2026-04-24_gabby_logs.md
@@ -264,7 +264,7 @@ change + rebuild. Not fixed today.
 - `bizzyboat_project11/launch/core_launch.py` (load new mavros.yaml)
 - `bizzyboat_project11/config/mavros.yaml` (new — plugin frame-id overrides)
 - `bizzyboat_project11/config/bizzyboat.yaml` (+ `/**/sea_surface_estimator:` block)
-- `docs/logs/2026/gabby_2026-04-24.md` (this log)
+- `docs/logs/2026/2026-04-24_gabby_logs.md` (this log)
 
 **`mru_transform`**:
 

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -22,8 +22,12 @@ docs/logs/<year>/<YYYY-MM-DD>_<label>_logs.md
   - `hostname -s` when the agent is in a **field-origin** clone (e.g.,
     gitcloud). Stable per-machine identity (`gabby`, `mercat`, `lr30`,
     etc.).
-  - The dev-vs-field distinction matches `field_mode.sh --describe` on
-    the project repo, so the label can be derived programmatically.
+  - The dev-vs-field distinction matches `field_mode.sh --describe`
+    (provided by the parent workspace at
+    `ros2_agent_workspace/.agent/scripts/field_mode.sh`) on the project
+    repo, so the label can be derived programmatically. If reading this
+    README outside the workspace context: the rule is `dev` for
+    GitHub-origin clones, `hostname -s` otherwise.
 
 Examples:
 
@@ -43,7 +47,7 @@ Every log file starts with:
 
 **Host**: <hostname or "dev">
 **Operator**: <human> + <agent identity, e.g. "Claude Code Agent (Claude Opus 4.7)">
-**Mode**: dev (github origin) | field (gitcloud origin) | field (other)
+**Mode**: dev (GitHub origin) | field (gitcloud origin) | field (other)
 **Deployment**: #<deployment-issue-number> (link)
 ```
 
@@ -57,8 +61,9 @@ Then sections by topic, in chronological order within the deployment.
    `docs/roadmap.md` and the open task issues, proposes the day's items.
 2. User confirms. Agent opens a **deployment issue** (see
    [Deployment issue](#deployment-issue) for title format, labels, and
-   body template), creates a worktree (via
-   `.agent/scripts/worktree_create.sh --issue <N>`), opens a draft PR.
+   body template), creates a worktree (via the parent workspace's
+   `ros2_agent_workspace/.agent/scripts/worktree_create.sh --issue <N>`),
+   opens a draft PR.
 3. Agent initializes the day's log file in the worktree with the header
    above. Issue body links to the file (and to any other host files as
    they appear).

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -55,8 +55,9 @@ Then sections by topic, in chronological order within the deployment.
 
 1. User prompts the dev agent at start of day. Agent reads
    `docs/roadmap.md` and the open task issues, proposes the day's items.
-2. User confirms. Agent opens a **deployment issue** with the agreed
-   item list in the body, creates a worktree (via
+2. User confirms. Agent opens a **deployment issue** (see
+   [Deployment issue](#deployment-issue) for title format, labels, and
+   body template), creates a worktree (via
    `.agent/scripts/worktree_create.sh --issue <N>`), opens a draft PR.
 3. Agent initializes the day's log file in the worktree with the header
    above. Issue body links to the file (and to any other host files as
@@ -76,6 +77,11 @@ Then sections by topic, in chronological order within the deployment.
 - Cross-host work (e.g., dev SSHs into salmon) is logged in the
   **agent's own host's file**, not the target's. The file describes
   work done by an agent, not work done to a host.
+- **Multiple agents on one host**: parallel agent sessions on the
+  same host (separate threads of work) all append to the **same**
+  host log file. The file is per-host, not per-agent. One designated
+  **primary logger** per host coordinates with the user and may
+  summarize peer agents' work at user request.
 
 ### Wrap-up
 
@@ -99,13 +105,50 @@ If a deployment surfaces work that's:
 roadmap is the carry-over mechanism between deployments. The next
 deployment's planner reads the roadmap to pick what to fold in.
 
+## Deployment issue
+
+Each deployment gets its own GitHub issue, opened on the dev side at
+the start of the session.
+
+**Title**: `Deployment YYYY-MM-DD: <one-line scope>`
+
+The agent drafts the one-line scope from the proposed day's items;
+the user **approves the scope** before the issue is opened.
+
+**Labels**: `deployment` + `documentation`. (`deployment` is a
+repo-specific label — create it the first time if it doesn't exist.)
+
+**Body sections** (in order):
+
+- **Scope today** — the user-approved one-line scope expanded into
+  a few bullets
+- **Open task issues in scope** — links to focused issues being
+  worked on (e.g., `#76`, `#77`, `#87`)
+- **Hosts active** — which agent hosts are involved (gabby, dev,
+  salmon, mercat, etc.)
+- **Logs** — populated during the session as files appear:
+  - per-host base log files (one per active host)
+  - any task-specific deep-dive log files spun off during the session
+    (see [Task-specific deep-dive logs](#task-specific-deep-dive-logs))
+- **Wrap-up checklist** — push field logs to gitcloud, pull to dev,
+  audit for carry-forward, open follow-up task issues, update
+  `docs/roadmap.md` with anything deferred, merge the wrap-up PR
+
+### Field-side hosts have no GitHub access
+
+`gabby`, `salmon`, and other field-deployed hosts don't carry user
+GitHub credentials. Their only responsibility is to append to their
+host log file and push to gitcloud at session end. **All GitHub
+interaction** — opening the deployment issue, body updates,
+comments, follow-up task issues, the wrap-up PR, the merge —
+happens on the dev side after the dev agent pulls field logs into
+the worktree branch.
+
 ## What to write in a log
 
 The log captures **what an agent did and what it learned**, in enough
 detail that a future agent (or human) can pick up cold. Strong sample:
-[`2026-04-24_gabby_logs.md`](2026/2026-04-24_gabby_logs.md) — currently
-under the legacy `gabby_2026-04-24.md` filename, will be renamed to
-match this convention on next deployment.
+[`2026-04-24_gabby_logs.md`](2026/2026-04-24_gabby_logs.md).
 
 Useful sections (use what fits, skip what doesn't):
 
@@ -124,6 +167,37 @@ Avoid:
   raw data stays in `~/data/logs/`
 - Multi-paragraph design discussions — those belong on the
   deployment issue or a focused task issue
+
+### Timestamp every entry
+
+Prefix each entry — observation, action, summary — with an ISO-8601
+timestamp in **local time with the UTC offset**:
+
+```
+2026-04-27T08:42-04:00 — started charging the boat before launch
+2026-04-27T09:15-04:00 — boat in the water, FCU armed
+```
+
+Local-with-offset is unambiguous (no UTC mental conversion for the
+on-site human) and trivially correlatable to bag timestamps later.
+Even editorial summaries get timestamps — knowing **when** a
+summary was written can matter as much as the summary itself. Use
+**minute precision by default**; bump to seconds when correlating
+tightly to a bag or a ROS event.
+
+### Task-specific deep-dive logs
+
+When a single topic warrants its own running log (e.g., a multi-hour
+sonar bring-up, a deep dive on a network issue), spin off a
+deep-dive log alongside the base host log:
+
+```
+docs/logs/<year>/<YYYY-MM-DD>_<label>_<topic>_logs.md
+```
+
+The base host log gets a short summary entry pointing at the
+deep-dive rather than carrying the full detail. Link both from the
+deployment issue's **Logs** section.
 
 ## Anti-pattern: the monolithic log
 

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -1,0 +1,150 @@
+# Deployment logs convention
+
+Per-deployment, per-host log files. Each agent writes its own file; no
+coordination needed for parallel agents on different hosts.
+
+## File layout
+
+```
+docs/logs/<year>/<YYYY-MM-DD>_<label>_logs.md
+```
+
+- **`<year>`** — UTC year of the deployment start date
+- **`<YYYY-MM-DD>`** — UTC date of the deployment **start**, not the
+  date of the writing. A multi-day deployment uses one file across all
+  its days; sections inside can have date sub-headers when crossing
+  UTC midnight.
+- **`<label>`** —
+  - `dev` literal when the agent is in a **GitHub-origin** clone
+    (workspace dev workstation, agent has GitHub access). The hostname
+    of the dev machine is intentionally not encoded — the role matters,
+    the specific dev box doesn't.
+  - `hostname -s` when the agent is in a **field-origin** clone (e.g.,
+    gitcloud). Stable per-machine identity (`gabby`, `mercat`, `lr30`,
+    etc.).
+  - The dev-vs-field distinction matches `field_mode.sh --describe` on
+    the project repo, so the label can be derived programmatically.
+
+Examples:
+
+- `docs/logs/2026/2026-04-24_gabby_logs.md` — agent on the boat-side
+  Linux host during the 2026-04-24 deployment (gitcloud origin)
+- `docs/logs/2026/2026-04-24_dev_logs.md` — agent on a dev machine
+  doing pre-deploy or wrap-up work for the 2026-04-24 deployment
+- `docs/logs/2026/2026-05-12_lr30_logs.md` — agent on LR30 during a
+  multi-day deployment that started 2026-05-12
+
+## File header
+
+Every log file starts with:
+
+```markdown
+# <Platform> deployment log — <label> — <YYYY-MM-DD>
+
+**Host**: <hostname or "dev">
+**Operator**: <human> + <agent identity, e.g. "Claude Code Agent (Claude Opus 4.7)">
+**Mode**: dev (github origin) | field (gitcloud origin) | field (other)
+**Deployment**: #<deployment-issue-number> (link)
+```
+
+Then sections by topic, in chronological order within the deployment.
+
+## Lifecycle
+
+### Deployment start
+
+1. User prompts the dev agent at start of day. Agent reads
+   `docs/roadmap.md` and the open task issues, proposes the day's items.
+2. User confirms. Agent opens a **deployment issue** with the agreed
+   item list in the body, creates a worktree (via
+   `.agent/scripts/worktree_create.sh --issue <N>`), opens a draft PR.
+3. Agent initializes the day's log file in the worktree with the header
+   above. Issue body links to the file (and to any other host files as
+   they appear).
+4. On any field machine that wakes up, the user tells the agent
+   "continue with existing log" or "start new". Agent acts accordingly.
+   Field machines do not open GitHub issues themselves; the dev side's
+   deployment issue is the single source of truth.
+
+### During
+
+- The "logger" agent on each host owns appends to that host's log.
+  When other agents on the same host do work, the logger summarizes
+  them (often at user request).
+- Multi-day deployments append to the same file under date sub-headers,
+  no rotation.
+- Cross-host work (e.g., dev SSHs into salmon) is logged in the
+  **agent's own host's file**, not the target's. The file describes
+  work done by an agent, not work done to a host.
+
+### Wrap-up
+
+1. User signals: "wrap up the deployment" / "close out".
+2. Field machines push their logs to gitcloud at end of session.
+3. Dev pulls those into the worktree branch.
+4. Dev agent reviews the full deployment, opens follow-up task issues
+   for any genuine carry-forward, updates `docs/roadmap.md` with
+   anything that's "do this someday but not now".
+5. Dev pushes, gets the PR ready for review, merges.
+6. Merging closes the deployment issue.
+
+### Deferred / no-issue items → roadmap
+
+If a deployment surfaces work that's:
+
+- Not bounded enough to be a focused task issue, **or**
+- Not on deck for the next deployment
+
+…it goes on `docs/roadmap.md`, not into a placeholder issue. The
+roadmap is the carry-over mechanism between deployments. The next
+deployment's planner reads the roadmap to pick what to fold in.
+
+## What to write in a log
+
+The log captures **what an agent did and what it learned**, in enough
+detail that a future agent (or human) can pick up cold. Strong sample:
+[`2026-04-24_gabby_logs.md`](2026/2026-04-24_gabby_logs.md) — currently
+under the legacy `gabby_2026-04-24.md` filename, will be renamed to
+match this convention on next deployment.
+
+Useful sections (use what fits, skip what doesn't):
+
+- **Summary** — 2–3 sentences at the top
+- **Numbered topic sections** — actual work done, with file paths and
+  line numbers
+- **Issues encountered + diagnoses**
+- **Pending on operator** / **Handoff** — cross-host coordination
+- **Files touched** — repos and paths changed (helps future grep)
+
+Avoid:
+
+- Restating what the diff shows; describe **why** and **what was
+  learned**
+- Long bag-data dumps in the log itself — analysis goes in the log,
+  raw data stays in `~/data/logs/`
+- Multi-paragraph design discussions — those belong on the
+  deployment issue or a focused task issue
+
+## Anti-pattern: the monolithic log
+
+`docs/bizzyboat_deployment_log.md` (frozen, see header at the top of
+that file) is what this convention replaces. It accumulated 5 weeks of
+content into 3500 lines, mixing per-session detail with umbrella-style
+milestones. Hard to navigate, hard to scope changes against, hard to
+close.
+
+The per-deployment per-host model fixes this by giving each unit of
+work its own bounded artifact.
+
+## Future automation
+
+This convention is a candidate for a Claude Code skill that handles:
+
+- Today's filename derivation (UTC date, `field_mode.sh --describe`)
+- Initialization with header
+- Append API for structured entries
+- Summarization of peer agents' work (commits, branches, PRs)
+- End-of-deployment handoff (move items to roadmap / open task issues
+  / update deployment-issue body)
+
+Until that skill exists, agents follow this README manually.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,109 @@
+# BizzyBoat / hydrography roadmap
+
+What we're aiming for, and what's deferred. Scope is BizzyBoat plus the
+sensor payload (M3 sonar, SBG, SVS) bound for the June 2026 field
+hydrography class.
+
+This document is the **carry-over mechanism between deployments**.
+Items here are durable direction; specific bounded work belongs in
+GitHub task issues (referenced from here when relevant).
+
+## End goal
+
+**Fully autonomous survey round-trips.** Plan a survey from the
+operator station; boat transits to the area, runs survey lines, returns
+to the pier — all without user intervention.
+
+## Forcing function
+
+**Field hydrography class — June 2026.** Students plan surveys, monitor
+execution, configure sonar software, and measure offsets. The system
+must be reliable and novice-friendly by then.
+
+## Active threads (have task issues)
+
+Cross-references — the roadmap is not the source of truth for any
+specific task; the linked issue is. Listed here so the threads are
+visible from one place.
+
+### Sensor payload integration (M3 + SBG + SVS on mercat)
+
+- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP
+- [`unh_echoboats_project11#77`](https://github.com/rolker/unh_echoboats_project11/issues/77) — physical install, offsets, URDF, SVG diagram
+- [`rolker/marine_tools#1`](https://github.com/rolker/marine_tools/issues/1) — QINSy → ROS bridge for coverage / sounding feedback
+
+### Camera obstacle avoidance
+
+- [`rolker/unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) — `SeaSurfaceLayer::matchSize()` segfault (blocker)
+- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK→costmap validation (blocked on #6)
+
+### Navigation reliability
+
+- [`rolker/unh_marine_navigation#23`](https://github.com/rolker/unh_marine_navigation/issues/23) — TF extrapolation on multi-line survey goals
+
+### Class-ready operator UI
+
+- [`rolker/rqt_operator_tools#2`](https://github.com/rolker/rqt_operator_tools/issues/2) — operator logbook (Phase 1 landed, not field-tested)
+- [`rolker/rqt_operator_tools#29`](https://github.com/rolker/rqt_operator_tools/issues/29) — pre-launch checklist (form factor TBD)
+- [`unh_echoboats_project11#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) — student-facing operating documentation
+
+### FCU configuration
+
+- [`unh_echoboats_project11#55`](https://github.com/rolker/unh_echoboats_project11/issues/55) — FCU battery params recalibration (field-gated, PR [#56](https://github.com/rolker/unh_echoboats_project11/pull/56) ready)
+
+## Deferred / lower priority — no current issue
+
+These items are explicitly not on deck. Promote to a task issue when
+they become relevant.
+
+### Navigation polish
+
+- **Hover v5** (range-aware taper for faster excursion recovery) —
+  v4 is sufficient for current use; revisit only if v4's behavior
+  becomes a real ergonomics problem
+- **Hover vectored-thrust parameter** — works well enough with v4 cliff
+
+### Networking
+
+- **DNS-over-HTTPS on RUTX11** — exploration item, not urgent
+- **WiFi bridge: static routes → default gateway approach** — current
+  static-route setup works; cleaner default-gateway redesign deferred
+- **IzzyBoat WireGuard return path fix** — IzzyBoat is parked, fix
+  this before next IzzyBoat deployment
+
+### Testing
+
+- **Formal WiFi range test** — 2026-04-21 field data shows graceful
+  degradation well past the old "300 m limit" and range comparable to
+  or better than 2025 IzzyBoat (see memory `project_wifi_range.md`).
+  A dedicated controlled range test is out of class-prep scope.
+
+### Hardware oddities
+
+- **Forward USB camera** publishes a black image — root cause unknown,
+  USB camera has not been needed for any field work. Revisit if it
+  becomes load-bearing.
+
+## What's not on this roadmap
+
+- Specific bug fixes — those are task issues
+- Specific deployments — those get their own deployment issues
+- Anything that's on deck for the **next** deployment — that goes in
+  the next deployment issue's body, not here
+
+## How this roadmap stays useful
+
+- At deployment start: planner reads this + open task issues → picks
+  the next deployment's scope
+- At deployment wrap-up: items that came up but aren't bounded enough
+  for a task issue and aren't going to be done next time → land here
+- Periodically: if "deferred" items have been sitting more than a
+  couple of months without any pull toward them, they're probably
+  dropped, not deferred. Edit them out.
+
+This document was seeded from the milestone content of
+[`unh_echoboats_project11#57`](https://github.com/rolker/unh_echoboats_project11/issues/57)
+(BizzyBoat field ops umbrella) when that issue was closed in favor of
+the per-deployment convention. See
+[`unh_echoboats_project11#92`](https://github.com/rolker/unh_echoboats_project11/issues/92)
+for the close-out rationale.


### PR DESCRIPTION
## Summary

Implements the per-(deployment, host) logging convention agreed in [#92](https://github.com/rolker/unh_echoboats_project11/issues/92), and closes out the long-running umbrella issue [#57](https://github.com/rolker/unh_echoboats_project11/issues/57).

- Adds `docs/logs/README.md` — convention spec
- Adds `docs/roadmap.md` — durable direction + deferred items, seeded from #57's milestone content
- Freezes `docs/bizzyboat_deployment_log.md` with a header pointing forward — **does not migrate content**

The 4 carry-forward task issues were opened before the PR so #92's body and `docs/roadmap.md` can reference them by number:

- [`rolker/unh_marine_navigation#23`](https://github.com/rolker/unh_marine_navigation/issues/23) — TF extrapolation on multi-line survey goals
- [`rolker/unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) — `SeaSurfaceLayer::matchSize()` segfault
- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — OAK→costmap end-to-end (blocked on #6)
- [`rolker/rqt_operator_tools#29`](https://github.com/rolker/rqt_operator_tools/issues/29) — pre-launch checklist

## Test plan

- [ ] Read `docs/logs/README.md` end-to-end — convention is unambiguous, edge cases (multi-day, multi-host, dev-vs-field label) are addressed
- [ ] Read `docs/roadmap.md` — vision is right, deferred items are correctly classified, no duplicates with active task issues
- [ ] Read the freeze header on `docs/bizzyboat_deployment_log.md` — clear signal to future agents that the file is closed
- [ ] After merge: close [#57](https://github.com/rolker/unh_echoboats_project11/issues/57) with a reference back here

Closes [#92](https://github.com/rolker/unh_echoboats_project11/issues/92).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`