### PR TITLE
Add sound_speed_bridge to bizzyboat core launch (AML SVS → ROS + Valeport UDP to M3)

### DIFF
--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -238,6 +238,21 @@ def generate_launch_description():
                         ])
                     ),
                 ),
+
+                # Sound-speed bridge (AML SVS on gabby /dev/ttyS1
+                # -> ROS topic + Valeport UDP to M3 on mercat:20003)
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('bizzyboat_project11'),
+                            'launch',
+                            'sound_speed_launch.py'
+                        ])
+                    ),
+                    launch_arguments={
+                        'frame_prefix': frame_prefix,
+                    }.items()
+                ),
             ]
         ),
 

--- a/bizzyboat_project11/launch/sound_speed_launch.py
+++ b/bizzyboat_project11/launch/sound_speed_launch.py
@@ -1,0 +1,54 @@
+"""Sound-speed bridge launch for BizzyBoat.
+
+AML SVS on gabby /dev/ttyS1 -> ROS topic + Valeport-format UDP fan-out to
+M3 (mercat:20003). The driver is in the rolker/marine_tools repo as the
+sound_speed_bridge package.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    frame_prefix = LaunchConfiguration('frame_prefix')
+    frame_prefix_arg = DeclareLaunchArgument(
+        'frame_prefix', default_value='bizzy/'
+    )
+
+    device = LaunchConfiguration('device')
+    device_arg = DeclareLaunchArgument(
+        'device', default_value=TextSubstitution(text='/dev/ttyS1')
+    )
+
+    baud = LaunchConfiguration('baud')
+    baud_arg = DeclareLaunchArgument('baud', default_value='9600')
+
+    return LaunchDescription([
+        frame_prefix_arg,
+        device_arg,
+        baud_arg,
+
+        Node(
+            package='sound_speed_bridge',
+            executable='sound_speed_bridge',
+            name='sound_speed_bridge',
+            parameters=[{
+                'device': device,
+                'baud': baud,
+                'parser': 'aml',
+                'frame_id': [frame_prefix, 'sound_speed_sensor'],
+                # Valeport-format UDP to M3 (built-in Valeport listener on mercat).
+                # Replaces the interim PowerShell stand-in (aml_bridge.ps1).
+                'udp_hosts': ['mercat'],
+                'udp_ports': [20003],
+                'udp_formats': ['valeport'],
+                'udp_templates': [''],
+            }],
+            respawn=True,
+            respawn_delay=2.0,
+            emulate_tty=True
+        ),
+    ])

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>rmw_zenoh_cpp</exec_depend>
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>
+  <exec_depend>sound_speed_bridge</exec_depend>
   <exec_depend>starlink_stats</exec_depend>
   <exec_depend>teltonika_monitor</exec_depend>
   <exec_depend>topic_tools</exec_depend>


### PR DESCRIPTION
## Summary

- Add `bizzyboat_project11/launch/sound_speed_launch.py` — boat-specific launch for the `sound_speed_bridge` driver: AML SVS on gabby `/dev/ttyS1` at 9600 baud, ROS topic at `<frame_prefix>sound_speed_sensor`, Valeport-format UDP fan-out to `mercat:20003`.
- Wire it into `core_launch.py` inside the existing namespace + `frame_prefix` `GroupAction` so the topic is namespaced and the frame_id picks up the boat's `bizzy/` prefix.
- Add `<exec_depend>sound_speed_bridge</exec_depend>` to `bizzyboat_project11/package.xml`.

This replaces the interim PowerShell stand-in (`aml_bridge.ps1` on mercat) now that the AML SVS lives on gabby.

Closes #101

## Dependency

Hard dependency on [rolker/marine_tools#4](https://github.com/rolker/marine_tools/pull/4) — the `sound_speed_bridge` package must be available for this launch to actually start. **Merge order: #4 first, then this PR**, otherwise the boat's default-branch bringup will fail to launch.

## Test plan

- [x] `colcon build --packages-select bizzyboat_project11` succeeds (verified locally)
- [x] `python3 -m py_compile` on both launch files passes
- [ ] Smoke test on gabby (after marine_tools#4 merges and builds): `ros2 launch bizzyboat_project11 sound_speed_launch.py` brings up `sound_speed_bridge`, `/sound_speed` publishes at ~26 Hz with finite m/s values, M3 receives Valeport UDP on `mercat:20003`, `/diagnostics` carries the live `sound_speed_m_s` value with `OK` status. (Standalone launch is unnamespaced — matching every other leaf launch in `bizzyboat_project11`. The `bizzy/` prefix only applies under `core_launch.py`'s `PushRosNamespace` group.)
- [ ] Run via full `core_launch.py` to confirm namespace + frame_prefix wiring: topic is `/bizzy/sound_speed`, frame_id is `bizzy/sound_speed_sensor`
- [ ] After parity verified, delete `aml_bridge.ps1` on mercat (separate cleanup)

## Boat-specific defaults

| Parameter | Default | Notes |
|-----------|---------|-------|
| `device` | `/dev/ttyS1` | gabby's COM2 |
| `baud` | `9600` | |
| `parser` | `aml` | |
| `frame_id` | `<frame_prefix>sound_speed_sensor` | typically `bizzy/sound_speed_sensor` |
| `udp_hosts` | `['mercat']` | |
| `udp_ports` | `[20003]` | M3's Valeport listener |
| `udp_formats` | `['valeport']` | byte-exact replacement for the PowerShell stand-in |

The launch exposes `device`, `baud`, and `frame_prefix` as launch arguments for ad-hoc overrides; the UDP target is hard-coded since it's specific to BizzyBoat's M3 setup. If we ever need to run this driver on a boat where M3 lives elsewhere (or there's no M3), a future PR can lift those into launch arguments too.

## Related

- Depends on [rolker/marine_tools#4](https://github.com/rolker/marine_tools/pull/4)
- Replaces interim PowerShell `aml_bridge.ps1` on mercat (memory: `project_aml_bridge_powershell.md`)

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`

