### PR TITLE
Field import: unh_echoboats_project11 (2026-04-30)

### DIFF
--- a/bizzyboat_project11/launch/bag_recorder_operator_launch.py
+++ b/bizzyboat_project11/launch/bag_recorder_operator_launch.py
@@ -9,7 +9,7 @@ The output directory is computed in this launch file (not a shell wrapper)
 so the recorder can be auto-launched as part of operator_core_launch.py
 the same way every other operator subsystem is. Layout:
 
-    ~/data/logs/operator/<YYYY-MM-DD>/diagnostics_<HH.MM.SS>/
+    ~/data/logs/operator/<YYYY-MM-DD>/bags/operator_<YYYY-MM-DDTHH.MM.SS>/
 
 Per-day parent dir so multiple deployments in a day group naturally; one
 bag-dir per launch. Path under ${HOME} so this runs without root.
@@ -62,9 +62,9 @@ def generate_launch_description():
 
     now = datetime.now()
     day_dir = now.strftime('%Y-%m-%d')
-    bag_name = now.strftime('diagnostics_%H.%M.%S')
+    bag_name = now.strftime('operator_%Y-%m-%dT%H.%M.%S')
     out_dir = os.path.expanduser(
-        f'~/data/logs/operator/{day_dir}/{bag_name}')
+        f'~/data/logs/operator/{day_dir}/bags/{bag_name}')
 
     record_cmd = [
         'ros2', 'bag', 'record',

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# called from cron @reboot (or by hand) on the operator station
-
-DAY=$(date "+%Y-%m-%d")
-NOW=$(date "+%Y-%m-%dT%H.%M.%S.%N")
-LOGDIR="${P11_LOG_DIR:-/home/field/data/logs/operator}"
-
-mkdir -p "$LOGDIR"
-LOG_FILE="${LOGDIR}/autostart_${NOW}.txt"
-{
-
 echo ""
 echo "#############################################"
 echo "Running start_tmux_operator_project11.bash"
@@ -60,4 +50,7 @@ sleep 2
 /usr/bin/tmux send-keys "source /opt/ros/jazzy/setup.bash && source /home/field/project11/layers/main/site_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp" C-m
 /usr/bin/tmux send-keys "ros2 launch molab_hardware johnny5_launch.py" C-m
 
-} >> "${LOG_FILE}" 2>&1
+# Screenshooter: full-screen captures into ~/data/logs/operator_raw/...
+# Ctrl-C in this window prompts to encode the day's PNGs to HEVC.
+/usr/bin/tmux new-window -t project11 -n screenshooter
+/usr/bin/tmux send-keys "/home/field/project11/layers/main/site_ws/install/ccomjhc_project11/share/ccomjhc_project11/scripts/screenshooter.bash" C-m

--- a/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
+++ b/bizzyboat_project11/scripts/start_tmux_operator_project11.bash
@@ -52,5 +52,7 @@ sleep 2
 
 # Screenshooter: full-screen captures into ~/data/logs/operator_raw/...
 # Ctrl-C in this window prompts to encode the day's PNGs to HEVC.
+# SCREENSHOOTER_LABEL labels the encoded files so survey/other stations
+# don't collide when archived together.
 /usr/bin/tmux new-window -t project11 -n screenshooter
-/usr/bin/tmux send-keys "/home/field/project11/layers/main/site_ws/install/ccomjhc_project11/share/ccomjhc_project11/scripts/screenshooter.bash" C-m
+/usr/bin/tmux send-keys "SCREENSHOOTER_LABEL=operator /home/field/project11/layers/main/site_ws/install/ccomjhc_project11/share/ccomjhc_project11/scripts/screenshooter.bash" C-m


### PR DESCRIPTION
Closes #118.

Imports three field commits from `gitcloud/jazzy` into a reviewable PR.
See issue #118 for the full pre-review against the Quality Standard.

## Commits

- `2d93693` refactor: rename diagnostics_*.bag → operator_<datetime>; nest under bags/
- `5c8f181` feat: launch screenshooter as tmux window; drop autostart_*.txt redirection
- `f0337b7` feat(startup): set SCREENSHOOTER_LABEL=operator explicitly

## Diverged — merge needed before merging this PR

This branch was created from `gitcloud/jazzy`, which is ahead of `jazzy` by
3 commits. Local `jazzy` is **also ahead by 25 commits** (recent dev-log and
PR-merge series), so this branch is diverged from the merge base. **A merge
with `jazzy` is required before this PR can land** — please don't squash,
and resolve any conflicts during merge.

## Cross-repo coupling

Depends on the parallel field-import PR in `ccomjhc_project11`
(`CCOMJHC/ccomjhc_project11#50`) that ships the rewritten
`screenshooter.bash` consuming `SCREENSHOOTER_LABEL`. Both PRs should land
together.

## Test plan

- [ ] Manual: tmux session opens with a `screenshooter` window after merge
  + cron @reboot
- [ ] Manual: bag layout — confirm bags land at
  `~/data/logs/operator/<YYYY-MM-DD>/bags/operator_<YYYY-MM-DDTHH.MM.SS>/`
  (not the old `diagnostics_*.bag` flat layout)
- [ ] Manual: confirm that with `autostart_*.txt` redirection gone, cron-
  launch failures still surface via `journalctl -u cron` or equivalent

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
