### PR TITLE
feat(bizzyboat): bring SBG Ellipse-D into ROS on gabby (PORT_E)

### DIFF
--- a/bizzyboat_project11/CMakeLists.txt
+++ b/bizzyboat_project11/CMakeLists.txt
@@ -15,6 +15,7 @@ install(PROGRAMS
   scripts/stop_tmux_project11.bash
   scripts/gps_rtk_diagnostics_node.py
   scripts/ntrip_diagnostics_node.py
+  scripts/rtcm_relay_node.py
   DESTINATION lib/${PROJECT_NAME})
 
 ament_export_dependencies(

--- a/bizzyboat_project11/config/sbg_ellipse_d.yaml
+++ b/bizzyboat_project11/config/sbg_ellipse_d.yaml
@@ -1,0 +1,49 @@
+# SBG Ellipse-D driver config for gabby's PORT_E.
+#
+# QINSy on mercat owns PORT_A and the device-global configuration via
+# sbgCenter (motion profile, lever arms, aiding assignment, GNSS model,
+# magnetometer model, output assignments per port). This driver runs in
+# read-only mode (`confWithRos: false`) to avoid stomping that config.
+#
+# Output messages on PORT_E must be enabled in sbgCenter once before
+# this node will see anything.
+#
+# RTCM corrections arrive from the FCU's NTRIP stream via rtcm_relay_node;
+# launch remaps "ntrip_client/rtcm" -> "rtcm" so both nodes meet at
+# /bizzy/sensors/sbg/rtcm.
+
+/**:
+  ros__parameters:
+    driver:
+      # Should be at least 2x the highest output frequency.
+      frequency: 400
+
+    # Don't push YAML to device — sbgCenter is the config authority.
+    confWithRos: false
+
+    odometry:
+      enable: false
+      publishTf: false
+      odomFrameId: "odom"
+      baseFrameId: "base_link"
+      initFrameId: "map"
+
+    uartConf:
+      # Set per cable when PORT_E breakout exists. Placeholder until then.
+      portName: "/dev/ttyUSB_sbg"
+      baudRate: 921600
+      # 0 PORT_A | 1 PORT_B | 2 PORT_C | 3 PORT_D | 4 PORT_E
+      portID: 4
+
+    output:
+      time_reference: "ros"
+      ros_standard: true
+      # NED matches QINSy/FCU; flip to ENU only if downstream expects REP-103.
+      use_enu: false
+      # TODO: align with URDF frame once an SBG link is added.
+      frame_id: "imu_link_ned"
+
+    rtcm:
+      subscribe: true
+      # Defaults (namespace="ntrip_client", topic_name="rtcm") are
+      # remapped to "rtcm" in sbg_launch.py.

--- a/bizzyboat_project11/config/sbg_ellipse_d.yaml
+++ b/bizzyboat_project11/config/sbg_ellipse_d.yaml
@@ -45,5 +45,8 @@
 
     rtcm:
       subscribe: true
-      # Defaults (namespace="ntrip_client", topic_name="rtcm") are
-      # remapped to "rtcm" in sbg_launch.py.
+      # Pin to today's driver defaults so sbg_launch.py's
+      # ('ntrip_client/rtcm', 'rtcm') remap stays valid even if a
+      # future sbg_driver release changes its built-in defaults.
+      namespace: "ntrip_client"
+      topic_name: "rtcm"

--- a/bizzyboat_project11/config/sbg_ellipse_d.yaml
+++ b/bizzyboat_project11/config/sbg_ellipse_d.yaml
@@ -29,9 +29,9 @@
       initFrameId: "map"
 
     uartConf:
-      # Set per cable when PORT_E breakout exists. Placeholder until then.
-      portName: "/dev/ttyUSB_sbg"
-      baudRate: 921600
+      # Built-in serial on gabby; matches PORT_E config in sbgCenter.
+      portName: "/dev/ttyS0"
+      baudRate: 115200
       # 0 PORT_A | 1 PORT_B | 2 PORT_C | 3 PORT_D | 4 PORT_E
       portID: 4
 

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -265,6 +265,9 @@ def generate_launch_description():
                     'ntrip_launch.py'
                 ])
             ),
+            launch_arguments={
+                'namespace': namespace,
+            }.items()
         ),
 
         # SBG Ellipse-D INS (gabby's PORT_E). Logs nav data for FCU

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -266,4 +266,19 @@ def generate_launch_description():
                 ])
             ),
         ),
+
+        # SBG Ellipse-D INS (gabby's PORT_E). Logs nav data for FCU
+        # parity comparison and forwards NTRIP RTCM to the SBG.
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([
+                    FindPackageShare('bizzyboat_project11'),
+                    'launch',
+                    'sbg_launch.py'
+                ])
+            ),
+            launch_arguments={
+                'namespace': namespace,
+            }.items()
+        ),
     ])

--- a/bizzyboat_project11/launch/sbg_launch.py
+++ b/bizzyboat_project11/launch/sbg_launch.py
@@ -1,0 +1,58 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    namespace_arg = DeclareLaunchArgument(
+        'namespace', default_value='bizzy'
+    )
+
+    sbg_config = PathJoinSubstitution([
+        FindPackageShare('bizzyboat_project11'),
+        'config',
+        'sbg_ellipse_d.yaml'
+    ])
+
+    return LaunchDescription([
+        namespace_arg,
+        GroupAction(
+            actions=[
+                PushRosNamespace(namespace),
+                PushRosNamespace('sensors/sbg'),
+
+                # SBG INS driver. Subscribes to RTCM via the remapping below
+                # so it shares /bizzy/sensors/sbg/rtcm with rtcm_relay.
+                Node(
+                    package='sbg_driver',
+                    executable='sbg_device',
+                    name='sbg_device',
+                    parameters=[sbg_config],
+                    remappings=[
+                        ('ntrip_client/rtcm', 'rtcm'),
+                    ],
+                    respawn=True,
+                    respawn_delay=5,
+                    emulate_tty=True
+                ),
+
+                # mavros_msgs/RTCM (FCU NTRIP feed) -> rtcm_msgs/Message.
+                Node(
+                    package='bizzyboat_project11',
+                    executable='rtcm_relay_node.py',
+                    name='rtcm_relay',
+                    parameters=[{
+                        'input_topic': '/bizzy/mavros/gps_rtk/send_rtcm',
+                        'output_topic': 'rtcm',
+                    }],
+                    emulate_tty=True
+                ),
+            ]
+        )
+    ])

--- a/bizzyboat_project11/launch/sbg_launch.py
+++ b/bizzyboat_project11/launch/sbg_launch.py
@@ -48,9 +48,11 @@ def generate_launch_description():
                     executable='rtcm_relay_node.py',
                     name='rtcm_relay',
                     parameters=[{
-                        'input_topic': '/bizzy/mavros/gps_rtk/send_rtcm',
+                        'input_topic': ['/', namespace, '/mavros/gps_rtk/send_rtcm'],
                         'output_topic': 'rtcm',
                     }],
+                    respawn=True,
+                    respawn_delay=5,
                     emulate_tty=True
                 ),
             ]

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -26,6 +26,8 @@
   <exec_depend>rmw_zenoh_cpp</exec_depend>
   <depend>robot_state_publisher</depend>
   <depend>rosbag2_transport</depend>
+  <exec_depend>rtcm_msgs</exec_depend>
+  <exec_depend>sbg_driver</exec_depend>
   <exec_depend>starlink_stats</exec_depend>
   <exec_depend>teltonika_monitor</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/bizzyboat_project11/scripts/rtcm_relay_node.py
+++ b/bizzyboat_project11/scripts/rtcm_relay_node.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Relay RTCM corrections from mavros_msgs/RTCM to rtcm_msgs/Message.
+
+The NTRIP client publishes mavros_msgs/RTCM directly to the FCU's mavros
+gps_rtk plugin. The SBG ROS 2 driver expects rtcm_msgs/Message instead.
+Same RTCM3 payload, different package and field name. This node copies
+each incoming message to the SBG-flavored topic so the same NTRIP stream
+can feed both receivers.
+"""
+
+import rclpy
+from rclpy.node import Node
+from mavros_msgs.msg import RTCM as MavrosRTCM
+from rtcm_msgs.msg import Message as RtcmMessage
+
+
+class RtcmRelayNode(Node):
+
+    def __init__(self):
+        super().__init__('rtcm_relay')
+
+        self.declare_parameter('input_topic', '/bizzy/mavros/gps_rtk/send_rtcm')
+        self.declare_parameter('output_topic', 'rtcm')
+
+        input_topic = self.get_parameter('input_topic').value
+        output_topic = self.get_parameter('output_topic').value
+
+        self._pub = self.create_publisher(RtcmMessage, output_topic, 10)
+        self._sub = self.create_subscription(
+            MavrosRTCM, input_topic, self._on_rtcm, 10
+        )
+
+        self.get_logger().info(
+            f'Relaying RTCM: "{input_topic}" (mavros_msgs/RTCM) '
+            f'-> "{output_topic}" (rtcm_msgs/Message)'
+        )
+
+    def _on_rtcm(self, msg: MavrosRTCM):
+        out = RtcmMessage()
+        out.header = msg.header
+        out.message = msg.data
+        self._pub.publish(out)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = RtcmRelayNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/bizzyboat_project11/scripts/rtcm_relay_node.py
+++ b/bizzyboat_project11/scripts/rtcm_relay_node.py
@@ -19,6 +19,10 @@ class RtcmRelayNode(Node):
     def __init__(self):
         super().__init__('rtcm_relay')
 
+        # Default assumes the bizzyboat namespace; sbg_launch.py overrides
+        # this with the live LaunchConfiguration so the relay follows the
+        # configured namespace. Override the parameter for direct
+        # `ros2 run` invocations on a non-bizzy boat.
         self.declare_parameter('input_topic', '/bizzy/mavros/gps_rtk/send_rtcm')
         self.declare_parameter('output_topic', 'rtcm')
 


### PR DESCRIPTION
## Summary

Brings the SBG Ellipse-D INS into ROS on **gabby** via the SBG's **PORT_E**:

- Apt-installed `ros-jazzy-sbg-driver` (declared as `<exec_depend>sbg_driver</exec_depend>`).
- Driver runs with `confWithRos: false` — sbgCenter remains the device-config authority, so QINSy/mercat (PORT_A) is unaffected.
- Small `rtcm_relay_node` copies the existing NTRIP stream from `mavros_msgs/RTCM` (`/bizzy/mavros/gps_rtk/send_rtcm`) to `rtcm_msgs/Message` (`/bizzy/sensors/sbg/rtcm`), enabling RTK on the SBG without touching the FCU pipeline.
- All SBG topics land under `/bizzy/sensors/sbg/...`, matching the `sensors/<name>` convention used by `sensors/ntrip`, `sensors/deltat`, `sensors/cameras`.

Closes #103.

## Changes

- `bizzyboat_project11/scripts/rtcm_relay_node.py` — new node, ~60 lines.
- `bizzyboat_project11/config/sbg_ellipse_d.yaml` — driver config for PORT_E in read-only mode.
- `bizzyboat_project11/launch/sbg_launch.py` — pushes namespace `sensors/sbg`, runs `sbg_device` + relay; remaps the driver's hardcoded `ntrip_client/rtcm` to flat `rtcm` so both meet at `/bizzy/sensors/sbg/rtcm`.
- `bizzyboat_project11/launch/core_launch.py` — wires `sbg_launch.py` in after `ntrip_launch.py`.
- `bizzyboat_project11/package.xml` — adds `<exec_depend>sbg_driver</exec_depend>` and `<exec_depend>rtcm_msgs</exec_depend>`.
- `bizzyboat_project11/CMakeLists.txt` — installs `rtcm_relay_node.py`.

## Test plan

Bench/field test requires hardware that isn't yet in place (gabby<->SBG PORT_E cable). On a clean dev host:

- [x] `colcon build --packages-select bizzyboat_project11` succeeds.
- [x] All three launch/script files import cleanly under the workspace's sourced env.
- [ ] On gabby, after sbgCenter setup: `ros2 launch bizzyboat_project11 sbg_launch.py` brings up the driver against `/dev/ttyS0`.
- [ ] Topics confirmed under `/bizzy/sensors/sbg/...` (paths match `sensors/<name>` convention).
- [ ] `ros2 topic hz /bizzy/sensors/sbg/rtcm` matches `/bizzy/mavros/gps_rtk/send_rtcm` rate.
- [ ] SBG GNSS reaches RTK-FIXED with NTRIP active.
- [ ] Bag captures both `/bizzy/sensors/sbg/...` and `/bizzy/mavros/...` for offline parity.
- [ ] QINSy on mercat (PORT_A) is unaffected.

## Field prerequisites (not blocking merge)

- Cable on gabby is wired and PORT_E is live at 115200 baud on `/dev/ttyS0` (verified — bytes flowing). YAML pinned to match in `19d9d47`.
- Output messages on PORT_E must be enabled in sbgCenter once before gabby will see anything (consequence of `confWithRos: false`). In progress at PR-update time — message list provided to operator.
- `frame_id: "imu_link_ned"` is a placeholder; needs to be aligned with URDF in a follow-up once an SBG link is added.

## Out of scope (deferred to follow-up issues)

- Live SBG-vs-FCU diff/comparison node (this PR just publishes + bags both for offline analysis).
- SBG-flow diagnostics node (parallel to `ntrip_diagnostics`, `gps_rtk_diagnostics`).
- PPS splitter cable for the M3 sonar — independent of UART wiring (PPS rides on a SYNC_OUT pin, not on PORT_A or PORT_E).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`

