### PR TITLE
docs(logs): 2026-04-27 deployment log + wrap-up (#94)

### DIFF
--- a/bizzyboat_project11/launch/oak_cameras_launch.py
+++ b/bizzyboat_project11/launch/oak_cameras_launch.py
@@ -22,6 +22,13 @@ def _oak_camera_node(name, cfg):
     params = {
         'camera_ids': [cfg['mx_id']],
         'camera_names': [name],
+        # Match the URDF-published frame in `urdf/sensors/camera_oak.xacro`
+        # (`bizzy/<name>_optical`) so the segmentation Image + CameraInfo
+        # frame_id resolves in the live TF tree. Without this the publisher
+        # falls back to the package default `<name>_optical_frame`, which
+        # is not in BizzyBoat's TF tree and breaks any consumer that does
+        # a TF lookup against the message header (e.g. SeaSurfaceLayer).
+        'frame_ids': [f'bizzy/{name}_optical'],
         'neural_network': PathJoinSubstitution([
             FindPackageShare('sea_surface_segmentation'),
             'config',

--- a/bizzyboat_project11/scripts/record_camera_topics.sh
+++ b/bizzyboat_project11/scripts/record_camera_topics.sh
@@ -3,7 +3,7 @@
 # segmentation (raw + compressed) topics, plus TF, diagnostics, and the
 # latched robot description.
 #
-# Sufficient to replay-debug `sea_surface_segmentation::SeaSurfaceLayer`
+# Sufficient to replay-debug `sea_surface_layer::SeaSurfaceLayer`
 # (the nav2 costmap plugin) offline: it subscribes to the raw
 # `<cam>/segmentation` Image topic and the matching `camera_info`, and
 # does a TF lookup from the image header frame to the costmap global

--- a/bizzyboat_project11/scripts/record_camera_topics.sh
+++ b/bizzyboat_project11/scripts/record_camera_topics.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # record_camera_topics.sh — Ad-hoc bag capture of OAK camera ffmpeg +
-# segmentation/compressed topics, plus /diagnostics and /tf[_static].
+# segmentation (raw + compressed) topics, plus TF, diagnostics, and the
+# latched robot description.
+#
+# Sufficient to replay-debug `sea_surface_segmentation::SeaSurfaceLayer`
+# (the nav2 costmap plugin) offline: it subscribes to the raw
+# `<cam>/segmentation` Image topic and the matching `camera_info`, and
+# does a TF lookup from the image header frame to the costmap global
+# frame.
 #
 # Usage: ./record_camera_topics.sh [duration_secs]
 #   duration_secs: recording length in seconds (default: 120)
@@ -25,6 +32,7 @@ TOPICS=(
     /diagnostics
     /tf
     /tf_static
+    /robot_description
     /bizzy/sensors/cameras/oak_forward/image_raw/ffmpeg
     /bizzy/sensors/cameras/oak_starboard/image_raw/ffmpeg
     /bizzy/sensors/cameras/oak_aft/image_raw/ffmpeg
@@ -33,6 +41,10 @@ TOPICS=(
     /bizzy/sensors/cameras/oak_starboard/camera_info
     /bizzy/sensors/cameras/oak_aft/camera_info
     /bizzy/sensors/cameras/oak_port/camera_info
+    /bizzy/sensors/cameras/oak_forward/segmentation
+    /bizzy/sensors/cameras/oak_starboard/segmentation
+    /bizzy/sensors/cameras/oak_aft/segmentation
+    /bizzy/sensors/cameras/oak_port/segmentation
     /bizzy/sensors/cameras/oak_forward/segmentation/compressed
     /bizzy/sensors/cameras/oak_starboard/segmentation/compressed
     /bizzy/sensors/cameras/oak_aft/segmentation/compressed

--- a/bizzyboat_project11/scripts/record_camera_topics.sh
+++ b/bizzyboat_project11/scripts/record_camera_topics.sh
@@ -32,7 +32,7 @@ TOPICS=(
     /diagnostics
     /tf
     /tf_static
-    /robot_description
+    /bizzy/robot_description
     /bizzy/sensors/cameras/oak_forward/image_raw/ffmpeg
     /bizzy/sensors/cameras/oak_starboard/image_raw/ffmpeg
     /bizzy/sensors/cameras/oak_aft/image_raw/ffmpeg

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -1,0 +1,50 @@
+# BizzyBoat deployment log — dev — 2026-04-27
+
+**Host**: dev
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7)
+**Mode**: dev (GitHub origin)
+**Deployment**: [#94](https://github.com/rolker/unh_echoboats_project11/issues/94)
+
+## Summary
+
+First deployment under the per-(deployment, host) logging convention
+([PR #93](https://github.com/rolker/unh_echoboats_project11/pull/93),
+spec at [`docs/logs/README.md`](../README.md)). Dev-side coordination
+log; gabby and salmon will produce their own host logs and push to
+gitcloud at end of session.
+
+## Pre-flight
+
+2026-04-27T08:55-04:00 — Cleared yesterday's pending PRs on
+`unh_echoboats_project11`:
+- PR #83 merged (2026-04-24 pier session log + hydro-payload SBG/M3/QINSy/1PPS wiring + AML SVS)
+  — applied 4 doc-quality fixes from Copilot review (Valeport `␠`
+  visible-space marker, line-wrapped paths unwrapped, NOAA ANTCAL URL
+  as proper Markdown link)
+- PR #90 merged (2026-04-24 dynamics preliminary findings)
+  — applied 3 doc-quality fixes from Copilot review (replaced
+  agent-memory references with in-repo equivalents, expanded
+  L43↔L44 caveat to name plan-line IDs); skipped 2 false-positive
+  table-pipe comments (verified single-pipe with grep)
+- PR #93 merged (per-deployment logs convention) — also auto-closed
+  the long-running umbrella #57 via "closes out" keyword in body;
+  posted a carry-forward table in [a comment on #57](https://github.com/rolker/unh_echoboats_project11/issues/57#issuecomment-4327249594)
+
+2026-04-27T09:05-04:00 — Pushed all 32 workspace repos to gitcloud
+via `.agent/scripts/push_remote.py --remote gitcloud`. Boat-side
+(gabby) and operator (salmon) ready to pull.
+
+2026-04-27T09:08-04:00 — Created `deployment` label on
+`rolker/unh_echoboats_project11` (color `#1d76db`) and opened
+deployment issue [#94](https://github.com/rolker/unh_echoboats_project11/issues/94).
+
+## Deferred / unaddressed
+
+- 4 additional Copilot comments on PR #93 (workspace-tooling references
+  in Examples + Future automation sections, plus a stylistic note on
+  the `bizzyboat_deployment_log.md` freeze header) — non-blocking,
+  could be addressed in a follow-up if it bothers anyone.
+- Branch cleanup question pending: `feature/issue-89` and
+  `feature/issue-92` are now merged-and-stale on the remote.
+  `feature/issue-57` stays alive per the iterative-PR pattern even
+  though #57 itself is now closed.

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -1017,3 +1017,548 @@ visible-config routers.
   we need to better understand how to acquire **cleaner data at
   capture time**. Acquisition-side investigation is the higher-leverage
   follow-up.
+
+## Bag inventory + event extraction (gabby persistent + on-demand)
+
+Three persistent-logger bag rotations on gabby cover the full day
+(`/home/roland/data/logs/bizzyboat/`); paired sonar bags
+(`/home/roland/data/logs/bizzyboat_sonar/`); plus on-demand
+camera-recorder captures (`/home/roland/data/logs/bizzy_images/`).
+Times below are **EDT, taken from bag epoch metadata** (the
+authoritative source).
+
+| Bag | Window (EDT) | Topics | Notes |
+|---|---|---|---|
+| persistent #1 (`T10.27.49`) | 10:27:55 → 11:17:02 | 29 | Pre-launch only |
+| persistent #2 (`T11.17.22`) | 11:17:28 → 13:51:24 | 29 | **Still pre-launch** (boat on dock) |
+| persistent #3 (`T13.51.46`) | 13:51:51 → 19:31:15 | 30 | **Launch + all surveys + range test + recovery** |
+| sonar #1/#2/#3 | mirror persistent | 6 | DeltaT removed → only `/tf`, `/odom`, `/diagnostics` |
+| `bag_T14.25.31_ffmpeg_seg` | 14:25:32 (2 min) | 20 | First on-water 120 s camera capture |
+| `bag_T15.02.15_ffmpeg_seg` | 15:02:16 (2 min) | 20 | Second 120 s capture |
+| `bag_T15.21.26_ffmpeg_seg` | 15:21:27 (2 min) | 20 | Third 120 s capture |
+| `bag_T17.54.26_ffmpeg_seg` | 17:54:26 (60 min) | 20 | Hour-long capture |
+| `bag_T18.55.46_ffmpeg_seg` | 18:55:46 (35.7 min) | 20 | Late afternoon capture |
+
+Naming-convention note: persistent + bizzy_images dirs use **local
+EDT** in their names; bizzyboat_sonar uses **UTC** (`+00-00`
+suffix). The gabby agent's `2026-04-27_gabby_logs.md §7-§8` log
+entries cite the UTC-named sonar epochs but conflate them with
+local-time bag dirnames — the resulting timestamp claims for
+on-demand captures are off vs. ground truth (see next section).
+
+Extraction scripts saved to `.agent/scratchpad/`:
+
+- `bizzyboat_2026-04-27_event_extraction.py` — GPS reference + altitude/distance traces
+- `bizzyboat_launch_window.py` — launch-event detail at the bag 2 → bag 3 boundary
+- `bizzyboat_rtk_check.py` — fix-type histogram + RTCM injection rates
+- `bizzyboat_rtk_diag_trace.py` — diagnostic-level transitions + rosout RTK lines
+
+## ⚠️ Launch was at 14:01-14:02 EDT, not 11:13 EDT
+
+Gabby's `§6 On-water 11:13-04:00` claim is wrong by **~2.5 hours**.
+Boat sat on the dock all morning (bags #1 and #2 show distance from
+dock = 0 m and altitude pegged at the pre-launch reference). Actual
+launch is in bag #3 (which itself starts 13:51:51 EDT).
+
+Operator-station reference (median of first 5 min of bag #1,
+stddev=0.08 m on altitude):
+
+- **lat**: 43.0720410° N
+- **lon**: -70.7116514° W
+- **alt**: -21.039 m WGS84 (pier deck)
+
+Crane launch sequence (bag #3, EDT):
+
+| Time | alt | Δalt | dist | Event |
+|---|---|---|---|---|
+| 13:51:52 → 13:56:38 | -21.04 | 0 | 0 m | Boat still on dock |
+| 13:56:53 | -21.04 | 0 | 1.1 m | First motion (crane begins moving boat) |
+| 13:57:08 → 13:58:08 | -21.04 | 0 | 16 → 55 m | Crane swing to launch point |
+| 13:59:54 | -20.74 | **+0.30** | 55 m | Crane lifts boat off cradle (typical pre-lower bump) |
+| 14:01:09 → 14:01:54 | -22.0 → -26.07 | -1 → -5 m | 62 m | **Lowering into water** |
+| 14:02:00+ | -26.30 | -5.26 | ~62 m | **🚤 Boat afloat** |
+
+So the dock-to-water drop is **~5.3 m** (consistent with high-pier
+crane operation).
+
+Crane recovery (end of bag #3, EDT):
+
+| Time | alt | Δalt | dist | Event |
+|---|---|---|---|---|
+| ~19:15 | -24.4 | -3.4 | 100 m | Approaching pier |
+| 19:21:22 | -21.21 | -0.17 | 60 m | **Back at dock height** (lifted out) |
+| 19:21:52 | -19.75 | **+1.29** | 59 m | Crane overshoot (typical lift signature) |
+| 19:25:52 → 19:26:22 | -20.4 → -21.1 | | 32 → 6.8 m | Settled on cradle |
+| 19:31:15 | -21.30 | | 7 m | Bag end |
+
+So **recovery: ~19:21-19:26 EDT**. Bag #3 ends at 19:31:15 EDT —
+includes a few minutes of post-recovery on the cradle. (Persistent
+logger likely kept running after recovery; bag ended on its own
+size/time threshold rather than a deliberate stop.)
+
+**Anchored event timeline (EDT)**:
+
+- 10:27:55 — gabby system bring-up, mavros + GPS + diagnostics start
+- 13:51:51 — bag #3 starts; some kind of system handover (matched
+  by sonar bag rollover)
+- **13:56:53** — first crane motion
+- **14:01:09** — crane begins lowering boat into water
+- **14:02:00** — 🚤 boat afloat
+- 14:02 → ~14:30 — likely window for the **external current
+  measurement** (~67 A on BT meter); dev log's "~14:30 EDT" claim
+  is plausible now that we know launch was 14:02, not 11:13
+- **19:05:46** — NTRIP (RTCM corrections) lost
+- ~19:07-19:10 — range-test peak (max distance 417 m at 19:07:29)
+- **19:15:41** — RTK degrades from RTK_FIXED → 3D Fix (10-min coast
+  after RTCM loss, as expected)
+- **19:21:22** — boat lifted back to dock height (recovery)
+- **19:25:52** — boat settled on cradle
+- 19:31:15 — bag #3 ends
+
+**Max distance from operator station**: 417.46 m at 19:07:29 EDT
+(during range test, between cod rock and the buoy).
+
+## RTK status — was actually OK for 97.5% of the day
+
+User asked to look into "the lack of RTK" because no alert showed
+up in the annunciator panel. Initial scan of
+`/bizzy/mavros/global_position/raw/fix.status.status == 0` looked
+like no RTK, but **mavros maps RTK → STATUS_FIX (0)** because
+`sensor_msgs/NavSatStatus` doesn't have an RTK enum value. Real
+RTK detail lives in `mavros_msgs/GPSRAW.fix_type` on
+`/bizzy/mavros/gpsstatus/gps1/raw`.
+
+Across all three persistent bags (323,541 GPSRAW messages):
+
+- `RTK_FIXED` (6): 315,562 messages — **97.5%**
+- `3D` (3): 7,931 — early startup + post-NTRIP-loss tail
+- `DGPS` (4): 48 — transient
+
+**Fix-type transitions (entire day, only 4)**:
+
+| Time | Transition | Sat |
+|---|---|---|
+| 10:27:56 | (init) → 3D | 28 |
+| 10:27:59 | 3D → DGPS | 15 |
+| 10:28:04 | DGPS → **RTK_FIXED** | 29 |
+| **19:15:40** | RTK_FIXED → 3D | 28 |
+
+So RTK locked 5 seconds after first 3D fix at startup, stayed
+solid for **~8.8 hours**, and dropped to plain 3D only during
+the return-to-pier at 19:15:40 EDT. The drop never recovered
+before bag end at 19:31:15 (recovery completed).
+
+### Why RTK dropped: NTRIP source unreachable
+
+`/rosout` has the full mechanism: gabby's NTRIP client
+(`bizzy.sensors.ntrip.ntrip_client`) connects to
+`http://macorsrtk.massdot.state.ma.us:31000/RTCM3_MASA` (Mass DOT
+CORS network) over the internet and forwards RTCM3 to mavros.
+
+- **18:53:52** — first brief NTRIP hiccup ("RTCM data not received
+  for 4 seconds, reconnecting"); recovers immediately
+- **19:05:44** — NTRIP fails again, "Unable to connect socket to
+  server" repeats every ~25 s through bag end
+- **19:09:49** — ntrip_client gives up: "Stopping RTCM publisher,
+  Disconnecting NTRIP client" (but the reconnect-attempt loop
+  continues)
+
+Result chain:
+
+1. 19:05:44 — internet path to MA DOT CORS lost
+2. 19:05:46 — `NTRIP` diagnostic transitions OK → WARN ("no data
+   for 5s")
+3. 19:05:56 — `NTRIP` escalates to ERROR (15 s threshold)
+4. 19:05:41 — RTCM injection actually stops on
+   `/bizzy/mavros/gps_rtk/send_rtcm` (last RTCM at 19:05:41 EDT)
+5. 19:05:44 → 19:15:40 — **RTK coasts on cached corrections** for
+   ~10 minutes (typical age-out behavior)
+6. 19:15:41 — `GPS: RTK` diagnostic OK → WARN ("3D Fix")
+7. 19:15:40 → 19:31:15 — boat finishes its return + recovery on
+   plain 3D
+
+The 19:05 NTRIP loss correlates exactly with the range test (max
+417 m at 19:07:29). Probable cause: range-driven comms
+degradation breaking gabby's outbound internet path. **Worth
+adding to `project_wifi_range.md` once the comms data is
+fully analyzed.**
+
+### So why didn't the annunciator show an alert?
+
+The annunciator config IS set up to surface both:
+
+`bizzyboat_project11/config/bizzyboat_annunciator.yaml`:
+
+```yaml
+- name: RTK
+  source: diagnostics
+  diagnostic_name: "GPS: RTK"
+
+- name: NTRIP
+  source: diagnostics
+  diagnostic_name: "NTRIP"
+  stale_timeout: 10.0
+```
+
+And `/diagnostics` is in udp_bridge's forwarded topic list
+(`bizzyboat.yaml:68,105,149,174,210,270`). Boat side did publish
+the right level transitions at the right times.
+
+**Most likely explanation: a udp_bridge wedge concurrent with the
+RTK loss event prevented the diagnostic update from reaching
+salmon's annunciator.**
+
+Cross-referencing the dev log's "Telemetry spotty again — but boat
+is CLOSER (likely 4th wedge)" entry: that wedge was during the
+return leg (19:15-19:30 window), exactly when `GPS: RTK` went WARN.
+With udp_bridge wedged, salmon's `/diagnostics` stream goes stale —
+the annunciator continues showing the last-known OK state. That
+matches "I don't remember seeing an alert about that."
+
+Two follow-up actions worth tracking:
+
+1. **udp_bridge wedge bug already on the deferred list** — same
+   bug that hid the NTRIP/RTK alert is the one that needed
+   killing the operator-side udp_bridge PID 4× during the day.
+   Already flagged in the dev log § "CAMP latency / position not
+   updating — RECURRENCE of 12:40 wedge".
+2. **Annunciator could surface stale `/diagnostics` itself** —
+   today the only signal that `/diagnostics` had stopped flowing
+   was the absence of *new* indicator updates, which is invisible
+   to a human watching a static-looking panel. A "diagnostics
+   stream stale" indicator (or a per-indicator stale-flash on
+   the existing `stale_timeout` already in the config) would
+   make wedge-vs-everything-OK distinguishable. Worth opening as
+   a focused issue on `rqt_operator_tools` after wrap-up.
+
+Both held — combine with post-recovery network bug evidence into
+one focused issue once the network picture is fuller.
+
+## Terminology — what "wedge" means
+
+Throughout this log and the salmon log, "**wedge**" refers
+specifically to a known `udp_bridge` failure mode (first
+diagnosed on salmon 2026-04-27): the bridge process is alive
+but its UDP reader thread is blocked, the kernel `Recv-Q`
+backs up (361 KB observed earlier), no forwarded topics make
+progress on the operator side, and the only known recovery is
+`kill` + `operator_core_launch` respawn. The boat-side bridge
+keeps running normally throughout — only the receiving side
+stalls. This is **not** a crash, **not** a network outage, and
+**not** an authentication/firewall issue. When I say "wedge" I
+mean specifically this bug; other failure modes (RF range
+degradation, NTRIP socket loss, restarts) get their own names.
+
+## Voltage / PWM / SOC analysis — bag-derived
+
+(Scripts: `.agent/scratchpad/bizzyboat_power_analysis.py`,
+`.agent/scratchpad/bizzyboat_soc_estimate.py`.)
+
+### Voltage and PWM by phase
+
+`/bizzy/mavros/battery` (BatteryState) and `/bizzy/mavros/rc/out`
+(RCOut, channels 0..3 = thrusters, 0/1 paired = port,
+2/3 paired = stbd):
+
+| Phase | V (med/min) | ΔV peak | ch0/1 PWM range | ch2/3 PWM range |
+|---|---|---|---|---|
+| Pre-launch (idle on dock) | 29.03 / 28.82 | 0.24 V | 1500 (idle) | 1500 |
+| Launch + early teleop (14:02-14:30) | 28.63 / 27.08 | 1.75 V | 1140-2000 | 1000-2000 |
+| Mid-survey (15:00-17:00) | 28.30 / 26.51 | 2.00 V | 1000-2000 | 1000-2000 |
+| Late afternoon (17:00-19:00) | 28.07 / 26.39 | 1.97 V | 1215-2000 | 1000-2000 |
+| Range test (19:00-19:15) | 27.49 / 26.14 | 1.71 V | 1407-2000 | 1000-2000 |
+| Recovery idle (19:21-19:27) | 27.59 / 26.42 | 1.20 V | 1490-1500 | 1497-1640 |
+
+- 145 peak-PWM windows ≥5 s found (any channel saturating to
+  PWM 2000) starting at 14:02:24 and continuing across the day.
+- FCU current reading flat at 0 A throughout (294,116 samples,
+  median = -0.000) — **confirms BATT_MONITOR=4 inherited from
+  IzzyBoat with no current sensor wired between Torqeedo packs
+  and Cube** (per memory `project_bizzyboat_autonomy_stack.md`).
+
+### Internal resistance estimate from V-drop + external 67 A
+
+ΔV ≈ 1.7 V at I = 67 A (peak) → **R_internal ≈ 25 mΩ** for the
+full path (Torqeedo BMS internal R + cabling + connectors,
+across the 2-pack parallel arrangement). One operating point;
+not a curve, but useful for cross-validating the V-drop /
+power-proxy work in PR #90.
+
+### Base current at rest: 7-9 A
+
+User observation (in-water, both thrusters at PWM 1500, all
+systems on, no propeller spin demanded): **~8 A drawn at the
+battery output**. Not previously logged; capturing here for
+future reference.
+
+This is the floor used as `I_idle = 8 A` in the SOC estimate
+below. Composition (back-of-the-envelope):
+
+- gabby compute, fans, USB hubs, peripheral sensors: 2-4 A
+- Cube + servos + ESCs in idle: 1-2 A
+- LTE/WiFi/Starlink stacks (when booted): 1-2 A
+- Cooling, lights, etc.: 1-2 A
+
+A proper PWM × current sweep (folds into #88) would also
+characterise the per-thruster contribution at 25%, 50%, 75%
+of full to validate the model. Today we have only two anchor
+points: 1500 PWM (idle, both thrusters off) → 8 A, and 2000
+PWM both → 67 A.
+
+### SOC estimate by coulomb counting
+
+Calibration anchors:
+
+- Idle (PWM 1500 both): I_total = 8 A
+- Full throttle (PWM 2000 both): I_total = 67 A → per-thruster
+  contribution at full = (67 − 8) / 2 = 29.5 A
+
+Two models for per-thruster current vs. PWM:
+
+- **Linear**: `I_thr ∝ |pwm − 1500| / 500`  (worst-case ceiling)
+- **Quadratic**: `I_thr ∝ (|pwm − 1500| / 500)²`  (closer to
+  the physical P ∝ ω² propeller-power relationship)
+
+Battery capacity (denominator): 2 × Torqeedo Power 24-3500 in
+parallel = ~7000 Wh / 25.6 V ≈ **273 Ah nominal**.
+
+Coulomb-counting integration over RC time series (sample-and-hold
+between samples), bag #2 + bag #3:
+
+| Phase | Dur | Ah (lin) | Ah (quad) | %SOC loss (lin) | %SOC loss (quad) |
+|---|---|---|---|---|---|
+| Launch + early teleop | 0.47 h | 16.18 | 13.65 | 5.93% | 5.00% |
+| Mid-afternoon (surveys) | 2.50 h | 76.63 | 58.73 | 28.07% | 21.51% |
+| Late afternoon (cod rock+) | 2.00 h | 53.14 | 36.62 | 19.46% | 13.42% |
+| Range test | 0.25 h | 7.72 | 5.77 | 2.83% | 2.11% |
+| Return + recovery | 0.27 h | 4.22 | 3.73 | 1.55% | 1.37% |
+| **TOTAL on-water** | **5.48 h** | **157.9** | **118.5** | **57.8%** | **43.4%** |
+
+Pre-launch dock idle (10:28 → 14:02 = 3.6 h, assumed I ≈ 6-8 A,
+thrusters disarmed/idle out of water):
+
+| I_dock | Ah | %SOC |
+|---|---|---|
+| 6 A | 21.4 | 7.8% |
+| 7 A | 25.0 | 9.1% |
+| 8 A | 28.5 | 10.5% |
+
+**Whole-day SOC estimate at boat recovery**:
+
+- Linear (worst-case): 100% − 58% on-water − ~9% dock = **~33%
+  remaining**
+- Quadratic (more physical): 100% − 43% on-water − ~9% dock =
+  **~48% remaining**
+
+So the day's actual energy use was somewhere in the **52-67% of
+pack capacity** range. The gap between the two models (~15%)
+reflects the genuine uncertainty until we have a proper
+PWM × current sweep — one operating point doesn't pin the curve.
+
+### What FCU still says vs. reality
+
+Throughout the day the BMS reading reported on
+`/bizzy/mavros/battery.percentage` stayed at **99%**.
+
+That's because BATT_MONITOR=4 is *voltage-based* and:
+
+1. No current sensor → no coulomb counting → percentage just
+   tracks voltage.
+2. LiFePO4 has a famously flat voltage curve from ~30% to ~90%
+   SOC — for most of the discharge, voltage tells you basically
+   nothing. The pack went from 28.98 V (start) to 27.60 V (end)
+   while real SOC dropped by ~50-60%.
+3. ArduPilot's voltage→percentage map is calibrated for typical
+   chemistries (Li-ion-ish curve), not LiFePO4.
+
+**Action: update FCU BATT_MONITOR params** to reflect the
+no-current-sensor reality (or accept SOC reading is uninformative
+and tell the operator UI to suppress it). PR #56 is already
+field-gated for parameter rework on this pack — fold this in.
+
+### Voltage cross-check (rough, LiFePO4-aware)
+
+- Initial resting V (early bag 2): 28.98 V → fully charged
+  (Torqeedo charge target ~28.8-29.0 V)
+- Final resting V (post-recovery, 19:27+): 27.60 V → still
+  near-nominal (8 × 3.45 V) — well above the 21 V cutoff
+- LiFePO4 voltage is unreliable as an SOC indicator across
+  this range; coulomb counting wins. The voltage-based view
+  alone might suggest "still mostly full" — **don't trust it.**
+
+## udp_bridge behaviour during deployment
+
+(Script: `.agent/scratchpad/bizzyboat_udp_bridge_analysis.py`.)
+
+### Bridge_info publish-rate timeline
+
+`/bizzy/udp_bridge/bridge_info` (boat publishes its own state at
+0.5 Hz) and `/bizzy/udp_bridge/remotes/operator/bridge_info`
+(operator's own bridge_info forwarded back into bizzy — gaps in
+*this* topic mean the operator-side bridge stopped sending).
+
+| Phase | dur | Operator bridge_info | rate | max gap |
+|---|---|---|---|---|
+| Pre-launch bag 1 | 47 min | 1392 | 0.49 Hz | 2.3 s |
+| Pre-launch bag 2 | 153 min | 4560 | 0.50 Hz | 2.4 s |
+| Launch + early teleop | 28 min | 844 | 0.50 Hz | 2.7 s |
+| Mid-afternoon (surveys) | 120 min | 3603 | 0.50 Hz | 8.2 s |
+| Late afternoon (cod rock+) | 120 min | 3555 | 0.49 Hz | **59.4 s** |
+| Range test peak | 15 min | 383 | 0.43 Hz | 10.4 s |
+| Return to pier | 6 min | 183 | 0.51 Hz | 4.4 s |
+| Recovery + post-recovery | 10 min | 235 | 0.37 Hz | 5.1 s |
+
+### Gap inventory (operator bridge_info)
+
+Gaps > 10 s (suggesting a real interruption rather than the
+0.5 Hz heartbeat slipping):
+
+| # | Time (EDT) | Duration | Distance | Notes |
+|---|---|---|---|---|
+| 1 | 11:17:01 → 11:17:29 | 28 s | dock | Bag rotation; coincides with mavros restart on boat |
+| 2 | 13:49:29 → 13:55:05 | **336 s** | dock | Bag rotation + mavros restart at 13:51 — system was down for ~5.6 min on operator's view |
+| 3 | **17:40:33 → 17:41:33** | **59 s** | 75 m | Mid-survey wedge candidate |
+| 4 | 19:10:49 → 19:10:59 | 10 s | 250 m | Marginal; just over threshold during return after range peak |
+
+(My initial framing of "4 wedges" was loose. By the strict
+definition above, only #3 is unambiguously a wedge — bridge
+silent for 59 s while bizzy is publishing fine. #1 and #2
+correlate with mavros restarts; #4 is on the edge.)
+
+### Two restarts during the day
+
+Bag rollovers at 11:17 EDT and 13:51 EDT each begin with
+"Plugin gps_rtk created", "ntrip_diagnostics", etc. on
+`/rosout` — i.e., **gabby's mavros stack restarted twice while
+the boat was on the dock**, well before the 14:02 launch. Cause
+unknown from this log; presumably user-initiated as part of
+pre-launch debug. Worth confirming with the operator on the
+next session.
+
+### `/diagnostics` forward rate stayed ~9.2 Hz all day
+
+Cross-checking input rate of `/diagnostics` on bizzy's
+udp_bridge `topic_statistics`:
+
+- 9.0-9.4 messages/sec consistently across the 5+ hours
+- **Input bytes/sec dropped ~25% at 18:52 EDT** (~17,800 →
+  ~13,200 B/s) and stayed lower through bag end. Some
+  diagnostic publisher reduced its output around then. Worth
+  checking which node went quieter; could correlate with the
+  network degradation that began with NTRIP loss at 19:05.
+
+### Caveat — udp_bridge "send" stats not populated
+
+`topic_statistics.send.{success,failed,dropped}_bytes_per_second`
+read 0 across the entire day for every topic, including
+`/diagnostics` which was clearly being forwarded. This is
+either:
+
+- udp_bridge instrumentation gap (the success/fail counters
+  aren't being updated for these topics), or
+- A schema-interpretation issue on my side
+
+Either way, **we cannot directly confirm successful forward
+delivery from the bizzy-side bag**. Operator-side delivery
+would need salmon's bag (which we don't have for today).
+Worth a focused look at `rolker/udp_bridge` to confirm whether
+the send stats *should* be populating.
+
+## Power usage by commanded mode
+
+(Scripts: `.agent/scratchpad/bizzyboat_cmd_vel_histogram.py`,
+`.agent/scratchpad/bizzyboat_power_by_mode.py`.)
+
+Binning on-water time (14:02 → 19:21 EDT) by the most recent
+`/bizzy/piloting_mode/autonomous/cmd_vel.linear.x`. Pre-autonomy
+window (14:02 → first plan at 15:17:39 EDT, ~75.7 min) is teleop +
+current measurement + system bring-up; not classified by mode.
+
+Achieved (odom) speed reported as median + IQR. Current is the
+PWM-based estimate (quadratic model, anchored at 8 A idle / 67 A
+full-throttle).
+
+| Mode | Time | % on-water | Avg I (lin) | Avg I (quad) | Ah (quad) | V med | Achieved v (med, IQR) |
+|---|---|---|---|---|---|---|---|
+| Hover (cmd≈0) | 95.7 min | 39.3% | 25.4 A | **20.6 A** | 32.89 | 28.27 V | 0.04 (-0.02 / 0.11) |
+| Fine-maneuver (cmd 0.05-0.45) | 75.5 min | 31.0% | 31.1 A | 20.6 A | 25.88 | 28.25 V | 0.20 (0.09 / 0.25) |
+| Low-mid (0.45-0.65) | 7.5 min | 3.1% | 27.2 A | 22.5 A | 2.81 | 27.58 V | 0.02 (-0.15 / 0.39) |
+| Survey @ 0.75 m/s | 47.4 min | 19.5% | 23.2 A | **13.4 A** | 10.58 | 27.97 V | 0.76 (0.74 / 0.80) |
+| Mid (0.85-1.40) | 4.1 min | 1.7% | 31.3 A | 20.8 A | 1.42 | 27.84 V | 0.78 (0.66 / 0.84) |
+| Survey @ 1.5 m/s | 12.4 min | 5.1% | 34.7 A | **25.6 A** | 5.29 | 27.40 V | 1.50 (1.48 / 1.53) |
+| Fast (>1.60) | 0.7 min | 0.3% | 50.8 A | 44.1 A | 0.54 | 26.99 V | 1.36 (range-test transients) |
+
+### Three findings
+
+**1. Hover costs more than slow survey.** Station-keeping at
+cmd_vel ≈ 0 (achieved speed ~0.04 m/s — basically drift) drew
+**20.6 A average**, while surveying at 0.75 m/s drew only
+**13.4 A** despite the boat actually moving forward. Active
+counter-current pulsing on a stationary boat is more
+thruster-active than the steady-state low-throttle output needed
+to maintain 0.75 m/s through the water. **Minimum-power state
+isn't `v = 0`.**
+
+**2. Wh/km is essentially flat across both survey speeds.**
+Specific-energy comparison:
+
+| Survey speed | Distance | Energy | Wh/km |
+|---|---|---|---|
+| 0.75 m/s (47.4 min) | 2.16 km | 295.8 Wh | **137** |
+| 1.5 m/s (12.4 min)  | 1.12 km | 144.9 Wh | **130** |
+
+Doubling speed roughly doubles drag power but halves the time
+the boat pays the 8 A baseline platform draw → per-km cost
+nearly cancels. **For class endurance: faster survey speed is
+a free win.** Higher speed also doubles throughput and shortens
+the inter-line hover dwell, which was the single biggest energy
+sink today.
+
+Per-charge survey range estimate (7000 Wh, ignoring hover/transit
+overhead): ~51 km at 0.75 m/s, ~54 km at 1.5 m/s. Real practical
+endurance is ~half that because hover dwell + transit eat
+significantly into the budget.
+
+**3. Hover dominated total on-water energy.** Of the 79.4 Ah
+accounted for in the mode breakdown:
+
+- Hover: **41%** (32.89 Ah)
+- Fine-maneuver / approach: **33%** (25.88 Ah)
+- Survey @ 0.75: 13% (10.58 Ah)
+- Survey @ 1.5: 7% (5.29 Ah)
+- Other: 6%
+
+So **roughly three-quarters of mode-classified on-water energy
+went to hover or low-speed maneuvering**, not surveying. Tighter
+task chaining — less between-task hover dwell — would
+significantly extend mission duration.
+
+This connects to:
+
+- [#35](https://github.com/rolker/unh_echoboats_project11/issues/35)
+  — when to clear stale mission on GUIDED entry. Relevant because
+  current default likely contributes to dwell at task boundaries.
+- The BT → FollowPath gap (gabby log §8): once `target_speed`
+  reaches nav2's `/speed_limit`, per-survey speed becomes
+  selectable per task, not just a controller-level default.
+  Folds into a `unh_marine_navigation` follow-up.
+- [#88](https://github.com/rolker/unh_echoboats_project11/issues/88)
+  (dynamics calibration) — a proper PWM × current sweep would
+  tighten these estimates and let us choose survey speed for
+  energy budget too, not only throughput.
+
+### Caveats
+
+- The "achieved speed" for hover (0.04 m/s with IQR -0.02 to
+  0.11 m/s) shows mostly drift, but the boat *did* track within
+  hover tolerance — not actually drifting away. Means the
+  20.6 A hover current is a real cost of holding station against
+  this site's currents/wind on this day, not an artifact of
+  cmd_vel ≈ 0 with disengaged thrusters.
+- Quadratic model anchored at two points (idle + full); the
+  middle of the curve is interpolation. The Wh/km figures could
+  shift ±15% with better calibration.
+- Pre-autonomy 75 min (14:02 → 15:17) is excluded from the mode
+  breakdown — it's teleop / current measurement / shakedown, not
+  a steady mode. Adding ~28 Ah at the FCU-arming-to-first-survey
+  rate.

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -130,6 +130,862 @@ calibration runs, anything that needs flat-water data. Wind stays
 align with the daylight high (07:00–10:30 EDT) and the evening high
 (19:30–22:00); the afternoon low has no impact on pier ops.
 
+## mercat QINSy bring-up — discovery (cross-host SSH from dev)
+
+User stood up SSH to mercat at ~11:00 EDT (`field@mercat`, cmd.exe
+prompt). Tmux session `mercat:0`. Per coordination rule: batch
+commands sent with permission, no extras without notice.
+
+2026-04-27T11:02-04:00 — Sanity batch 1 (`where ntpq`, ping M3,
+`Get-Date`, `Get-PnpDevice -Class Ports`, `dir "C:\Program Files\QPS"`):
+
+- Meinberg `ntpq` at `C:\Program Files (x86)\NTP\bin\ntpq.exe`
+- M3 (192.168.1.234) reachable, <1 ms RTT, 0% loss
+- mercat clock is **UTC** (`+00:00`). Confirmed with user: gabby
+  also UTC (TZ adjusted today); mercat stays UTC because it's
+  Windows. salmon + dev remain EDT. Mixed-TZ deployment; convention
+  (local-with-offset) handles it.
+- COM1–COM5 enumerated as "Communications Port" (no SBG/AML driver
+  installs — expected for raw serial).
+- `C:\Program Files\QPS` has only `Qimera` + `HelpServer` — QINSy
+  not installed there.
+
+2026-04-27T11:05-04:00 — Sanity batch 2 (`dir Program Files (x86)
+\QPS`, `dir C:\QPS`, `dir C:\Qinsy`, `dir public Qinsy user data`,
+`reg query HKLM\SOFTWARE\QPS`):
+
+- **QINSy 9.8.2** installed at
+  `C:\Program Files (x86)\QPS\Qinsy\9.8.2\`
+- Survey Manager at
+  `C:\Program Files (x86)\QPS\Qinsy\9.8.2\Survey manager\`
+- User data at `C:\Users\Public\Documents\Qps\Qinsy\` (Documentation,
+  Drivers, Eventing, Qontrol, Settings). `Settings/` modified
+  04/22 17:53 UTC — matches the SBG/M3 measurement session.
+- `where /R` recursive search misfired earlier — likely
+  access-denied on a subdir aborted recursion. `dir` works fine.
+
+2026-04-27T11:08-04:00 — `ntpq -pn`: locked to `*192.168.20.123`
+(TM2000B), stratum 1 GPS, reach 377, delay 0.767 ms, **offset
+−9.544 ms**, jitter 0.245 ms. **Larger than memory's recorded ~0.5
+ms** (`reference_mercat_time_sync.md`). Could be a slow slew or a
+real regression; will re-check before QINSy logging starts. Flagged.
+
+2026-04-27T11:12-04:00 — Pre-launch checks (`tasklist sbgCenter*`,
+`tasklist M3*`, `mode COM4/COM3`):
+
+- sbgCenter and M3 software both **not running** — COM3 + COM4
+  free.
+- `mode COMx` reports Windows defaults (1200 7-N-1) — not
+  meaningful, since QINSy will set 115200 8-N-1 when it opens
+  COM4. Useful only as a port-not-busy proxy (no error here).
+
+Ready for user to launch QINSy via RDP. Sequence on deck:
+
+1. Survey Manager → confirm v9.8.2 + active project / template
+2. DbSetup → add Position Navigation system → driver
+   `SBG Systems (R-P-H) – 03` on COM4 @ 115200; same instance
+   wires Gyro Compass + Pitch-Roll-Heave systems
+3. Verify position + heading + attitude at steady rate via QINSy
+   port monitor
+4. **No QINSy-side lever arms** (already in sbgCenter from 04/22)
+5. NTRIP path decision deferred (independent SBG MACORS vs.
+   shared via Cube vs. routed via mercat)
+
+## QINSy bring-up — first SBG fix on map
+
+2026-04-27T~12:30-04:00 — User drove QINSy DbSetup via RDP, with
+me providing reference info from the install log. Sequence:
+
+- SBG ECOM message set verified in sbgCenter (STATUS, UTC_TIME,
+  EKF_NAV, EKF_EULER, SHIP_MOTION, GPS1_POS/VEL/HDT enabled on
+  COM4); save persisted; data flowing per TeraTerm check.
+- DbSetup → SBG (R-P-H) – 03 driver added on COM4 @ 115200 N81.
+- Related systems added: P/R/H slot, Gyro Compass slot (Euler
+  source — EKF-fused over GPS1_HDT), Position Navigation slot
+  (EKF_NAV source).
+- Time Sync System added with **"Third Party synchronized Windows
+  system time"** driver (per QPS docs — keeps QINSy out of OS
+  clock steering, so ntpd → TM2000B continues to discipline
+  uncontested). Misc Metadata + Misc Delayed Heave also added.
+- M3 driver added (Kongsberg Mesotech M3 – 20, UDP port 20002,
+  bind 127.0.0.1) with mounting offsets x=-0.23 / y=0 / z=-0.145,
+  face Down. M3 software side config still pending.
+- Hit "no steered node available" warning. **Resolved in Controller
+  (not DbSetup)**: Computation Settings panel while online. Saved
+  to memory `project_qinsy_steered_node_in_controller.md` since
+  this is a QINSy 9.x quirk that'll bite again.
+- Result: boat position now appearing on the QINSy crude map —
+  end-to-end SBG → QINSy nav working. First milestone of the day.
+
+Still pending on the QINSy side:
+- M3 software config (UDP export to 127.0.0.1:20002, .ALL format,
+  link speed override, Deployment dialog with zero offsets)
+- AML SVS routing (deferred until gabby's sv_bridge is up)
+- NTRIP path decision (independent SBG MACORS vs. shared via
+  Cube vs. routed via mercat)
+- ZDA UDP-31100 from QINSy to M3 head for 1PPS time sync
+- Multibeam Echosounder Computation entry + Steered Node set in
+  Controller for it too
+
+## Field data — external current measurement
+
+2026-04-27T~14:30-04:00 (approx) — Boat deployed. User performed
+the first ever **external current measurement** on BizzyBoat using
+a Bluetooth current meter, with throttle held at full via the RC
+controller. Reading: **~67 A**.
+
+Why this matters:
+- The FCU `BATT_MONITOR=4` config inherited from IzzyBoat reports
+  ~0 A because **no current sensor is wired** between the two
+  Torqeedo Power 24-3500 packs and the Cube (per
+  `project_bizzyboat_autonomy_stack.md`). Voltage reads correctly,
+  current does not. PR
+  [#56](https://github.com/rolker/unh_echoboats_project11/pull/56)
+  is field-gated on apply for that reason.
+- PR
+  [#90](https://github.com/rolker/unh_echoboats_project11/pull/90)
+  (merged today) characterized PWM → speed using **V-drop as a
+  proxy for power** because no current was available. With this
+  external measurement, V-drop / kt / amp becomes actually useful
+  for cross-validation.
+
+Confirmed context: **DC clamp meter on the whole system** (combined
+output, post-parallel), boat **in the water under full load**, **full
+throttle via RC**. So this is the real, all-up current draw at peak.
+
+Math:
+- Power: 67 A × ~25.6 V nominal ≈ **~1715 W** at the battery output
+- 2 × 3500 Wh / 1715 W = **~4.08 h nominal** at constant full
+  throttle. Realistically 2.5–3 h after voltage-sag cutoff at the
+  21 V Torqeedo floor (and BMS may cut earlier).
+- Cross-check vs. PR #90 dynamics: at PWM ~1940 (max observed, ~3.78
+  kt steady), this gives **~454 W/kt** at peak — useful absolute
+  scale for the V-drop proxy curve.
+
+This is the first useful absolute-power number on this boat. Worth:
+- Folding into the dynamics doc's Caveats / Provenance as an
+  "external power reference at peak" data point (one operating
+  point — does not give us the curve, but anchors it)
+- A proper PWM-vs-current sweep with the BT meter would give us
+  the full curve and let us turn the V-drop proxy into a calibrated
+  one. That fits naturally into [#88](https://github.com/rolker/unh_echoboats_project11/issues/88)
+  (dynamics calibration field experiment) — propose adding a
+  "current sweep" task there.
+
+## M3 → QINSy UDP export — root cause
+
+2026-04-27T~16:30-04:00 — After hours of QINSy/M3 config verification
+(install log followed exactly, mercat-side `Setup → Preferences →
+UDP Data Export` set to 127.0.0.1:20002, `File → Exporting Format →
+Profile Point (.all)`, `Override Network Link Speed = 125 Mbps`,
+M3 software restart, Wireshark `udp.port == 20002` filter on the
+Loopback adapter showing zero packets), root cause located in the
+M3 Sonar Reference Manual at line 2378–2381:
+
+> If you wish to export the sonar data to third-party software, click
+> the **circular icon in the top-right corner of the sonar view** to
+> open the **Menu Widget**. Click **Export Data**.
+
+This is a **per-session toggle** that gates all UDP/file export
+regardless of how completely the destination is configured in
+Preferences. The icon is **small and visually low-contrast against
+the sonar view background** — easy to miss entirely. Quote from
+user: *"That little circle is small and does not contrast well with
+the background and is easy to miss!"*
+
+Saved to memory `project_m3_export_data_menu_widget.md` so the next
+agent who hits this doesn't burn the same hours.
+
+**Follow-ups**:
+- Amend `bizzyboat_project11/docs/hydro_payload_install_log.md`
+  M3-software checklist with explicit "click Menu Widget → Export
+  Data" final step. Worth a focused issue.
+- Display Mode in Profiling Settings must also be Profile Only
+  or Image and Profile (not Image Only) — was already fine, but
+  worth calling out in the same checklist amendment.
+
+## SBG delayed heave — confirmed unsupported on Ellipse-D
+
+2026-04-27T~17:15-04:00 — Verified via sbgCenter COM4 output
+configuration that the Ellipse-D-G4A2-B1 on FW 3.0.3949-stable
+exposes only the **standard SHIP_MOTION** ECOM message — **no
+HP / Delayed / High-Precision variant** available.
+
+Cross-checked against [SBG FW 3.0.3949 release notes](https://support.sbg-systems.com/sc/el/firmware-v2.x/firmware-releases/3-0-3949-stable):
+the only heave-related improvements are to the standard SHIP_MOTION
+(latest-generation filter, 1 kHz, EKF-aligned timestamps). No
+SHIP_MOTION_HP. This is a product-tier limitation — HP/delayed
+heave is reserved for higher-end SBG units (Apogee/Quanta/Navsight).
+
+**Decision**: remove the Misc Delayed Heave related system from
+QINSy DbSetup. Slot would sit permanently empty and generate
+warnings. Real-time SHIP_MOTION (already in the P/R/H slot) is
+what we have, and is sufficient for live coverage + class scope.
+
+For highest-precision post-processing, delayed heave can be
+re-derived in Qimera (or similar) from logged raw IMU data —
+out of scope for in-survey workflow.
+
+Saved to memory `project_sbg_ellipse_d_no_delayed_heave.md` so
+future agents don't rediscover this. Worth amending the install
+log's QINSy SBG checklist to flip Misc Delayed Heave from
+"add this" to "skip — Ellipse-D doesn't support it; only add
+for higher-tier SBG units."
+
+## AML SVS — PowerShell bridge end-around (works!)
+
+2026-04-27T~17:50-04:00 — After several hours fighting M3's custom-
+sensor parser (turned out the AML emits **CRCRLF** `0D 0D 0A` line
+terminators, not standard CRLF — multiple format permutations
+silently failed even though the XML defs looked correct), pivoted
+to a **serial-to-UDP bridge** on mercat:
+
+- Script: `C:\Users\admin\aml_bridge.ps1` (PowerShell, ~80 lines)
+- Reads COM3 @ 9600 (`$AML,SVM,...`)
+- Parses SV value with **`[decimal]` precision** (no IEEE-754
+  rounding when scaling m/s → mm/s)
+- Emits Valeport-format `␠NNNNNNN\r\n` via UDP to `127.0.0.1:20003`
+- ~26 Hz throughput, M3 receives via built-in Valeport UDP driver
+
+This is **the same architecture the planned gabby `sv_bridge`
+(`marine_tools#1`) will use**, just on mercat as the interim host.
+When gabby's bridge lands, swap the source host; M3 (and QINSy
+when added) consumer config stays the same.
+
+Cleaner than fighting M3's parser:
+- No custom-sensor XML to maintain
+- M3 uses its own well-tested built-in Valeport driver
+- Same path will eventually feed QINSy (just add second UDP send
+  in the script) → dual-feed architecture available today, no
+  Y-cable / com0com / port-sharing nonsense
+
+**Follow-ups**:
+- Commit the script to project repo (currently only on mercat —
+  loss risk). Suggested home:
+  `bizzyboat_project11/scripts/aml_bridge.ps1`.
+- Wrap as Windows scheduled task at boot if it needs to survive
+  logout / reboot.
+- Extend to fan out to QINSy too (one additional `$udp.Send` call).
+- AML serial number reported in sentence is **205937**, not
+  **11357** as recorded in `bizzyboat_setup_progress.md`. Verify
+  at boat which is which (housing vs. electronics SN).
+
+## AML stream gotcha — CRCRLF line terminator
+
+2026-04-27 — Burned hours on M3 custom-sensor parser failing
+silently. Root cause: AML emits sentences terminated with
+`\r\r\n` (`0D 0D 0A`), not standard `\r\n`. M3's parser with
+Termination=CRLF either rejects on the extra CR or includes it
+in the last field's content (truncating the checksum or
+poisoning the field). Termination=CR works (first CR terminates
+the line cleanly).
+
+Saved to memory `project_aml_bridge_powershell.md` so future
+agents recognize this fingerprint quickly.
+
+## First survey started
+
+2026-04-27T~18:00-04:00 — User started the first BizzyBoat survey
+with the new hydro payload pipeline live end-to-end:
+
+- SBG (Ellipse-D) → COM4 → QINSy SBG (R-P-H) - 03 driver ✓
+- M3 → UDP 20002 → QINSy Kongsberg Mesotech M3 - 20 driver ✓
+- AML SVS → COM3 → mercat PowerShell bridge → UDP 20003 →
+  M3 Valeport driver ✓
+- M3 mounting offsets in QINSy: x=0, y=−0.23, z=−0.145
+  (QINSy frame: stbd+, fwd+, up+)
+- Time sync: QINSy Third Party driver, Meinberg ntpd disciplines OS
+  (offset slewing toward zero across the day, was −7.7 ms last check)
+- ZDA UDP-18 from QINSy → M3 head 192.168.1.234:31100 ✓
+- Steered Node = CoG, set in Controller Computation Settings ✓
+
+Known gaps for this shakedown survey (planned, accepted):
+- SBG without RTK (gabby NTRIP forwarder + QINSy WinSocket Diff
+  Input planned as follow-up)
+- QINSy without independent SV (M3 has it via the bridge; QINSy can
+  be added by extending the bridge to fan out)
+- AML serial number discrepancy (sentence 205937 vs. memory 11357)
+  not yet field-verified
+- Misc Delayed Heave slot still in QINSy DbSetup (cosmetic; will
+  generate "no data" warnings)
+
+Get observations and any hiccups during/after the survey and I'll
+fold them in.
+
+## Survey observation — weird turn onto line 3
+
+2026-04-27T~18:1?-04:00 — User reported a "weird turn onto 3rd line"
+during the live survey. Detail TBD (asked for shape/values/timing).
+
+Strong candidate cause: **TF extrapolation on multi-line goals**
+(`rolker/unh_marine_navigation#23`, carried forward from #57).
+Symptom is stale `header.stamp` on per-line goals making
+`lookupTransform` fall outside the cached buffer at the line
+transition. If this is what we saw, today is the first real-world
+repro — bag should be informative for the fix.
+
+Bag should be in `~/data/logs/bizzyboat/` on gabby for the survey
+session; flag the relevant time window when wrap-up happens.
+
+## CAMP latency / position not updating — RECURRENCE of 12:40 wedge
+
+2026-04-27T~18:1?-04:00 — User reported CAMP latency, position not
+updating mid-survey. Cross-referenced salmon's host log: this is the
+**second occurrence today** of the same `udp_bridge` wedge that hit
+at 12:40 EDT.
+
+Salmon agent's earlier diagnosis (in `2026-04-27_salmon_logs.md`):
+
+- udp_bridge process alive but reader thread wedged
+- 361 KB kernel Recv-Q backup → bridge not draining
+- Root cause hypothesis: back-pressure / deadlock when republishes
+  hit a now-dead CAMP-side subscriber during a CAMP freeze + kill
+  window. Bridge never recovers discovery state.
+- Recovery: kill operator-side udp_bridge PID; operator_core_launch
+  respawns it clean. Topics resume within seconds.
+
+**Two occurrences in one day = real follow-up needed**, not just a
+one-off. The salmon agent already noted the engineering direction:
+
+> A single subscriber going away should not be able to wedge the
+> bridge's UDP reader thread. Either the publish path needs to be
+> non-blocking against any single subscriber, or the bridge needs a
+> watchdog that kicks the reader if Recv-Q grows beyond a threshold
+> for too long.
+
+**Wrap-up follow-up**: open a focused issue against `rolker/udp_bridge`
+for the wedge-on-subscriber-loss bug, with both today's incidents as
+repro evidence. Bag from the survey window will likely show the
+back-pressure pattern.
+
+## CAMP escalation — frozen, video broken, autonomy still healthy
+
+2026-04-27T~18:2?-04:00 — Latency progressed to: CAMP frozen, video
+arriving broken, but **boat still following lines** (gabby's
+autonomy is unaffected). This is a partial-wedge mode (some video
+bytes still flow but degraded) rather than the full silent wedge
+seen at 12:40.
+
+Critical point: **boat-side bag continues recording survey data on
+gabby**, so survey data integrity is not at risk regardless of
+operator-side recovery. Only operator situational awareness is lost
+during the wedge window.
+
+Recovery is the same: salmon agent kills operator-side udp_bridge
+(and CAMP, if truly frozen); operator_core_launch respawns. Should
+recover within seconds once issued.
+
+This is now the **third occurrence today** of operator-side comms
+degradation under sustained survey load — making the udp_bridge
+follow-up issue even more urgent than initially noted. The pattern
+is consistent: prolonged operation with full-stack consumers leads
+to bridge wedge.
+
+## Local Windows laptop crashed during survey
+
+2026-04-27T~18:10-04:00 — User's local Windows laptop (used to RDP
+to mercat) hit a "ran into a problem and needs to restart" error.
+RDP to mercat was lost.
+
+**mercat itself is unaffected** — verified via SSH from a separate
+machine (the deadpool/dev tmux paths are independent of the
+crashed laptop). AML bridge still running (sentence #33,400 at
+22:09 UTC, ~26 Hz steady), QINSy/M3 on mercat presumed healthy.
+Survey continues: boat-side autonomy unaffected, mercat-side
+logging continues, no data loss.
+
+Recovery: laptop reboots, user re-RDPs, all mercat windows in
+their previous state.
+
+2026-04-27T~18:?? — Laptop rebooted, RDP reconnected. **M3 sonar
+still running, QINSy still logging.** Confirmed mercat-side
+processes survived the laptop crash without any intervention. AML
+bridge (SSH-tmux) also confirmed running through the whole
+incident. Net: zero downtime on data acquisition.
+
+Worth a side-note: the laptop crashing during a live survey is a
+single point of failure for the operator-side hydrographic UI (RDP
+to mercat is the only access path). For the June class a more
+robust fallback would be useful — at minimum, document the SSH-
+based recovery path so a laptop crash doesn't blind the operator
+mid-survey. Could also stand up a second RDP-capable machine.
+
+## M3 sonar mode for today's survey
+
+2026-04-27 — M3 set to **Profiling – Bathymetry** mode for the
+shakedown survey. This is the right mode for the .all/Profile
+Point export pipeline — generates the profile-point depth data
+that the QINSy Kongsberg Mesotech M3 - 20 driver consumes. (Other
+modes like Imaging would not produce profile points and the .ALL
+export would be empty.)
+
+## M3 Depth Tracking — disabled, using manual range
+
+2026-04-27 — M3 software's **Depth Tracking** (auto range adjust
+based on observed depth) was misbehaving in today's pier-and-near-
+pier conditions, so user disabled it. Operating with manual range
+setting for the shakedown survey.
+
+Likely causes worth investigating later: shallow-water multi-path,
+pier reflections in the side beams, or just an over-aggressive
+algorithm in this depth regime. Not blocking today.
+
+**Class-prep follow-up**: document the recommended manual-range
+range for typical class operating depths so students don't fight
+this. Either fix the auto-tracker or lean into manual operation
+as the documented default.
+
+## M3 range bumped — 20 m → 30 m
+
+2026-04-27 — User bumped M3 manual range from **20 m to 30 m**
+mid-survey. Likely moved into deeper water (channel side?) and
+needed more range to keep bottom in the swath. Worth noting in the
+bag for later correlation if any line shows clipped/missing bottom
+at the line beginning before the change took effect.
+
+## Traffic — fishing boat docking at our pier (LOS + WiFi blocker)
+
+2026-04-27 — Fishing boat is docking at the same pier we operate
+from, **partially blocking line-of-sight and WiFi signal** to
+BizzyBoat in the survey area.
+
+Operational implications:
+- Visual contact with the boat degraded
+- WiFi signal degraded — may worsen the udp_bridge wedge pattern
+  seen 3× already today, since back-pressure from missed packets
+  is the suspected trigger
+- Survey-side data acquisition unaffected (everything writes
+  locally on gabby/mercat)
+
+Worth noting as a class-day risk: pier-blocking traffic can
+silently degrade operator-side comms even though the boat is fine.
+
+## Survey 1 ended → transit to cod rock survey
+
+2026-04-27 — First survey ended. Line-completion status uncertain
+on the operator side because of the udp_bridge wedges and CAMP
+freezes; gabby's bag will have the authoritative record of what
+got run. Worth a post-deployment check to count actual lines
+completed vs. planned.
+
+Now transiting to **cod rock** (the patch-test feature for the
+June 2026 hydrography class per `project_bizzyboat_sonar_architecture.md`)
+to start a second survey. This is high-value test data — cod rock
+is the pingable feature students will use for their patch test.
+
+## Survey 2 started — cod rock
+
+2026-04-27 — Second survey started over cod rock. Same pipeline as
+survey 1: SBG → QINSy, M3 → QINSy via UDP, AML SVS → mercat bridge
+→ M3, etc.
+
+## Cod rock — range reduced 30 m → 20 m, top not visible at 30
+
+2026-04-27 — At 30 m range over cod rock, the M3 was **not seeing
+the top of the rock** in the sonar display. Reduced range to 20 m
+to bring the rock peak into the swath properly. User took a phone
+photo of the display for reference (not yet committed; worth
+attaching to the deployment issue or this log when convenient).
+
+Possible causes worth investigating later:
+- Beam footprint at longer range — M3 across-track beams may have
+  enough swath that the very-near-bottom returns from a sharp
+  feature get integrated/attenuated
+- Range gain / TVG settings at 30 m vs 20 m
+- Detection algorithm threshold at the longer range
+
+For class prep, this is an important data point: students working
+cod rock will benefit from a documented "start at X m range" rec
+based on water depth at the feature. Add to class-prep notes.
+
+## Off cod rock — 20 m barely reaches bottom
+
+2026-04-27 — Once off the rock into surrounding deeper water, 20 m
+range is barely reaching the bottom. Inverse of the rock-top
+issue.
+
+This is exactly the dynamic-range problem **Depth Tracking** is
+meant to solve automatically — but it's misbehaving in this
+environment so we're working manually. Cod rock + surrounding
+basin appears to be a particularly nasty test case for it
+(steep relief). Worth documenting for class prep that students
+working cod rock should expect to manually toggle range across
+the feature, OR that fixing Depth Tracking is a class-prep
+priority. Add to follow-ups.
+
+## Survey 2 done — adjusting default speed
+
+2026-04-27 — Cod rock survey complete. User adjusting controller
+default speed.
+
+Two adjustment paths, currently in-session via:
+```
+ros2 param set /controller_server FollowPath.default_speed <m/s>
+```
+Persistent change requires editing
+`seafloor_echoboat_project11/echoboat_project11/config/nav2_params.yaml:64`
+on gabby and restarting `controller_server`.
+
+**Confirmed working at 1.5 m/s** — user set 1.5 via `ros2 param
+set`, issued a goto-near-pier task, boat moved at the new speed.
+First end-to-end verification today that the runtime param tweak
+flows through to actual thruster command.
+
+**Known limitation** (per gabby agent's earlier trace today):
+per-task speed via BT `target_speed` field is broken — value is
+extracted but never published to nav2 `/speed_limit`. Today
+controller default is the only knob.
+
+## Telemetry range test — back-and-forth past cod rock + buoy
+
+2026-04-27 — Sending the boat on a back-and-forth pattern past cod
+rock and the buoy to characterize WiFi/telemetry range.
+
+Useful context: today's udp_bridge wedges (3×) and the
+fishing-boat-blocking-LOS event make this a good day to capture
+real-world degradation. Cross-reference against
+`project_wifi_range.md` (2026-04-21 baseline showing graceful
+degradation well past 300 m).
+
+For class prep: this kind of controlled range test should produce
+a documented "operating envelope" for students — at distance X with
+LOS, expect Y. With LOS blocked (e.g., pier traffic), expect Z.
+
+Bag from this run is the reference data; specific findings to
+fold into `project_wifi_range.md` once analyzed.
+
+## Network monitors not working — teltonika + mikrotik
+
+2026-04-27 — User reports `teltonika_monitor` and `mikrotik_monitor`
+nodes not working. State (silent / errored / not running) TBD —
+asked operator for clarification.
+
+History context:
+- Both nodes built clean today on gabby (per make build report)
+- 2026-04-13 session validated all 4 monitoring nodes publishing
+  diagnostics on salmon — that confirmed they work in principle
+- Possible: not in startup launch file on gabby (pattern matches
+  earlier "nav launch not in startup script" finding from
+  2026-04-08)
+- Or: router credentials/IPs changed since 04-13 testing
+- Or: launched but failing silently (auth or connectivity to
+  router APIs)
+
+Not a blocker for the survey itself — the boat is fine — but
+operator situational awareness loses the network health diagnostic
+that would have been useful during today's udp_bridge wedge events.
+
+(Aside from gabby tmux peek: on-host agent is doing BBR / TCP
+congestion control tuning work, probably exploring whether that
+improves bridge performance. Unrelated to the monitor issue but
+worth knowing in case it changes router-traffic timing.)
+
+## Range-test comms degradation observed
+
+2026-04-27 — During the back-and-forth telemetry range test:
+videos breaking up, CAMP not updating much. Expected outcome of
+the range test — this is the **degradation signature at extended
+distance** (or with intervening obstructions / fishing-boat-LOS).
+
+Worth distinguishing from the earlier udp_bridge wedge events:
+- Wedge events are a software bug (back-pressure deadlock)
+- Range degradation is environmental (RF link)
+
+Both produce similar operator-side symptoms (video broken,
+position stale), but only one is a software defect. Whether
+today's "video breaking up" episodes are wedge-pattern or
+range-pattern can be told apart later by checking gabby's
+publication rates (still healthy = link issue, dropped =
+software issue).
+
+This is exactly the kind of behavioral characterization data
+worth folding into `project_wifi_range.md` once the bag is
+analyzed post-deployment.
+
+## Comms recovered as boat returned closer
+
+2026-04-27 — Things are better now — boat presumably back closer to
+the operator station, link quality restored.
+
+**Diagnostic confirmation**: this episode of degradation **was
+environmental** (range/LOS), not a udp_bridge wedge. Evidence:
+the link recovered automatically when conditions improved, with
+no kill+respawn needed. Wedge events stay wedged until manual
+intervention. Two distinct failure modes today, similar
+symptoms — important to be able to tell apart for class
+operations.
+
+For class prep: an **operator-side "is this a wedge or just
+range?" diagnostic** would be valuable. Could be as simple as a
+status indicator that shows boat-side publication rate (queryable
+via VPN or another low-bandwidth path) — if rate is healthy and
+bridge is silent → wedge. If rate is dropping with bridge → range.
+
+## Boat returning to pier
+
+2026-04-27 — Boat on return leg from the range test. Survey day
+wrapping up; ready to switch into wrap-up mode whenever recovery
+is done.
+
+## Op-side diagnostics gap — class-prep priority
+
+2026-04-27 — Major learning today: we have great visibility into
+boat-side state (gabby publishes diagnostics, mavros battery,
+all the cube_bathymetry and nav stuff) but **operator-side
+diagnostics are essentially missing** during the wedge / range
+events. Recovering the wedges was reactive ("CAMP frozen → kill
+udp_bridge"), not signal-driven.
+
+For the **June class**, students need both sides instrumented
+so they can:
+
+1. **Tell wedge from range degradation in real time** (today
+   required forensics after the fact)
+2. **See operator-router health** (signal strength to boat,
+   Starlink stats, VPN tunnel status) — currently we have these
+   as ROS monitor nodes but they're only running on the boat side
+3. **Have op-side `/diagnostics` recorded to a bag** so wedge
+   events can be debugged post-incident
+
+Concrete actions for class-prep:
+
+- **Run `teltonika_monitor` / `mikrotik_monitor` / `starlink_stats`
+  on salmon too** — pointing at the operator router (192.168.13.1)
+  and operator Starlink. Same nodes, different config. Give the
+  annunciator on salmon visibility into operator-side network.
+- **Add a salmon-side rosbag recorder for `/diagnostics`** during
+  deployments — small footprint, huge debug value.
+- **Update operator launch file** (`operator_core_launch` or
+  similar in `unh_echoboats_project11`) to bring up these monitors
+  automatically.
+
+This pairs with the "network monitors not working" finding from
+earlier — both are part of the same op-side instrumentation gap.
+
+## Telemetry spotty again — but boat is CLOSER (likely 4th wedge)
+
+2026-04-27 — Telemetry getting spotty during the return leg, even
+as the boat is getting closer. **Distance-independent degradation
+points to another udp_bridge wedge**, not range/LOS.
+
+If correct, that's now the **4th wedge today** under sustained
+operation — strongly reinforcing the engineering follow-up
+against `rolker/udp_bridge` for the back-pressure / deadlock bug.
+
+This event also crisply illustrates the diagnostic gap discussed
+above: without op-side `/diagnostics` recording, we can't
+definitively tell wedge from RF degradation in real time. Today
+we infer "wedge" from the geometry (closer ≠ better), but a
+quantitative diagnostic stream would settle it instantly.
+
+Other less-likely possibilities to keep in mind:
+- Operator router/WiFi issue independent of the boat
+- Antenna pattern null at this approach angle
+- CPU pressure on operator from CAMP rendering accumulated buffer
+  after a prior recovery
+
+Recovery same as before: kill operator-side udp_bridge PID,
+operator_core_launch respawns.
+
+## Boat recovered — survey day complete
+
+2026-04-27 — Boat out of the water, recovered. End of operational
+day. Wrap-up sequence ready to start whenever:
+
+1. Field logs from gabby (and salmon, mercat as applicable) push
+   to gitcloud
+2. Dev side runs `make sync` to pull them into the worktree branch
+3. Bag pull from gabby via `~/.local/bin/pull_bizzy_logs.sh`
+4. Audit dev log + queued follow-ups → open task issues for the
+   bounded ones
+5. Update `docs/roadmap.md` for anything deferred
+6. Commit + push the dev log to `feature/issue-94`
+7. Mark PR #95 ready for review, merge → auto-closes #94
+
+## QINSy survey data — location + session inventory
+
+2026-04-27 — AML bridge stopped cleanly at **154,762 sentences**
+processed (full day's runtime).
+
+**Project path on mercat**:
+`C:\Users\admin\QPS-Data\Projects\2026SpringShakedown\`
+
+**Recordings subdir**: `\DtmData\` — `.qpd` files.
+
+Today's recording sessions (UTC, mercat is on UTC):
+
+| UTC start | EDT  | Files | Notes |
+|-----------|------|-------|-------|
+| 21:52:03  | 17:52| 4     | Survey 1 |
+| 22:27:54  | 18:27| 2     | (between surveys) |
+| 22:45:37  | 18:45| 1     | |
+| 22:51:20  | 18:51| 2     | Cod rock survey |
+| 23:02:50  | 19:02| 3     | Range test / return |
+
+Multi-segment recordings are QINSy splitting on size/time limits;
+all `<timestamp> - Noname - NNNN.qpd` files for a given start
+timestamp belong to the same session. "Noname" because nobody
+named the recordings — could improve UX for class operations.
+
+Pull plan: rsync from mercat to dev archive, OR copy via RDP/USB
+since mercat is Windows. Path syntax for mercat OpenSSH is
+`\Users\admin\QPS-Data\Projects\2026SpringShakedown\`.
+
+## Network — new connections failing, existing SSH OK
+
+2026-04-27 — User reports inability to reach mercat or gabby with
+**new** connections over WiFi, but the **existing** SSH/tmux
+session to mercat is still alive. Established vs. new asymmetry
+points to DNS, ARP, AP association, or firewall/route change —
+not a host outage.
+
+**Operational impact**:
+- Existing tmux SSH session is the lifeline — preserve it
+- The new `pull_qps_data.sh` rsync needs a fresh SSH connection,
+  so will fail until new connections work
+- If user needs to make any other changes on mercat/gabby in the
+  near term, they're constrained to whatever they can do through
+  the existing session(s)
+
+Suggested triage (when convenient): try ping by hostname vs IP to
+isolate DNS, toggle local WiFi to refresh association, check
+operator router state if accessible.
+
+This is yet another argument for op-side `/diagnostics` recording
+— a salmon-side log of network monitor outputs would tell us
+exactly when this started.
+
+## Op-router forwarding asymmetry (deep dive)
+
+2026-04-27 — Network diag from op-router tmux session:
+
+- Op router (Teltonika RUTX11, 192.168.13.1) reaches boat router
+  (172.16.20.1) at 1.3 ms — bridge L3 link is up
+- Op router → mercat (192.168.20.8): **works** (2 ms)
+- Op router → gabby (192.168.20.5): **fails** (100% loss) — likely
+  stale ARP / MAC on boat router for gabby
+- Op router pinging mercat sourced as 192.168.13.1 (deadpool's
+  gateway IP): **works** (proves boat-side return path for
+  192.168.13.x exists)
+- Yet deadpool → mercat fails
+
+Concluded: forwarding asymmetry on the op router for actual
+deadpool-sourced traffic — possibly a connection-tracking, NAT,
+or zone-firewall state that drifted during today's load. Not the
+WiFi bridge link itself.
+
+Op router wireless state: `wlan1-2 "UNH Pier"` client mode,
+signal -80 dBm / quality 30/70 (degraded but up — the pier-traffic
+blocking earlier may have contributed to whatever stuck-state
+developed).
+
+Recovery options ranked: (1) reboot op router — brief outage,
+high success; (2) restart WiFi-bridge interface only — less
+disruptive; (3) use ZeroTier hostnames for new connections as
+workaround.
+
+Follow-up: op-router→gabby unreachable while op-router→mercat
+works = boat-side ARP/MAC anomaly. Worth a quick `ip neigh flush`
+on the boat router when convenient.
+
+## gabby DNS — fixed
+
+2026-04-27 — `systemd-resolved` on gabby was wedged (local stub at
+127.0.0.53 timing out, but direct DNS to 8.8.8.8 worked). Fix:
+`sudo systemctl restart systemd-resolved`. Working now. Why it
+wedged in the first place is a separate question for later
+(`journalctl -u systemd-resolved` would have the story if needed).
+
+## Network full-power-cycle recovery
+
+2026-04-27 — After exhausting in-place fixes (firewall restart,
+op router reboot — neither fixed the new-connection forwarding
+asymmetry), user **power-cycled both the operator-side stack
+(op router + MikroTik bridge dish) AND the boat** (gabby, boat
+router, presumably mercat and other boat-side hosts).
+
+This is the full reset; all tmux SSH sessions through
+op/bridge/boat are dead now. Waiting on all gear to come back
+(~1–4 min depending on slowest device, Windows mercat usually
+last).
+
+Wrap-up implication: today's deployment was operationally
+successful for survey data acquisition, but ended with a deep
+operator-side network pathology that we documented but didn't
+root-cause. Strong follow-up issue for class prep — the same
+failure mode under sustained load would be very disruptive in a
+class context.
+
+## Recovery: many cycles, root cause indeterminate
+
+2026-04-27 — Network finally recovered after many power cycles
+across multiple devices. **Root cause not isolated.**
+
+Sequence over the course of the troubleshooting:
+- Op router firewall restart (briefly worse, then back to similar
+  broken state)
+- Op router reboot (no fix)
+- Operator-side MikroTik bridge power cycle (twice earlier in the
+  day, no fix)
+- Op router + MikroTik + boat-side power cycle (no immediate fix)
+- Another operator-side MikroTik power cycle — at this point
+  things came back
+
+Honest interpretation: many cycles across multiple devices may
+have collectively cleared accumulated state on more than one
+device; the order isn't conclusive. "Last action before recovery"
+isn't proof it caused the recovery. Could have been:
+- MikroTik state finally clearing on the second/Nth cycle
+- Op router needing the bridge to come up cleanly first
+- Some interaction with boat-side state from the boat power cycle
+- Or a coincident environmental change (RF conditions improving)
+
+What we DO know with confidence:
+- Existing established TCP flows survived throughout (gabby and
+  mercat tmux SSH stayed alive all day) — points to L2/forwarding
+  state pathology rather than total link failure
+- The op router firewall RULES were structurally correct (we
+  walked the chains)
+- Reproduction of "deadpool → mercat ICMP arrives at mercat per
+  tcpdump on br-lan, but no reply visible" — there's a real
+  forward-vs-reply path asymmetry, but we couldn't isolate which
+  device caused it
+
+**Lesson learned**: when an established connection works but new
+connections to the same destination fail, the failure could be on
+any device along the path that affects new-flow handling
+differently from established. Diagnostic priority should include
+the bridge L2 devices (MikroTiks here) early, not just the
+visible-config routers.
+
+**Class-prep follow-ups**:
+- Document this failure mode + the multi-device-power-cycle
+  recovery procedure for class operator notes (since we don't
+  know which single action fixes it, the procedure is "cycle
+  things until it works")
+- Investigate MikroTik (and op router) stability under sustained
+  load / extended uptime — this happened after a long day with
+  udp_bridge wedges, range test load, and physical pier blocking
+- Consider remote management / monitoring of the MikroTik bridge
+  devices so we can see their state without physical access
+- Op-side `/diagnostics` recording (already on the to-do) would
+  have helped a lot here too
+
+## Wrap-up to-do (queued)
+
+- **Land `aml_bridge.ps1` in repo** — user agreed to a focused PR
+  against `unh_echoboats_project11` placing the script at
+  `bizzyboat_project11/scripts/aml_bridge.ps1` along with a README
+  documenting the M3 UDP Valeport configuration. Open as part of
+  end-of-day wrap-up. Currently script lives only on mercat at
+  `C:\Users\admin\aml_bridge.ps1`.
+- **Install-log amendments** (Menu Widget Export Data step, SBG
+  Misc Delayed Heave skip note, ROS-vs-QINSy coordinate convention
+  call-out) — bundle as a single docs PR or a series, depending on
+  what feels right at wrap-up.
+- **Remove Misc Delayed Heave slot from QINSy DbSetup** for this
+  vessel (Ellipse-D doesn't support it).
+
 ## Deferred / unaddressed
 
 - 4 additional Copilot comments on PR #93 (workspace-tooling references

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -94,6 +94,42 @@ re-sync and re-read `docs/logs/README.md`):
 User asked me to stay in observer mode (no commands into the field
 tmuxes); will re-check on cue.
 
+## Conditions — 2026-04-27, Newcastle NH
+
+2026-04-27T10:05-04:00 — Pulled tide / weather / marine forecast.
+
+**Tides** (Fort Point NOAA #8423898, EDT, ft above MLLW):
+
+| Time | Type | Height |
+|---|---|---|
+| 02:35 | low | 0.77 |
+| 08:55 | HIGH | 8.84 |
+| 15:04 | low | 0.45 |
+| 21:26 | HIGH | 8.98 |
+
+Range ~8.5 ft. The 15:04 low is unusually shallow but **not a draft
+constraint at the Judd Gregg pier** (user-confirmed; see memory
+`project_judd_gregg_pier_no_draft.md`).
+
+**Weather** (NWS point forecast, 43.07°N / 70.72°W):
+
+- Today: sunny, high 59°F, **E ~5 mph**, no precip
+- Tonight: clear, low 38°F, calm
+- Current 09:55 EDT: 60°F, NE 6 mph, 10 mi vis, fair
+
+**Marine** (NWS zone ANZ154 — Cape Elizabeth ME → Merrimack River
+MA, 25 NM offshore):
+
+- Today: NE ~5 kt shifting E late, seas ≤ 1 ft
+- Tonight: E 5–10 kt, seas 2–3 ft (SE 2 ft @ 7 s)
+- No advisories.
+
+**Operationally**: about as clean as it gets for sonar testing,
+calibration runs, anything that needs flat-water data. Wind stays
+≤ 10 kt all day and tonight; no whitecaps. Best operational windows
+align with the daylight high (07:00–10:30 EDT) and the evening high
+(19:30–22:00); the afternoon low has no impact on pier ops.
+
 ## Deferred / unaddressed
 
 - 4 additional Copilot comments on PR #93 (workspace-tooling references

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -996,3 +996,24 @@ visible-config routers.
   `feature/issue-92` are now merged-and-stale on the remote.
   `feature/issue-57` stays alive per the iterative-PR pattern even
   though #57 itself is now closed.
+
+---
+
+# 2026-04-28 — Post-deployment data review
+
+## QPS data — copy + Qimera upgrade
+
+- QPS project files from yesterday's surveys copied from mercat to
+  the dev workstation after recovery.
+- Existing Qimera install on dev couldn't open the projects — newer
+  QPS project format. Upgraded Qimera to **2.8.3** to load them.
+
+## Initial surface review
+
+- Data is present — surveys captured what was expected.
+- An initial surface generated in Qimera shows the data needs **lots
+  of cleaning**.
+- Takeaway: focus shouldn't only be on post-processing cleanup —
+  we need to better understand how to acquire **cleaner data at
+  capture time**. Acquisition-side investigation is the higher-leverage
+  follow-up.

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -38,6 +38,62 @@ via `.agent/scripts/push_remote.py --remote gitcloud`. Boat-side
 `rolker/unh_echoboats_project11` (color `#1d76db`) and opened
 deployment issue [#94](https://github.com/rolker/unh_echoboats_project11/issues/94).
 
+## Sync bug + PR #26 merge
+
+2026-04-27T09:35-04:00 — User reported `make sync` on gabby and
+salmon picked up no new code. Root-caused: `push_remote.py` doesn't
+pull from origin first, so the 09:05 gitcloud push pushed our **local
+state** (`bdc4a1a`, yesterday) — github had already moved to
+`6da895d` after my morning merges, but local wasn't pulled. Push
+reported "ok: pushed" because the no-op fast-forward succeeded.
+
+Fix sequence executed:
+
+2026-04-27T09:42-04:00 — User asked to merge `rqt_operator_tools`
+PR #26 (the staleness-border `header.stamp` fix, originally held open
+to batch with #27/#28; manually closed by user at 12:28 UTC today).
+Reopened, applied 2 Copilot review fixes on its branch:
+- `camera_pane_widget.cpp`: `update_label()` 1 Hz throttle now
+  requires `since_update >= 0.0` so a backwards clock jump forces a
+  refresh instead of freezing the label.
+- `staleness_tracker.cpp`: comment about "negative age triggers
+  Error" reworded to clarify it's negative *worst-of-both* age
+  (header-ahead-of-now alone is masked by `max(arr_age, hdr_age)`).
+Local `colcon build --packages-select rqt_camera_grid` clean.
+Merged via `gh pr merge 26 --merge`; #25 auto-closed.
+
+2026-04-27T09:46-04:00 — `make sync` on dev (workspace-wide pull
+from origin), then `push_remote.py --remote gitcloud`. Verified
+post-push state: gitcloud `unh_echoboats_project11/jazzy` =
+`6da895d` (matches origin), gitcloud `rqt_operator_tools/jazzy` =
+`9e08f49` (the new merge of #26). gabby/salmon `make sync` will now
+pick up the convention spec, roadmap, and staleness fix.
+
+## Field-side state observed (read-only via tmux)
+
+2026-04-27T09:55-04:00 — Captured `tmux capture-pane` on the `gabby`
+and `salmon` sessions to see what their on-host agents are doing.
+Both built cleanly this morning and ran `make sync` — but **both
+syncs predated the 09:46 gitcloud push**, so neither host actually
+has the new convention spec, roadmap, or staleness fix yet. Need a
+re-sync on each before they can use the convention or test the fix.
+
+Header conventions noted (will be reconciled when field agents
+re-sync and re-read `docs/logs/README.md`):
+
+- gabby agent: header matches convention (`# BizzyBoat deployment
+  log — gabby — 2026-04-27`); `**Deployment**: #TBD` is stale, will
+  be `#94` after re-sync.
+- salmon agent: header is `# Field log — salmon — 2026-04-27` —
+  doesn't match the spec's `# <Platform> deployment log — <label> —
+  <YYYY-MM-DD>` pattern; missing `**Deployment**:` line entirely.
+  Salmon's `make sync` was 08:57 EDT, before PR #93 merged at 09:12,
+  so the agent invented a header style without the spec to read.
+  Will be reconciled after re-sync.
+
+User asked me to stay in observer mode (no commands into the field
+tmuxes); will re-check on cue.
+
 ## Deferred / unaddressed
 
 - 4 additional Copilot comments on PR #93 (workspace-tooling references

--- a/docs/logs/2026/2026-04-27_dev_logs.md
+++ b/docs/logs/2026/2026-04-27_dev_logs.md
@@ -26,9 +26,11 @@ gitcloud at end of session.
   agent-memory references with in-repo equivalents, expanded
   L43↔L44 caveat to name plan-line IDs); skipped 2 false-positive
   table-pipe comments (verified single-pipe with grep)
-- PR #93 merged (per-deployment logs convention) — also auto-closed
-  the long-running umbrella #57 via "closes out" keyword in body;
-  posted a carry-forward table in [a comment on #57](https://github.com/rolker/unh_echoboats_project11/issues/57#issuecomment-4327249594)
+- PR #93 merged (per-deployment logs convention) — also closed the
+  long-running umbrella #57 as part of the same flow (the merge body's
+  wording wasn't a recognized GitHub auto-close keyword, so the close
+  was effectively manual); posted a carry-forward table in
+  [a comment on #57](https://github.com/rolker/unh_echoboats_project11/issues/57#issuecomment-4327249594)
 
 2026-04-27T09:05-04:00 — Pushed all 32 workspace repos to gitcloud
 via `.agent/scripts/push_remote.py --remote gitcloud`. Boat-side
@@ -43,7 +45,7 @@ deployment issue [#94](https://github.com/rolker/unh_echoboats_project11/issues/
 2026-04-27T09:35-04:00 — User reported `make sync` on gabby and
 salmon picked up no new code. Root-caused: `push_remote.py` doesn't
 pull from origin first, so the 09:05 gitcloud push pushed our **local
-state** (`bdc4a1a`, yesterday) — github had already moved to
+state** (`bdc4a1a`, yesterday) — GitHub had already moved to
 `6da895d` after my morning merges, but local wasn't pulled. Push
 reported "ok: pushed" because the no-op fast-forward succeeded.
 
@@ -108,8 +110,7 @@ tmuxes); will re-check on cue.
 | 21:26 | HIGH | 8.98 |
 
 Range ~8.5 ft. The 15:04 low is unusually shallow but **not a draft
-constraint at the Judd Gregg pier** (user-confirmed; see memory
-`project_judd_gregg_pier_no_draft.md`).
+constraint at the Judd Gregg pier** (user-confirmed context).
 
 **Weather** (NWS point forecast, 43.07°N / 70.72°W):
 
@@ -988,6 +989,9 @@ visible-config routers.
 
 ## Deferred / unaddressed
 
+2026-04-28T17:55-04:00 — wrap-up audit before merge. Items below were
+surfaced during the day but intentionally not chased in this PR.
+
 - 4 additional Copilot comments on PR #93 (workspace-tooling references
   in Examples + Future automation sections, plus a stylistic note on
   the `bizzyboat_deployment_log.md` freeze header) — non-blocking,
@@ -999,7 +1003,7 @@ visible-config routers.
 
 ---
 
-# 2026-04-28 — Post-deployment data review
+## 2026-04-28 — Post-deployment data review
 
 ## QPS data — copy + Qimera upgrade
 

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -82,3 +82,31 @@ to ~256×256 RGB8 — `sea_surface_segmentation.cpp:38` calls
 estimate at 256×256 RGB8 × 5 Hz × 4 cams ≈ 4 MB/s, ≈ 480 MB for the
 default 120 s capture. Should be fine, but **measure on first run**
 before relying on this in the field.
+
+## 3. Pre-launch system bring-up
+
+2026-04-27T10:34-04:00 — operator ran
+`~/start_tmux_project11.bash` (symlink to the project11 install-tree
+copy). `tmux ls` shows the `project11` session (4 windows) up.
+`ros2 node list` shows the full nav2 stack
+(`/bizzy/local_costmap/local_costmap`,
+`/bizzy/global_costmap/global_costmap`, `behavior_server`,
+`controller_server`, etc.), all four OAK cameras
+(`/bizzy/sensors/cameras/oak_{forward,starboard,aft,port}`), MAVROS,
+`deltat` + `cube_bathymetry`, and `sonar_logger`.
+
+### Recorder fix: `/robot_description` is namespaced
+
+Verified topic publication while the system was up; caught a typo in
+my own commit `cc7e7fe`. The recorder edit added bare
+`/robot_description`, but on this system the URDF is published as
+`/bizzy/robot_description` — under the `bizzy` namespace, like every
+other platform-side topic. (Cross-system topics `/diagnostics`, `/tf`,
+`/tf_static` are correctly un-namespaced and the script already had
+those right.)
+
+Fixed in the script — entry now reads `/bizzy/robot_description`.
+Lesson noted for future bag-recorder edits: **verify topic names
+against a live system before trusting documentation or assumed
+conventions** rather than just the namespacing pattern of nearby
+entries.

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -1,0 +1,25 @@
+# BizzyBoat deployment log — gabby — 2026-04-27
+
+**Host**: gabby
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
+**Mode**: field (gitcloud origin)
+**Deployment**: #TBD (dev-side issue not yet opened)
+
+## Scope
+
+Integrate sonar software and test on the water.
+
+## Summary
+
+_To be filled in at end of session._
+
+## 1. Session start
+
+2026-04-27T10:02-04:00 — `make sync` + `make build` clean on gabby. Sync
+pulled in the new `docs/logs/README.md` deployment-logging convention
+(7 files, +1273 lines on `unh_echoboats_project11`). Build report: 5
+layers, 45 packages, all green.
+
+2026-04-27T10:02-04:00 — system timezone was `Etc/UTC`; set to
+`America/New_York` (`timedatectl set-timezone America/New_York`). Local
+time now reads `EDT (-0400)` so log timestamps match the on-site clock.

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -23,3 +23,62 @@ layers, 45 packages, all green.
 2026-04-27T10:02-04:00 — system timezone was `Etc/UTC`; set to
 `America/New_York` (`timedatectl set-timezone America/New_York`). Local
 time now reads `EDT (-0400)` so log timestamps match the on-site clock.
+
+## 2. Camera-recorder coverage for SeaSurfaceLayer replay-debug
+
+2026-04-27T10:18-04:00 — audited
+`bizzyboat_project11/scripts/record_camera_topics.sh` against what the
+nav2 costmap plugin
+`sea_surface_layer::SeaSurfaceLayer` (in
+`unh_marine_perception/sea_surface_segmentation/src/sea_surface_layer.cpp`)
+actually consumes. Found one critical gap.
+
+Plugin subscriptions (`sea_surface_layer.cpp:38-48`):
+
+- `segmentation_topic` as **raw `sensor_msgs::msg::Image`** (default
+  `segmentation`) — NOT `CompressedImage`
+- `camera_info_topic` as `sensor_msgs::msg::CameraInfo` (default
+  `camera_info`)
+- TF lookup at `sea_surface_layer.cpp:141`:
+  `segments_msg->header.frame_id` → costmap global frame, 1 s timeout
+
+Pre-edit, the recorder captured `/segmentation/compressed` (×4) +
+`/segmentation/camera_info` (×4) but **not** the raw `/segmentation`
+Image topic that the plugin subscribes to. Replaying that bag against
+the plugin would never trigger the callback unless an image-transport
+republisher were chained in.
+
+The bizzyboat persistent-logger config
+(`bizzyboat_project11/config/bizzyboat.yaml:78,82,86,90,116,120,124,128`)
+already lists `oak_segmentation_<dir>_raw` →
+`sensors/cameras/oak_<dir>/segmentation` with `period: -1.0`, so the
+system is aware of those raw topics and explicitly opts out of
+always-on logging — confirming the topics exist and just need to be
+added to the ad-hoc recorder.
+
+### Edit
+
+Added to `record_camera_topics.sh`:
+
+- 4× `/bizzy/sensors/cameras/oak_<dir>/segmentation` (raw Image —
+  what the plugin subscribes to)
+- `/robot_description` (latched URDF — lets RViz render the boat
+  from the bag with no live system)
+
+Kept everything that was there: `/tf`, `/tf_static`, `/diagnostics`,
+the H.265 `image_raw/ffmpeg` streams (visual context for humans),
+the segmentation compressed variants and segmentation camera_info,
+plus the raw-camera `camera_info` (not used by SeaSurfaceLayer but
+useful if other downstream consumers ever need it).
+
+Header comment was tightened to state that the resulting bag is
+sufficient to replay-debug SeaSurfaceLayer offline.
+
+### Disk-space note (TODO)
+
+Raw segmentation Images are small (DepthAI NN output, likely ~128×96
+to ~256×256 RGB8 — `sea_surface_segmentation.cpp:38` calls
+`calibrationToCameraInfo(..., 128, 96)`). Worst-case order-of-magnitude
+estimate at 256×256 RGB8 × 5 Hz × 4 cams ≈ 4 MB/s, ≈ 480 MB for the
+default 120 s capture. Should be fine, but **measure on first run**
+before relying on this in the field.

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -110,3 +110,23 @@ Lesson noted for future bag-recorder edits: **verify topic names
 against a live system before trusting documentation or assumed
 conventions** rather than just the namespacing pattern of nearby
 entries.
+
+### Inventory correction: DeltaT is not live
+
+Operator clarified that the section-3 inventory misrepresented the
+sonar state. The **DeltaT (Imagenex 837) sensor is physically removed
+from BizzyBoat.** The `/bizzy/sensors/deltat/deltat` node, the
+`cube_bathymetry` node, and the `sonar_logger` shown in
+`ros2 node list` are leftover lifecycle/launch scaffolding plus
+udp_bridge listeners waiting on UDP packets that no longer arrive.
+Verified post-hoc with `ros2 topic hz`:
+
+- `/bizzy/sensors/deltat/soundings` — no messages in 2 s
+- `/bizzy/sensors/deltat/cube_bathymetry` — no messages in 2 s
+
+Lesson: **a node appearing in `ros2 node list` does not mean its
+underlying sensor is live.** Always confirm with `ros2 topic hz`
+on a known output topic before treating a node as a live data
+source. Same caveat for any udp_bridge-fronted sensor on this
+platform — the ROS-side topic exists whether or not bytes are
+flowing across the bridge.

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -11,7 +11,34 @@ Integrate sonar software and test on the water.
 
 ## Summary
 
-_To be filled in at end of session._
+Sonar-software integration day in name; sonar work itself ran on
+mercat, so the gabby side was logger + ROS-side support. Closed three
+worthwhile things along the way:
+
+1. **Camera→costmap TF gap fixed** — `sea_surface_segmentation` now
+   takes a `frame_ids` parameter (default-empty for back-compat) and
+   the BizzyBoat launch passes `bizzy/<name>_optical` to match the
+   URDF. SeaSurfaceLayer's TF lookup would now resolve in the live
+   system; still gated upstream on `unh_marine_perception#6/#7`.
+2. **Camera-recorder coverage** — `record_camera_topics.sh` now
+   captures the raw `/segmentation` Image streams (×4) plus the
+   namespaced `/bizzy/robot_description`, so a bag from this script
+   is sufficient on its own to replay-debug the costmap plugin.
+3. **Survey-speed audit + interim bump** — traced the
+   per-survey-speed pipeline end-to-end and identified the BT →
+   FollowPath gap that prevents per-survey speed today. Bumped the
+   shared `default_speed` 0.75 → 1.5 m/s as a deployment-blocking
+   tactical move; verified at ~3 kn underway.
+
+Plus: full prelaunch sweep clean, system timezone set to EDT,
+DeltaT-removed memory captured, and BBR + larger TCP buffers
+applied to gabby's host-level sysctls for Starlink performance.
+
+Three captures during transit (~2 min each) and two long captures
+(60 min, 36 min) — all clean. Disk after session: ~25 GiB used /
+1.8 TiB free.
+
+Carry-forward and follow-up issues are listed in §10.
 
 ## 1. Session start
 
@@ -197,3 +224,319 @@ publisher needs to publish the camera frames before the plugin can
 function.
 
 Not blocking launch.
+
+## 5. OAK segmentation frame_id fix
+
+2026-04-27T11:05-04:00 — closed the TF gap from §4. The publisher
+hardcoded its frame_id at
+`unh_marine_perception/sea_surface_segmentation/src/sea_surface_segmentation.cpp:35`:
+
+```cpp
+frame_id_ = name_ + "_optical_frame";
+```
+
+…producing `oak_forward_optical_frame` etc. The URDF
+(`bizzyboat_project11/urdf/sensors/camera_oak.xacro:25`) publishes the
+optical link as `bizzy/<name>_optical`. Two divergences in one line:
+missing `bizzy/` namespace + extra `_frame` suffix.
+
+### Fix path
+
+Did the architecturally-clean fix rather than hardcoding the BizzyBoat
+naming into the generic perception package:
+
+1. **`unh_marine_perception` —** added a new optional node parameter
+   `frame_ids` (array, position-matched to `camera_names`). When
+   empty (or shorter than `camera_names`), the camera falls back to
+   the historical `<name>_optical_frame` default → fully back-compat.
+   Per-camera init log line now reports the chosen frame_id so
+   misconfiguration is visible at boot. Commit on
+   `unh_marine_perception/jazzy`.
+2. **`unh_echoboats_project11` —** set
+   `'frame_ids': [f'bizzy/{name}_optical']` per camera in
+   `bizzyboat_project11/launch/oak_cameras_launch.py`. This pins the
+   BizzyBoat naming where it belongs (the platform launch). Commit
+   on `unh_echoboats_project11/jazzy`.
+
+Both edits done in field mode — they'll reconcile to GitHub via
+`/import-field-changes` on the dev side.
+
+### Verification (post stack-restart)
+
+- `frame_id` on `/bizzy/sensors/cameras/oak_forward/segmentation` →
+  `bizzy/oak_forward_optical` ✅
+- Same on `…/segmentation/camera_info` ✅
+- `tf2_echo bizzy/odom bizzy/oak_forward_optical` → resolves, e.g.
+  `Translation [0.348, -0.096, -19.674]`
+- `tf2_echo bizzy/base_link bizzy/oak_forward_optical` → resolves to
+  the URDF static `[0.310, 0.000, 1.410]` with the optical-convention
+  rotation `[-π/2, 0, -π/2]` applied
+- All 4 OAK segmentation streams still ~5.0 Hz — no regression
+
+### Standing caveats
+
+The matchSize() segfault (`unh_marine_perception#6`) is still the
+blocker for the costmap plugin itself; this fix only closes the TF
+gap that would have blocked it after #6 is resolved. Upstream of #6
+this is dead code until the plugin can run.
+
+## 6. On-water
+
+2026-04-27T11:13-04:00 — operator deployed BizzyBoat. Boat is in
+the water.
+
+Open thread paused: USB serial check (asked at 11:09) — no new
+device enumerated when checked; deferred until it's relevant again.
+
+## 7. First on-water bag with the updated recorder
+
+2026-04-27T11:25-04:00 — operator triggered a 120 s capture with
+`record_camera_topics.sh 120`. First real exercise of the recorder
+edits from §2 + §5 (raw `/segmentation` × 4 with the corrected
+`bizzy/<name>_optical` frame_ids, plus `/bizzy/robot_description`).
+
+Output: `~/data/logs/bizzy_images/bag_2026-04-27T14.25.31_ffmpeg_seg/`
+
+| Metric | Value |
+|---|---|
+| Bag size | **91.6 MiB** (~46 MB/min) |
+| Duration | 119.57 s |
+| Total messages | 14,519 |
+| Per-camera × per-stream | 598 msgs (= 5.00 Hz × 119.57 s) |
+| `/bizzy/robot_description` | 1 (latched) |
+| `/tf_static` | 2 |
+| `/tf` | 3,634 (~30 Hz) |
+| `/diagnostics` | 1,314 (~11 Hz aggregate across publishers) |
+
+Every topic the §2 audit identified is in the bag. Per-stream
+counts are identical (598) on all 4 cameras × 4 stream types — no
+drops. The latched `/bizzy/robot_description` recorded exactly 1
+message, as expected for a latched/transient-local publisher
+captured on subscription.
+
+### Closing the §2 disk-space TODO
+
+§2's worst-case estimate was 480 MB for 120 s (assumed 256×256 RGB8).
+**Reality: ~92 MB** — segmentation images are actually 128×96 RGB8
+(36 KB/frame), and mcap+zstd_fast packs the rest tight. Headroom is
+plenty for routine on-water captures; a multi-bag long campaign on
+a 1 TB disk would still want some thought, but for ad-hoc 2-min
+captures this is comfortably cheap.
+
+§2's TODO is **closed**: ~46 MB/min is the realistic figure to plan
+around for this recorder.
+
+### Second capture
+
+2026-04-27T11:04-04:00 (UTC start 15:02:15) — second 120 s capture
+at operator request.
+
+- `~/data/logs/bizzy_images/bag_2026-04-27T15.02.15_ffmpeg_seg/`
+- 85.3 MiB / 119.57 s / 14,579 messages
+- Slightly smaller than the first capture (91.6 → 85.3 MiB), same
+  per-camera coverage
+
+### Third capture
+
+2026-04-27T11:21-04:00 (UTC start 15:21:26).
+
+- `~/data/logs/bizzy_images/bag_2026-04-27T15.21.26_ffmpeg_seg/`
+- 82.6 MiB / 119.57 s / 14,542 messages
+- Trend: 91.6 → 85.3 → 82.6 MiB across the three captures (likely
+  scene-content-driven compression efficiency, not a recorder issue)
+
+## 8. Survey-speed pipeline audit + default bump 0.75 → 1.5 m/s
+
+Operator asked whether they could specify a per-survey speed today.
+Traced the chain end-to-end:
+
+| Layer | State |
+|---|---|
+| `marine_nav_interfaces/msg/TaskInformation.msg:26-29` | YAML `data` field documented to carry a `speed` member ✅ |
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml:384-387` | BT extracts `target_speed` via `GetTaskDataDouble` ✅ |
+| `run_tasks.xml` FollowPath call | **Gap** — `target_speed` is read but never passed downstream ❌ |
+| nav2 `/speed_limit` topic | Not published from anywhere on this stack ❌ |
+| `marine_nav_crabbing_path_follower::CrabbingPathFollower::setSpeedLimit()` (`crabbing_path_follower.cpp:74`) | Implemented — but `setSpeedLimit()` can only **decrease** below `desired_speed_` (line 113-120: `target_speed = min(desired_speed_, …)`) |
+| `desired_speed_` source | `default_speed` YAML param, read **once at init** at `crabbing_path_follower.cpp:35-36` |
+
+**Bottom line:** to raise speed beyond the YAML default, the BT→FollowPath
+gap needs closing (smallest fix: a small custom BT action node that
+publishes `nav2_msgs/SpeedLimit` to `/speed_limit` from the extracted
+`target_speed`). Worth a follow-up issue under
+`unh_marine_navigation` after wrap-up, not deployment-blocking.
+
+### Default bump
+
+For today, raised the floor instead. Edited
+`seafloor_echoboat_project11/echoboat_project11/config/nav2_params.yaml:64`:
+`default_speed: 0.75 → 1.5` (m/s).
+
+Important context: that YAML is **shared between BizzyBoat and the
+seafloor echoboat**. BizzyBoat's `bizzyboat_project11/launch/nav_launch.py`
+includes `echoboat_project11`'s `nav2_bringup_launch.py` with no
+`params_file` override, so it picks up the same file. Both platforms
+will now run at 1.5 m/s default until something else changes. A
+bizzy-only override would mean wiring an explicit `params_file` arg
+through `nav_launch.py` — deferred for now.
+
+Required a controller_server bounce to take effect (param read at
+init, no callback). Operator restarted; **boat now reports ~3 knots
+(≈ 1.54 m/s)**, exactly the configured 1.5 m/s within measurement
+noise. Change verified live.
+
+### Hour-long capture
+
+2026-04-27T13:54-04:00 (UTC start 17:54:26) — operator triggered a
+3600 s capture.
+
+- `~/data/logs/bizzy_images/bag_2026-04-27T17.54.26_ffmpeg_seg/`
+- 2.4 GiB / 3599.58 s / 437,997 messages
+- ~41 MB/min — slightly better than the 2-min average (46 MB/min);
+  long capture amortizes overhead and likely benefits from steadier
+  scene content
+- Disk after: 19 GiB used / 1.8 TiB free — no concern
+
+## 9. Starlink TCP tuning
+
+Operator asked about TCP buffer tweaks for Starlink. Pre-tune state on
+gabby was kernel default (`rmem_max = 208 KiB`, `tcp_congestion_control
+= cubic`, `default_qdisc = fq_codel`, BBR module not loaded). Starlink
+BDP at 300 Mbps × 50 ms ≈ 1.9 MB — autotuned TCP fits within
+`tcp_rmem` ceiling (6 MB) but apps that explicitly set
+`SO_{RCV,SND}BUF` were clipped at 208 KiB.
+
+Pre-tune RTT to 1.1.1.1: avg 27.1 ms / 0% loss / mdev 2.9 ms.
+
+### Drop-ins applied
+
+- `/etc/sysctl.d/30-starlink-tcp.conf` (965 B):
+    - `net.core.{rmem,wmem}_max = 16777216` (16 MiB)
+    - `net.ipv4.tcp_{rmem,wmem}` ceilings = 16 MiB
+    - `net.core.netdev_max_backlog = 5000`
+    - `net.core.default_qdisc = fq`
+    - `net.ipv4.tcp_congestion_control = bbr`
+- `/etc/modules-load.d/bbr.conf` (212 B): `tcp_bbr` (so BBR loads at
+  boot — wasn't auto-loaded before)
+
+### Why these
+
+- **CUBIC → BBR**: biggest single win for Starlink. CUBIC reads
+  satellite-handover transient loss as congestion and backs off
+  aggressively; BBR models bandwidth + RTT and rides through
+  short-loss windows.
+- **`fq_codel` → `fq`**: BBR's pacing relies on `fq`. `fq_codel`
+  works but BBR underperforms.
+- **`{r,w}mem_max` 208 KiB → 16 MiB**: lets apps using `setsockopt`
+  (e.g. SSH) actually request large buffers. Pure autotuned TCP
+  isn't capped by these (it's bounded by `tcp_{r,w}mem`), but tools
+  that opt out of autotuning hit the ceiling.
+
+### Verification
+
+Post-apply (no reboot needed — sysctls applied via `sysctl --system`,
+module via `modprobe tcp_bbr`):
+
+- `tcp_available_congestion_control = reno cubic bbr` ✅
+- `tcp_congestion_control = bbr` ✅
+- `default_qdisc = fq` ✅
+- `tcp_bbr` module loaded with 95 in-use refs immediately
+- 92 active TCP sockets using BBR within seconds (`ss -tin | grep -c bbr`)
+- Post-tune RTT to 8.8.8.8: 10/10 / avg 21.9 ms / mdev 3.1 ms — in
+  the same ballpark as the pre-tune baseline (different host, idle
+  RTT not the metric the change targets)
+
+The win is throughput stability under load, not idle RTT — would
+need a sustained iperf3 or large transfer to characterize, not worth
+doing mid-deployment.
+
+### Side-note on the verification false alarm
+
+First post-tune ping to 1.1.1.1 came back 100% loss in 5 packets,
+briefly looked alarming. Confirmed false alarm via spread: 8.8.8.8
+and the LAN router both at 0% loss with the same routing through
+`enp7s0`. 1.1.1.1 specifically was being dropped somewhere upstream;
+not a sysctl-change side-effect. **Lesson: when verifying network
+changes, ping at least three hosts (one external, one LAN), don't
+trust a single target.**
+
+## 10. Wrap-up
+
+2026-04-27T20:28-04:00 — operator signaled boat recovered; closing
+out the deployment.
+
+### 45-min capture (the in-flight one when recovery started)
+
+- `~/data/logs/bizzy_images/bag_2026-04-27T18.55.46_ffmpeg_seg/`
+- 1.5 GiB / 2143.69 s / 247,292 messages
+- Note: `Duration: 2143 s` rather than the requested 2700 s — the
+  bag's duration is computed from first-to-last message timestamp,
+  so if cameras stopped publishing at recovery (USB power cycle
+  during pull-out is plausible) but the recorder's `timeout` ran the
+  full 2700 s, only ~36 min of message content lives in the bag.
+  Not a recorder bug; the bag stops where the data stops.
+
+### State at wrap-up
+
+| Repo | Local commits ahead of `origin/jazzy` | Pushed? |
+|---|---|---|
+| `unh_echoboats_project11` | 9 (logs + recorder + launch) | (this commit, then yes) |
+| `unh_marine_perception` | 1 (frame_ids parameter) | not yet |
+| `seafloor_echoboat_project11` | 1 (default_speed bump) | not yet |
+
+All three will be pushed to gitcloud at the close of this session.
+Reconciliation to GitHub happens dev-side via `/import-field-changes`.
+
+### Capture archive (today)
+
+Five bags total, ~4.6 GiB on `~/data/logs/bizzy_images/`:
+
+| Start (UTC) | Duration | Size |
+|---|---|---|
+| 14:25:31 | 119.6 s | 91.6 MiB |
+| 15:02:15 | 119.6 s | 85.3 MiB |
+| 15:21:26 | 119.6 s | 82.6 MiB |
+| 17:54:26 | 3599.6 s | 2.4 GiB |
+| 18:55:46 | 2143.7 s | 1.5 GiB |
+
+### Carry-forward — for the dev-side wrap-up agent to action
+
+1. **Open issue** under `unh_marine_navigation` (or wherever the BT
+   lives): wire BT `{target_speed}` → `/speed_limit` topic publish.
+   Smallest fix: add a `PublishTopic` (or small custom action node)
+   firing `nav2_msgs/SpeedLimit` from the already-extracted
+   `target_speed` (`run_tasks.xml:384-387`) before each `FollowPath`.
+   With this, per-task survey speed becomes specifyable end-to-end —
+   today only the YAML default is honored.
+2. **Reconcile field commits via `/import-field-changes`** — three
+   field-mode repos have unmerged commits to land on GitHub:
+   `unh_echoboats_project11` (recorder edits + launch wiring + log),
+   `unh_marine_perception` (frame_ids parameter),
+   `seafloor_echoboat_project11` (default_speed bump). All three need
+   issues + draft PRs against GitHub `jazzy`.
+3. **Roadmap candidate** (`docs/roadmap.md`): bizzy-only nav2_params
+   override. The current shared `nav2_params.yaml` between BizzyBoat
+   and the seafloor echoboat means today's speed change applies to
+   both. If the seafloor platform ever wants a different default
+   speed, the cleaner fix is for BizzyBoat's `nav_launch.py` to
+   declare its own `params_file` override. Not on deck for next
+   deployment, but worth recording as a future-cleanup item.
+
+### Out-of-repo state worth knowing
+
+- **Starlink TCP tuning** is host-level on `gabby`
+  (`/etc/sysctl.d/30-starlink-tcp.conf` + `/etc/modules-load.d/bbr.conf`).
+  Not version-controlled in this workspace today — there is no
+  precedent for tracking host sysctls in any layer repo. If a similar
+  tweak is wanted on `mercat`, `salmon`, or other Starlink-fronted
+  field hosts, it should be replicated there manually (or eventually
+  rolled into an Ansible/role-style provisioning artifact, which is
+  bigger than a deployment-day fix).
+- **DeltaT removal** is captured in agent memory
+  (`project_bizzyboat_deltat_removed.md`) so future agents won't
+  misread the leftover ROS scaffolding as a live sensor.
+
+### Open thread
+
+USB serial check (asked at 11:09, paused on §6): never came back to
+this. If the device still needs reading, defer to the next session
+or to a ticket — not a wrap-up blocker.

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -3,7 +3,7 @@
 **Host**: gabby
 **Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
 **Mode**: field (gitcloud origin)
-**Deployment**: #TBD (dev-side issue not yet opened)
+**Deployment**: [#94](https://github.com/rolker/unh_echoboats_project11/issues/94)
 
 ## Scope
 
@@ -328,7 +328,7 @@ around for this recorder.
 
 ### Second capture
 
-2026-04-27T11:04-04:00 (UTC start 15:02:15) — second 120 s capture
+2026-04-27T11:02-04:00 (UTC start 15:02:15) — second 120 s capture
 at operator request.
 
 - `~/data/logs/bizzy_images/bag_2026-04-27T15.02.15_ffmpeg_seg/`

--- a/docs/logs/2026/2026-04-27_gabby_logs.md
+++ b/docs/logs/2026/2026-04-27_gabby_logs.md
@@ -130,3 +130,70 @@ on a known output topic before treating a node as a live data
 source. Same caveat for any udp_bridge-fronted sensor on this
 platform — the ROS-side topic exists whether or not bytes are
 flowing across the bridge.
+
+## 4. Prelaunch checks — gabby
+
+2026-04-27T10:48-04:00 — ran the full prelaunch sweep on gabby. All
+green except one gap, called out at the bottom.
+
+| Check | Status |
+|---|---|
+| Time sync (chrony → `time.lan.bizzy.p11.lan` S1) | ✅ system clock within 13 µs |
+| Timezone | ✅ `EDT (-04:00)` |
+| MAVROS ↔ FCU | ✅ connected, mode=MANUAL, disarmed, system_status=Active |
+| GPS-RTK gps1 | ✅ `fix_type=6` (RTK_FIXED), 32 sats, h_acc=21mm v_acc=27mm |
+| GPS gps2 raw | ❓ `--once` echo timed out twice; gps1 RTK-fixed so not blocking |
+| NTRIP | ✅ receiving corrections |
+| OAK cameras × 4 raw `segmentation` | ✅ ~5.0 Hz each |
+| OAK cameras × 4 `image_raw/ffmpeg` | ✅ ~5.0 Hz each |
+| `/tf` | ✅ ~33 Hz |
+| Nav2 lifecycle | ✅ "Managed nodes are active" |
+| Diagnostics aggregate | ✅ **48/48 OK**, 0 WARN/ERR/STALE |
+| Comms (WiFi/Starlink/LTE/multi-WAN/pings) | ✅ all healthy (WiFi 45 dB SNR, Starlink 20 ms 0% drop, LTE -81 dBm) |
+
+Notable diagnostics highlights from the 48-entry sweep:
+
+- `mikrotik_monitor: wifi.bizzy/wlan1`: associated 45 dB SNR
+- `starlink_diagnostics`: dish reachable, 0.0% drop, 20 ms, no
+  obstruction or thermal alerts
+- `teltonika_monitor: router.bizzy`: LTE -81 dBm, mwan3 wan online,
+  mob1s1a1 standby
+- `udp_bridge`: bizzy↔operator vpn (470 kB/s tx) + wifi (708 kB/s
+  tx, 810 B/s rx) both flowing
+
+There is **no `/diagnostics_agg` topic / no `diagnostics_aggregator`
+node** on this system — individual nodes publish to `/diagnostics`
+directly and the rqt_robot_monitor / operator UI must aggregate
+client-side. Not a problem; just an architectural fact worth knowing
+when looking for "the rolled-up status".
+
+### TF gap on OAK camera frames (note for costmap-plugin replay)
+
+`/bizzy/sensors/cameras/oak_forward/segmentation` messages carry
+`header.frame_id = oak_forward_optical_frame` — **no `bizzy/`
+namespace prefix.** That frame is **not in the TF tree**:
+
+```
+tf2_echo bizzy/base_link oak_forward_optical_frame
+  → "Invalid frame ID 'oak_forward_optical_frame'" (persistent)
+tf2_echo bizzy/odom oak_forward_optical_frame
+  → same
+```
+
+`bizzy/base_link` and `bizzy/odom` resolve fine (e.g.,
+`bizzy/odom → bizzy/base_link` is publishing at full rate, boat
+sitting at `[0.326, -0.622, -21.069]` rel. to odom origin). It's
+specifically the camera optical frames that aren't in the tree.
+
+Implication for the costmap-plugin work later: `SeaSurfaceLayer`'s
+TF lookup at `sea_surface_layer.cpp:141`
+(`segments_msg->header.frame_id` → `global_frame_id_`) would fail
+against this — consistent with `unh_marine_perception#6` (the
+`matchSize()` segfault blocker) and `#7` (end-to-end OAK→costmap
+validation, blocked on #6) being open in the roadmap. The plugin
+isn't end-to-end yet. Worth knowing when we replay from a bag —
+recording a bag won't paper over this; the upstream URDF / TF
+publisher needs to publish the camera frames before the plugin can
+function.
+
+Not blocking launch.

--- a/docs/logs/2026/2026-04-27_salmon_logs.md
+++ b/docs/logs/2026/2026-04-27_salmon_logs.md
@@ -1,0 +1,625 @@
+# Field log — salmon — 2026-04-27
+
+**Host**: salmon
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
+**Mode**: field (gitcloud origin)
+
+## Summary
+
+Day's plan: troubleshoot the camera grid rqt plugin, then software
+integration of the sonar and on-water testing. Session opens with a
+quick NVIDIA driver currency check, followed by `make sync` + `make
+build` — which brought in the new per-host deployment-log convention
+(this file is the first instance on salmon) and the camera-grid plugin
+changes that are today's first work item.
+
+## 1. NVIDIA driver check
+
+2026-04-27T09:51-04:00 — verified NVIDIA driver currency on salmon.
+
+- Running `580.126.09` on RTX 3070 Ti Laptop GPU
+- `apt-cache policy nvidia-driver-580`: candidate matches installed
+  (`580.126.09-0ubuntu0.24.04.2`, from `noble-updates`)
+- 580 is the current production branch in Ubuntu 24.04; nothing newer
+  offered
+- Aside: `nvidia-driver-550` package is still installed alongside 580
+  (not the active driver). Could `sudo apt autoremove --purge
+  nvidia-driver-550` to clean up — deferred, not blocking.
+
+No driver update needed.
+
+## 2. Workspace sync + build
+
+2026-04-27T09:53-04:00 — `make sync` then `make build`.
+
+Sync pulled:
+
+- `unh_echoboats_project11` (`bdc4a1a..6da895d`): new
+  `docs/logs/README.md` per-host deployment-log convention,
+  `docs/roadmap.md`, `docs/bizzyboat_deployment_log.md` frozen with
+  header pointer to the new convention, plus other doc updates.
+- `rqt_operator_tools` (`fd3bb3e..9e08f49`): camera grid plugin
+  changes — `staleness_tracker.{hpp,cpp}`, `camera_pane_widget.{hpp,cpp}`,
+  expanded `test_staleness_tracker.cpp`. Today's troubleshooting target.
+
+Build: all 7 layers (underlay, core, platforms, sensors, simulation,
+ui, site), 90 packages OK, no warnings or errors.
+
+## 3. Zenoh router + diagnostic rqt wrapper
+
+2026-04-27T10:15-04:00 — set up isolated tmux session for today's
+camera-grid debugging instead of bringing up the full operator stack.
+
+### Zenoh router
+
+- Session/window: `tmux attach -t rqt-debug`, window `zenoh`
+- Command (matches `bizzyboat_project11/scripts/start_tmux_*.bash`):
+  `ros2 run rmw_zenoh_cpp rmw_zenohd` after sourcing `/opt/ros/jazzy`
+  + `layers/main/site_ws/install`, with `RMW_IMPLEMENTATION=rmw_zenoh_cpp`
+- Verified healthy: `ros2 topic list` returns `/parameter_events` +
+  `/rosout` (the rmw_zenoh-default pair) within ~1 s. PIDs 652593
+  (`ros2 run` parent) / 652597 (`rmw_zenohd` binary).
+- Note: router stdout is silent by default. To get router-side
+  traffic logs, restart it with `RUST_LOG=zenoh=info` (or
+  `zenoh=debug` — firehose). Not done yet; revisit if camera-grid
+  symptoms point at transport issues.
+
+### Diagnostic rqt wrapper
+
+`/.agent/scratchpad/run_rqt_diag.sh` — wraps `rqt` with crash-friendly
+diagnostics. Lives in workspace scratchpad (not project repo) since
+it's a debugging tool, not project code.
+
+What it captures, per run, into `~/data/logs/rqt_camera_grid/rqt_<TS>.*`:
+
+- `*.meta.txt` — env snapshot up-front: `ROS*`/`RMW*`/`ZENOH*`/`QT*`
+  vars, `nvidia-smi`, `free -h`, ros2 daemon status, zenoh router
+  PIDs, camera-relevant topic list.
+- `*.log` — full stdout+stderr stream (Qt warnings/critical, plugin
+  load chatter from `QT_DEBUG_PLUGINS=1`, ROS log lines unbuffered).
+- `*.postmortem.txt` (only on non-zero exit) — recent `dmesg`
+  segfault lines, `coredumpctl list`, last 80 log lines, gdb hint.
+
+Knobs the wrapper sets:
+
+- `ulimit -c unlimited` — allow coredumps so systemd-coredump catches
+  segfaults (default `ulimit -c` on this shell is `0`)
+- `QT_LOGGING_RULES='*.warning=true;*.critical=true;qt.qpa.*=true'`
+- `QT_DEBUG_PLUGINS=1`
+- `RCUTILS_LOGGING_BUFFERED_STREAM=0`, `RCUTILS_COLORIZED_OUTPUT=0`
+- `RUST_LOG=zenoh=info,zenoh_transport=warn` (overridable)
+
+Usage examples:
+
+```bash
+.agent/scratchpad/run_rqt_diag.sh                              # full rqt
+.agent/scratchpad/run_rqt_diag.sh --standalone rqt_camera_grid # plugin only
+```
+
+`--standalone rqt_camera_grid` is the recommended starting point —
+fewer moving parts, log output stays on-topic.
+
+## 4. Camera grid test — no-data run did not repro; live-data test still owed
+
+2026-04-27T10:21–10:23-04:00 — first diag run: `--standalone
+rqt_camera_grid`, 88 s session, no camera topics published.
+
+### Result on the original issue — partial only
+
+Operator loaded the previously-problematic perspective/config and used
+the plugin normally — **no crash during use, but no data flowing
+either**. Plugin loaded silently (zero Qt warnings/critical, zero
+plugin-side log messages). This rules out a static-init or
+config-parse crash, but **does not** confirm the original issue is
+resolved — that bug was likely data-driven and needs a live-data
+repro attempt before we call it. The two upstream `rqt_operator_tools`
+commits brought in by today's sync are the candidate fix:
+
+- `2335fc6` — staleness border now driven by
+  `max(arrival_age, header.stamp_age)` instead of arrival-only, with
+  invalid-stamp handling forcing `Level::Error`. Closes its
+  `unh_echoboats_project11#25`.
+- `6682d0c` — `update_label()` throttle requires `since_update >=
+  0.0` so a backwards `use_sim_time` jump can't freeze the label;
+  `level_at()` comment corrected to describe worst-of-both negative-
+  age behavior.
+
+Files: `rqt_camera_grid/{src,include/rqt_camera_grid}/{camera_pane_widget,staleness_tracker}.{cpp,hpp}`,
+new tests in `test/test_staleness_tracker.cpp`.
+
+### Separate finding — shutdown segfault (exit 139)
+
+Operator closed the GUI normally; the wrapper caught a SIGSEGV during
+teardown. Sequence in
+`~/data/logs/rqt_camera_grid/rqt_2026-04-27T10.21.39.log`:
+
+```
+class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library
+while objects created by this loader exist in the heap! ...
+zenoh::api::session: close session zid=f0c006573...
+Segmentation fault (core dumped)
+```
+
+Classic pluginlib teardown ordering — `class_loader` unloads the
+plugin `.so` while live objects from it remain on the heap; their
+destructors then segfault on a now-dangling symbol. Likely upstream
+(pluginlib / rqt_gui_cpp lifecycle), not the camera-grid plugin
+itself. Process was exiting anyway, so functionally benign — but it
+masks any real teardown bug we might introduce later, so worth
+filing for someone to track down.
+
+### Wrapper limitation surfaced
+
+The post-mortem couldn't get a backtrace: `coredumpctl` is not
+installed on salmon (`coredumpctl: command not found`), and `dmesg`
+requires sudo. To capture stack traces from future segfaults:
+
+```
+sudo apt install systemd-coredump      # then re-run; coredumpctl gdb <PID>
+```
+
+Or run under gdb directly:
+
+```
+gdb --args rqt --force-discover --standalone rqt_camera_grid
+# (gdb) run     # then on segfault: thread apply all bt full
+```
+
+### Teardown
+
+2026-04-27T10:35-04:00 — stopped the dedicated `rqt-debug` tmux
+session (zenoh router C-c'd cleanly, then `tmux kill-session`).
+Operator switching to the project's normal start script
+(`bizzyboat_project11/scripts/start_tmux_*.bash`) for the live-data
+repro attempt — it brings up its own zenoh in its own tmux session.
+
+## 5. Live-data repro — crash IS still there, and it's an abort not a segfault
+
+2026-04-27T10:33-04:00 — operator launched the normal start script,
+opened the bizzyboat rqt (`project11:ui` window, `rqt_gui -p
+bizzyboat`), used the config dialog to add the **two side segmentation
+streams**, closed the dialog. rqt died.
+
+### What we caught (from the `project11:ui` tmux pane)
+
+```
+[FFMPEGSubscriber]: flushing decoder.        ← ×7
+terminate called after throwing 'eprosima::fastcdr::exception::BadParamException'
+  what():  The string contains null characters
+[ERROR] [rqt_gui-1]: process has died [pid 655426, exit code -6, ...]
+[INFO]  [rqt_gui-1]: process started with pid [656591]   ← launch respawn
+```
+
+- Exit code `-6` ⇒ killed by **SIGABRT**, not SIGSEGV. Different
+  failure mode from the §4 shutdown segfault.
+- `terminate()` from an uncaught `eprosima::fastcdr::BadParamException`
+  ("The string contains null characters") — fastcdr's standard message
+  for a string field with embedded `\0` during (de)serialization.
+- The 7× `flushing decoder` immediately before is rqt_camera_grid
+  tearing down the existing FFMPEGSubscribers as the apply replaces
+  the camera-pane layout. The abort lands during the fresh
+  re-subscribe / first-message-decode cycle.
+
+### Working hypothesis
+
+A string field of an incoming message on the new subscription contains
+embedded nulls, and fastcdr deserialization aborts. Most likely
+`header.frame_id` or another `std::string` field on the segmentation
+or ffmpeg topic — possibly something on the publisher side that builds
+a string from a fixed buffer without trimming at the terminator.
+Less likely: rqt_camera_grid itself constructs a string with stray
+nulls that gets round-tripped through DDS metadata.
+
+The 4-camera layout already running (forward, port, starboard, aft)
+did *not* trigger this — it's specifically the **add-and-apply** path
+that does. So either (a) a particular topic newly subscribed in this
+delta has the bad string and the existing 4 happen not to, or (b) the
+re-subscription cycle for any topic is the trigger and we just hadn't
+exercised it before today's repro.
+
+### Self-inflicted gotcha — apport rate-limited
+
+Diagnostic miss: the §4 shutdown segfault filled apport's quota for
+`/opt/ros/jazzy/bin/rqt` with a `.crash` at 10:23. When the live-data
+abort hit at 10:33, apport suppressed the duplicate. Result: no stack
+trace captured for the actual bug.
+
+Cleared `/var/crash/_opt_ros_jazzy_bin_rqt.1001.{crash,upload}` so
+the next repro is captured. The shutdown-segfault coredump was
+already unpacked to `/tmp/apport-rqt.pi51P3/CoreDump` (429 MB)
+before clearing — preserved for later inspection if useful, gone on
+reboot.
+
+**Wrapper followup**: `.agent/scratchpad/run_rqt_diag.sh` should
+`rm -f /var/crash/_opt_ros_jazzy_bin_rqt.*.crash` at start so it
+never poisons the apport slot for the real repro that follows.
+
+### Next step
+
+Operator to repeat the same dialog action (add two side seg streams,
+close to apply) on the respawned rqt. Apport will capture; we
+`apport-unpack` and `gdb` the CoreDump for a backtrace through
+`__cxa_throw` → fastcdr.
+
+### Repro and diagnosis from pane output (no apport needed)
+
+Apport actually didn't capture this one either (whoopsie still
+flagging within its window even after we cleared the file), but the
+respawn-launch printed the actual exception to the tmux pane:
+
+```
+terminate called after throwing 'rclcpp::exceptions::InvalidTopicNameError'
+  what():  Invalid topic name: ... must not contain characters other than
+           alphanumerics, '_', '~', '{', or '}':
+  '/bizzy/sensors/cameras/oak_starboard/segmentation  [compressed]/compressed'
+                                                     ^
+```
+
+Different exception type than the first crash (`fastcdr
+BadParamException` vs. `rclcpp InvalidTopicNameError`) but **same root
+cause**: the topic name contains the literal substring
+`"  [compressed]"` — i.e. the human-readable dropdown label was used
+as a topic name. So my §5 "string with null characters" hypothesis
+was wrong; the first crash was the same bug surfacing through fastcdr
+instead of rclcpp's name validator depending on transient state.
+
+### Bug location
+
+`rqt_camera_grid/src/config_dialog.cpp:610` —
+`save_current_editor_to_config`:
+
+```cpp
+p.base = base_combo_->currentText().toStdString();
+```
+
+The combo populates items as `addItem(label, base)` where
+`label = base + "  [" + transport + "]"` (line 271-272) and the clean
+base lives in `itemData`. `currentText()` returns the line-edit text,
+which is the **display label** — not the clean base.
+
+The dropdown-pick path is wired so `onBaseEditChanged` calls
+`setEditText(clean_base)` *before* committing — so most pick paths
+save clean. But line 223 wires `lineEdit::editingFinished` directly
+to `commit_current_editor`, bypassing `onBaseEditChanged`. On combo
+popup-close, `editingFinished` can fire on some Qt platforms/styles
+*before* `currentIndexChanged`, while the line edit still holds the
+dirty display label. That commit saves dirty, `rebuild_thumbnail_cell`
+constructs a `CameraPaneWidget` whose `subscribe()` passes
+`config_.base = "<base>  [<transport>]"` to
+`image_transport::subscribe`, the transport handler appends
+`/compressed`, rclcpp validates → `InvalidTopicNameError` → uncaught
+→ `terminate()` → SIGABRT.
+
+### Proposed minimal fix
+
+Three lines in `save_current_editor_to_config`:
+
+```cpp
+const int idx = base_combo_->currentIndex();
+const QString edit = base_combo_->currentText();
+if (idx > 0 && edit == base_combo_->itemText(idx)) {
+  p.base = base_combo_->itemData(idx).toString().toStdString();
+} else {
+  p.base = edit.toStdString();
+}
+```
+
+- Dirty-label commit path → line edit matches `itemText(idx)` → uses
+  clean `itemData`
+- Already-cleaned commit path (`setEditText(base)` ran) → line edit
+  doesn't match `itemText` → uses the (clean) line edit
+- Free-typed custom topic → `idx ≤ 0` → uses line edit verbatim
+
+Plus a defensive fix worth considering separately: catch
+`std::exception` from `subscribe()` in `CameraPaneWidget` and surface
+the error in the pane border instead of letting it `terminate()` the
+whole rqt process. A bad config in one pane should not take down the
+entire camera grid — and any exception thrown from `subscribe()`
+that bypasses our save-side validation will keep tripping
+`terminate()` until then.
+
+### Both fixes landed; partial result; moved on
+
+2026-04-27T10:55-04:00 — applied both edits to
+`rqt_operator_tools/rqt_camera_grid/`, rebuilt
+(`colcon build --symlink-install --packages-select rqt_camera_grid`,
+8.4 s, clean), committed as two atomic commits and pushed to
+gitcloud (field mode, no PR):
+
+- `b449acb fix(rqt_camera_grid): read base topic from itemData not display label`
+- `7f1d78b fix(rqt_camera_grid): catch subscribe() exceptions to keep one pane from terminate()ing rqt`
+
+Operator restarted the bizzyboat rqt window and re-ran the same
+add-two-side-seg-streams + close dialog action. **Behavior changed**:
+
+- No more `terminate called after throwing 'rclcpp::exceptions::InvalidTopicNameError'` line
+- No more exit code `-6` (SIGABRT)
+- Process now dies with exit code `-11` (SIGSEGV) during the same teardown sequence (8× `flushing decoder`, then segfault)
+
+Read: the SIGABRT crash mode from §5 is genuinely fixed (the dialog
+no longer leaks the dirty display label, and even if a bad config
+slipped through, `subscribe()` would catch). What remains is a
+**separate** segfault in the post-throw / re-subscribe lifecycle —
+likely either a `sub_` left in a half-state by the caught throw, or
+something downstream (ThumbnailCell?) that constructs its own
+subscriber from the same `config_.base` and is unprotected.
+
+Operator chose to commit the partial progress and move on rather
+than continue debugging — they have what they need to operate
+around the remaining issue. Worth a follow-up issue on
+`rqt_operator_tools` for the dev side to pick up:
+
+- Investigate the post-throw segfault path (CameraPaneWidget::sub_
+  state after caught exception, ThumbnailCell own subscriber)
+- Consider hardening populate_topic_combo's `preserved` capture too
+  (it uses currentText() the same way line 610 did)
+- Audit any other `currentText()`/`text()` reads on
+  base_combo_/lineEdit for the same display-label-leak class of bug
+
+A coredump should now be available for someone to chase the
+SIGSEGV (apport file gets refreshed each crash since the SIGABRT
+slot was freed earlier). `apport-unpack /var/crash/_opt_ros_jazzy_bin_rqt.1001.crash <dir>` then `gdb /opt/ros/jazzy/bin/python3 <dir>/CoreDump`.
+
+## 6. Post-fix SIGSEGV — diagnosed via gdb-wrapped diag session
+
+2026-04-27T11:18-04:00 — to capture the post-fix SIGSEGV with a
+proper backtrace (no apport rate-limit games), wrote a gdb-wrapped
+companion to the diag wrapper:
+
+- `.agent/scratchpad/run_rqt_gdb.sh` — `gdb -batch` around rqt with
+  auto `bt full` + `thread apply all bt` on signal/exit, output to
+  `~/data/logs/rqt_camera_grid/rqt_<TS>_gdb.{log,bt,meta.txt}`.
+
+Started in a dedicated `rqt-diag` tmux session running rqt with the
+`bizzyboat` perspective and `__node:=rqt_diag` (so it doesn't
+collide with the launch-respawned `__node:=rqt`). Operator
+reproduced the dialog action; gdb caught a clean SIGSEGV and dumped
+the backtrace before exiting.
+
+### Bug #2 — use-after-free in CameraPaneWidget callback lambda
+
+The crashing thread is a ROS spin thread (`rqt_gui_cpp::Nodelet
+PluginProvider::RosSpinThread`) inside the C++ message-delivery
+chain. Top frames:
+
+```
+#0  QObjectPrivate::maybeSignalConnected(unsigned int) const
+#1  ??? in libQt5Core.so.5                                  (Qt signal-emit machinery)
+#2  rqt_camera_grid::CameraPaneWidget::imageReceived(...)   ← `emit imageReceived(msg)`
+#3  rqt_camera_grid::CameraPaneWidget::handleImage(...)
+#4  rqt_camera_grid::CameraPaneWidget::subscribe()::lambda  ← `[this]` captured raw
+#8  compressed_image_transport::CompressedSubscriber::internalCallback
+#16 rqt_gui_cpp::...::RosSpinThread::run()
+```
+
+`CameraPaneWidget::subscribe` (`src/camera_pane_widget.cpp:121-129`)
+captures raw `this` in the message callback lambda. On config-apply,
+old panes are destroyed and new ones constructed; the old pane's
+destructor calls `sub_.shutdown()`, but `image_transport::Subscriber::shutdown` is **not** a synchronous drain of
+in-flight callbacks. A message already on the spin thread's
+dispatch path enters the lambda after the widget has been
+destroyed → `this->handleImage(msg)` → `emit imageReceived(...)` →
+Qt walks the connection list of a corrupted QObject → SIGSEGV.
+
+This is **a completely separate bug from §5's dialog-save bug**:
+- §5 = dialog leaks display label into `config_.base` → `subscribe()`
+  throws → terminate (SIGABRT). Fixed.
+- §6 = even with a clean `config_.base`, the destroy-then-rebuild
+  cycle on apply races with the executor delivering an in-flight
+  message to the destroyed pane → SIGSEGV.
+
+### Why this didn't show up on a different machine replaying data
+
+A destroyed-pane callback only races when a message arrives during
+the narrow destroy-then-recreate window. Live H.265 over zenoh on
+salmon delivers hot frames every ~200 ms per stream — small window,
+but achievable on apply. A bag replay at lower rate, paused, or with
+different scheduling would miss the window most of the time.
+
+### Fix shape (for the dev side)
+
+Capture a `QPointer<CameraPaneWidget>` instead of raw `this` — Qt's
+`QPointer` auto-nulls when the QObject is destroyed, so the lambda
+can early-return when it observes null:
+
+```cpp
+#include <QPointer>
+// ...
+QPointer<CameraPaneWidget> self(this);
+sub_ = it_->subscribe(
+  config_.base, qos,
+  [self](const sensor_msgs::msg::Image::ConstSharedPtr & msg) {
+    if (self) {self->handleImage(msg);}
+  },
+  ...);
+```
+
+Two-line change. Should also audit `imageReceived` connections —
+the slot side may need similar care if the connection target outlives
+the source signaler.
+
+Not landed today — operator chose to move on after gdb capture.
+Filing as a follow-up issue alongside the dialog-side cleanup
+already noted in §5.
+
+### Update — fix landed
+
+2026-04-27T~12:00-04:00 — operator delegated the fix while setting
+up sonar on a different machine. Applied as described above:
+QPointer capture in the subscribe() lambda with `if (!self) return`
+early-exit, plus `#include <QPointer>` next to the existing Qt
+includes. Built clean (7.5 s, single-package colcon).
+
+Commit: `d936384 fix(rqt_camera_grid): guard subscriber lambda
+against widget destruction race`. Pushed to gitcloud `jazzy`.
+
+Three fixes today on this repo, in order:
+
+- `b449acb` — bug #1, dialog dirty-save (SIGABRT)
+- `7f1d78b` — defensive try/catch in subscribe (SIGABRT → SIGSEGV
+  unmasking)
+- `d936384` — bug #2, callback lambda use-after-free (SIGSEGV)
+
+Verification of `d936384` requires the operator to restart the
+bizzyboat rqt window when they're back from the sonar setup and
+re-run the same dialog action. The rebuilt
+`librqt_camera_grid.so` is already in
+`layers/main/ui_ws/install/rqt_camera_grid/lib/`; respawn picks
+it up automatically. Did **not** kill the running rqt — operator
+restarts on their schedule (per the
+[don't-kill-user-processes](feedback memory) rule learned earlier
+this session).
+
+Residual concern documented in the commit body: there's a narrow
+race between `if (!self)` and the actual `self->handleImage(msg)`
+deref if destruction begins concurrently. For bulletproof safety
+the destructor needs to synchronize with the callback path
+(mutex around the destroyed flag). Not done — accepting the
+standard Qt+ROS idiom for now. If the SIGSEGV recurs in practice,
+that's the next step.
+
+### Verified
+
+2026-04-27T~12:30-04:00 — operator restarted the bizzyboat rqt and
+re-ran the same dialog action (add two side segmentation streams,
+close to apply). **No crash.** Three commits land the camera-grid
+work for today:
+
+- `b449acb` dialog dirty-save → cured the SIGABRT
+- `7f1d78b` defensive try/catch in subscribe → keeps one bad pane
+  from taking down rqt going forward
+- `d936384` QPointer in callback lambda → cured the SIGSEGV
+
+Camera grid line item is closed. Moving to sonar.
+
+## 7. Boat deployed — on-water phase
+
+2026-04-27T12:35-04:00 — boat in the water. Sonar bring-up was
+prepped on a separate machine while the camera-grid fix was being
+applied (§6). On-water testing phase begins.
+
+### CAMP freeze + udp_bridge wedge
+
+2026-04-27T~12:40-04:00 — operator reported CAMP frozen, killed it;
+launch respawned CAMP (new PID), but **all video feeds went dark**.
+
+Diagnosis from `ros2 topic info` + tmux `core` pane:
+
+- Camera topics still advertised, publisher = operator-side
+  `udp_bridge` (`/operator/udp_bridge`)
+- `ros2 topic hz` returned no samples on the forward ffmpeg topic
+  *or* on `/diagnostics`, `/bizzy/marine/heartbeat` — so this was
+  **not** camera-specific; the whole boat→operator UDP pipeline
+  was silent on our side
+- Crucially, `ss -ulnp` showed udp_bridge's socket had a
+  **361 KB Recv-Q backup** — kernel receive buffer was filling up
+  because the bridge wasn't draining it
+- udp_bridge's last log line in the `core` pane was ~14 min stale;
+  the process was alive (PID 675210) but had stopped processing
+  entirely
+
+So: link OK, kernel queuing UDP normally, but udp_bridge's reader
+thread wedged — almost certainly back-pressure or a deadlock when
+its republishes hit a (now-dead) CAMP-side subscriber during the
+freeze + kill window. Discovery state never recovered after CAMP
+respawned.
+
+**Recovery**: operator killed PID 675210; `operator_core_launch`
+respawned udp_bridge clean. Topics resumed flowing within seconds.
+
+Worth filing as a follow-up against the udp_bridge / operator-launch
+wiring: a single subscriber going away should not be able to wedge
+the bridge's UDP reader thread. Either the publish path needs to
+be non-blocking against any single subscriber, or the bridge needs
+a watchdog that kicks the reader if Recv-Q grows beyond a
+threshold for too long.
+
+### Survey started
+
+2026-04-27T~12:50-04:00 — survey running.
+
+### Boat recovered — wrap-up
+
+2026-04-27T~15:30-04:00 — boat recovered. End of on-water phase.
+
+## 8. Day recap + handoff
+
+### Net result
+
+- Camera grid plugin: three real bugs found, all fixed and verified
+  against live data. Plugin no longer crashes on dialog-apply with
+  side seg streams.
+- Sonar software integration + on-water survey: completed (set up on
+  a different machine while camera-grid bug #2 was being fixed).
+- One operational hiccup (CAMP freeze cascading into a wedged
+  udp_bridge) recovered cleanly with a single respawn.
+
+### Commits landed (all field-mode, all on `gitcloud:field/rqt_operator_tools.git`, branch `jazzy`)
+
+- `b449acb` `fix(rqt_camera_grid): read base topic from itemData not display label`
+  — bug #1, the SIGABRT crash from `InvalidTopicNameError` /
+  `BadParamException` when the dialog leaks the formatted display
+  label into `config_.base`.
+- `7f1d78b` `fix(rqt_camera_grid): catch subscribe() exceptions to keep one pane from terminate()ing rqt`
+  — defensive guard so any future bad pane config degrades to
+  log + missing-data rather than terminate.
+- `d936384` `fix(rqt_camera_grid): guard subscriber lambda against widget destruction race`
+  — bug #2, the SIGSEGV use-after-free where the ROS spin thread
+  delivers an in-flight image-transport callback to a destroyed
+  CameraPaneWidget. QPointer auto-null in the lambda.
+
+### Files touched (this repo)
+
+- `docs/logs/2026/2026-04-27_salmon_logs.md` (new — this file)
+
+### Files touched (other repos via gitcloud, push-only from salmon)
+
+`rqt_operator_tools` — `rqt_camera_grid/src/{config_dialog,camera_pane_widget}.cpp`
+(+ one `<QPointer>` include).
+
+### Pending — for the dev side / next deployment
+
+These are bounded enough to be issues, not roadmap items. Dev side
+should pick them up via `/import-field-changes` against the three
+commits above:
+
+1. **Residual destruction race in `CameraPaneWidget::subscribe`'s
+   QPointer lambda** — narrow window between `if (!self)` and the
+   subsequent `self->handleImage(msg)` deref if destruction begins
+   concurrently. Standard Qt+ROS idiom, accepted today, but a
+   bulletproof fix is destructor-side synchronization (mutex around
+   a destroyed flag, or shared_ptr ownership pattern that doesn't
+   fight Qt's parent-child management). Open if/when SIGSEGV recurs.
+2. **`ConfigDialog::populate_topic_combo` preserves dirty
+   text on Refresh** — line 262 captures `currentText()` (could be
+   the display label `"<base>  [<transport>]"`), then re-applies it
+   after re-populate. Same class of bug as the line-610 fix but at
+   a different trigger. Audit + fix similarly (use itemData lookup
+   when preserved text matches a known item's label).
+3. **udp_bridge wedge after subscriber death** — operator-side
+   `udp_bridge` stopped draining its UDP receive buffer (kernel
+   Recv-Q grew to ~361 KB) when CAMP died/was killed during the
+   deployment. Likely back-pressure or deadlock on a publish to a
+   dead subscriber. Either non-blocking publish, or a reader-thread
+   watchdog that kicks the bridge if Recv-Q stays above threshold.
+4. **`coredumpctl` not installed on salmon** — minor: would have
+   given us a backtrace earlier without the apport-rate-limit
+   detour. `sudo apt install systemd-coredump` on salmon. Also,
+   `.agent/scratchpad/run_rqt_diag.sh` should clear
+   `/var/crash/_opt_ros_jazzy_bin_rqt.*.crash` at start so a
+   diagnostic run never poisons the apport slot for the real bug
+   it's investigating.
+
+No follow-up needed for: nvidia driver currency (already up-to-date),
+zenoh router setup, the diag wrappers themselves
+(`.agent/scratchpad/run_rqt_diag.sh`, `run_rqt_gdb.sh` — keep as
+scratchpad tools, can be promoted to project repo if they prove
+useful across sessions).
+
+### What the GitHub deployment issue should reference
+
+Per the logs convention, dev side opens a `Deployment YYYY-MM-DD:
+<scope>` issue. For 2026-04-27 the scope was *camera grid bug
+hunt + sonar integration + on-water survey*. This file is the
+salmon-side host log; gabby's 2026-04-24 log is a different
+deployment, not part of today.

--- a/docs/logs/2026/2026-04-27_salmon_logs.md
+++ b/docs/logs/2026/2026-04-27_salmon_logs.md
@@ -1,8 +1,9 @@
-# Field log — salmon — 2026-04-27
+# BizzyBoat deployment log — salmon — 2026-04-27
 
 **Host**: salmon
 **Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
 **Mode**: field (gitcloud origin)
+**Deployment**: [#94](https://github.com/rolker/unh_echoboats_project11/issues/94)
 
 ## Summary
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,28 +28,47 @@ visible from one place.
 
 ### Sensor payload integration (M3 + SBG + SVS on mercat)
 
-- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP
+- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP. *Software pipeline live end-to-end as of 2026-04-27 (#94); first surveys recorded.*
 - [`unh_echoboats_project11#77`](https://github.com/rolker/unh_echoboats_project11/issues/77) — physical install, offsets, URDF, SVG diagram
 - [`rolker/marine_tools#1`](https://github.com/rolker/marine_tools/issues/1) — QINSy → ROS bridge for coverage / sounding feedback
 
 ### Camera obstacle avoidance
 
 - [`rolker/unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) — `SeaSurfaceLayer::matchSize()` segfault (blocker)
-- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK→costmap validation (blocked on #6)
+- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK→costmap validation (blocked on #6); per-camera `frame_ids` parameter landed in [PR #9](https://github.com/rolker/unh_marine_perception/pull/9) (2026-04-27)
 
 ### Navigation reliability
 
 - [`rolker/unh_marine_navigation#23`](https://github.com/rolker/unh_marine_navigation/issues/23) — TF extrapolation on multi-line survey goals
+- [`rolker/unh_marine_navigation#24`](https://github.com/rolker/unh_marine_navigation/issues/24) — wire BT `target_speed` → nav2 `/speed_limit` (per-task survey speed); deployment 2026-04-27 worked around with shared `default_speed` bump
+- [`unh_echoboats_project11#96`](https://github.com/rolker/unh_echoboats_project11/issues/96) — BizzyBoat-specific nav2 params override (decouple from seafloor echoboat defaults)
 
 ### Class-ready operator UI
 
 - [`rolker/rqt_operator_tools#2`](https://github.com/rolker/rqt_operator_tools/issues/2) — operator logbook (Phase 1 landed, not field-tested)
 - [`rolker/rqt_operator_tools#29`](https://github.com/rolker/rqt_operator_tools/issues/29) — pre-launch checklist (form factor TBD)
+- [`rolker/rqt_operator_tools#31`](https://github.com/rolker/rqt_operator_tools/issues/31) — rqt_camera_grid: harden destructor↔callback sync + audit `currentText()` reads
+- [`rolker/rqt_operator_tools#32`](https://github.com/rolker/rqt_operator_tools/issues/32) — rqt_camera_grid: `populate_topic_combo` Refresh re-leaks display label
 - [`unh_echoboats_project11#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) — student-facing operating documentation
+
+### Class-day operator observability *(new theme — 2026-04-27)*
+
+The 2026-04-27 deployment surfaced an asymmetry: boat-side instrumentation is rich, operator-side is sparse. The annunciator silently kept showing OK during an RTK loss because the udp_bridge wedge had stalled `/diagnostics`. Class operators need real-time visibility into the operator-side network + a way to know when the diagnostic stream itself is stale.
+
+- [`unh_echoboats_project11#97`](https://github.com/rolker/unh_echoboats_project11/issues/97) — run network monitor nodes on salmon + record salmon-side `/diagnostics` during deployments
+- *(future)* annunciator stale-stream indicator on `rqt_operator_tools` — distinguish "everything OK" from "stream wedged, last value stale"
+
+### Network reliability under load *(new theme — 2026-04-27)*
+
+Multiple network-layer issues surfaced during the same long deployment day: udp_bridge wedges (4×), post-recovery multi-device cycle, op-router forwarding asymmetry, gabby DNS wedge. Themes converge on (a) fix specific bugs, (b) better instrumentation (overlaps with observability theme above).
+
+- [`rolker/udp_bridge#10`](https://github.com/rolker/udp_bridge/issues/10) — bridge wedges (reader thread blocked, Recv-Q backup) when remote subscriber dies
+- [`rolker/udp_bridge#9`](https://github.com/rolker/udp_bridge/issues/9) — resend loop amplifies traffic (earlier related)
+- *(future)* End-of-day network pathology root-cause work — open once we have more signal from a future deployment with op-side diagnostics in place
 
 ### FCU configuration
 
-- [`unh_echoboats_project11#55`](https://github.com/rolker/unh_echoboats_project11/issues/55) — FCU battery params recalibration (field-gated, PR [#56](https://github.com/rolker/unh_echoboats_project11/pull/56) ready)
+- [`unh_echoboats_project11#55`](https://github.com/rolker/unh_echoboats_project11/issues/55) — FCU battery params recalibration (field-gated, PR [#56](https://github.com/rolker/unh_echoboats_project11/pull/56) ready). *Now also covers SOC reporting fix (`BATT_MONITOR`/percentage map) per 2026-04-27 debrief — added as additional acceptance to existing PR rather than separate issue.*
 
 ## Deferred / lower priority — no current issue
 


### PR DESCRIPTION
Dev-side log + wrap-up PR for the 2026-04-27 deployment ([#94](https://github.com/rolker/unh_echoboats_project11/issues/94)).

## Content

- `docs/logs/2026/2026-04-27_dev_logs.md` — dev workstation log
- `docs/logs/2026/2026-04-27_gabby_logs.md` — boat-side (merged from `gitcloud/jazzy`)
- `docs/logs/2026/2026-04-27_salmon_logs.md` — operator station (merged from `gitcloud/jazzy`)
- 3 field-mode code commits merged from `gitcloud/jazzy`:
  - `8bd7ce7` feat(scripts): record raw segmentation + robot_description for costmap-plugin replay
  - `661ae21` fix(scripts): correct `/robot_description` → `/bizzy/robot_description` in recorder
  - `1fe5884` feat(launch): wire OAK segmentation `frame_ids` to URDF-published frames

## ⚠️ Cross-repo dependency

`1fe5884` sets `frame_ids` on the OAK segmentation launch, which **requires** matching parameter support in `sea_surface_segmentation`. That support is in [`rolker/unh_marine_perception` PR #9](https://github.com/rolker/unh_marine_perception/pull/9).

**Do not merge this PR until [unh_marine_perception PR #9](https://github.com/rolker/unh_marine_perception/pull/9) merges**, or BizzyBoat's launch will pass an unknown parameter to the segmentation node.

## Related field-import PRs (sibling deployment changes in other repos)

- [`unh_marine_perception` PR #9](https://github.com/rolker/unh_marine_perception/pull/9) — per-camera `frame_ids` parameter (the dep above)
- [`rqt_operator_tools` PR #30](https://github.com/rolker/rqt_operator_tools/pull/30) — camera-grid crash fixes diagnosed on salmon (closes [#27](https://github.com/rolker/rqt_operator_tools/issues/27))
- [`seafloor_echoboat_project11` PR #17](https://github.com/rolker/seafloor_echoboat_project11/pull/17) — `FollowPath default_speed` 0.75 → 1.5 m/s

## Test plan

- [ ] Final pre-merge audit (carry-forward issues opened, roadmap updated, all host logs pulled in)
- [ ] All wrap-up checklist items in #94 ticked
- [ ] [unh_marine_perception PR #9](https://github.com/rolker/unh_marine_perception/pull/9) merged before this one

Closes #94.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
