### PR TITLE
docs(roadmap): refresh after 2026-04-28 cleanup chain (#99)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ visible from one place.
 ### Camera obstacle avoidance
 
 - [`rolker/unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) — `SeaSurfaceLayer::matchSize()` segfault (blocker)
-- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK→costmap validation (blocked on #6); per-camera `frame_ids` parameter landed in [PR #9](https://github.com/rolker/unh_marine_perception/pull/9) (2026-04-27)
+- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK→costmap validation (blocked on #6); per-camera `frame_ids` parameter + URDF-aligned `<label>_optical_frame` default across all `CameraBase` publisher paths landed via [PR #9](https://github.com/rolker/unh_marine_perception/pull/9) (merged 2026-04-28)
 
 ### Navigation reliability
 
@@ -65,10 +65,6 @@ Multiple network-layer issues surfaced during the same long deployment day: udp_
 - [`rolker/udp_bridge#10`](https://github.com/rolker/udp_bridge/issues/10) — bridge wedges (reader thread blocked, Recv-Q backup) when remote subscriber dies
 - [`rolker/udp_bridge#9`](https://github.com/rolker/udp_bridge/issues/9) — resend loop amplifies traffic (earlier related)
 - *(future)* End-of-day network pathology root-cause work — open once we have more signal from a future deployment with op-side diagnostics in place
-
-### FCU configuration
-
-- [`unh_echoboats_project11#55`](https://github.com/rolker/unh_echoboats_project11/issues/55) — FCU battery params recalibration (field-gated, PR [#56](https://github.com/rolker/unh_echoboats_project11/pull/56) ready). *Now also covers SOC reporting fix (`BATT_MONITOR`/percentage map) per 2026-04-27 debrief — added as additional acceptance to existing PR rather than separate issue.*
 
 ## Deferred / lower priority — no current issue
 


### PR DESCRIPTION
## Summary

Two stale entries in `docs/roadmap.md` after the 2026-04-28 cleanup chain:

- **FCU configuration thread removed** — issue [#55](https://github.com/rolker/unh_echoboats_project11/issues/55) is closed (auto-closed when [PR #56](https://github.com/rolker/unh_echoboats_project11/pull/56) merged at 21:11:23Z today). Nothing left to carry forward.
- **`unh_marine_perception` PR #9 wording refreshed** — said "landed (2026-04-27)" while #9 was still open. [PR #9](https://github.com/rolker/unh_marine_perception/pull/9) merged today (2026-04-28) with scope expansion: `CameraBase::initialize()` now defaults to `<label>_optical_frame` across all publisher paths (Image + FFMPEGPacket), so video and H.265 streams stamp consistently with segmentation.

Closes #99.

## Test plan

- [ ] Render the markdown — both entries are stale by today's merges, so verify the diff doesn't drop anything load-bearing.

---

**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
