### PR TITLE
log: record /bizzy/mavros/global_position/global (active mru_transform position source)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -217,6 +217,7 @@
       topics:
       - /diagnostics
       - /bizzy/mavros/battery
+      - /bizzy/mavros/global_position/global
       - /bizzy/mavros/global_position/raw/fix
       - /bizzy/mavros/global_position/raw/gps_vel
       - /bizzy/mavros/gpsstatus/gps1/raw


### PR DESCRIPTION
## Summary

- Adds `/bizzy/mavros/global_position/global` to the BizzyBoat logger topics list so the EKF3-fused position source actually used by `mru_transform` is captured in deployment bags.

## Why

`bizzyboat.yaml` configures `mru_transform` to fuse `mavros/global_position/global` (lines 24–25 default, 42–43 override; also declared as `mavros_position_ekf` source on lines 141 / 208). The logger block was capturing `global_position/raw/fix` and `raw/gps_vel` but not `global`, so today's deployment bag (`~/data/logs/bizzyboat/2026-04-29T21-43-29+00-00`) does not contain the position stream the platform was actually fusing. Discovered while cross-checking SBG INS vs FCU EKF on that bag (see `docs/logs/2026/2026-04-29_dev_logs.md`).

IzzyBoat is unaffected: `izzyboat.yaml` still uses `raw/fix` as its mru_transform position source (line 20), which is in its recorder list.

## Test plan

- [ ] Next BizzyBoat session: run `ros2 bag info` on a fresh bag and confirm `/bizzy/mavros/global_position/global` is in the topic list.
- [ ] Confirm `mru_transform` continues to fuse position normally (no behavior change — recorder-only addition).

Closes #112. Part of #104 (deployment-day data-loss spotcheck).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
