### PR TITLE
Deployment wrap-up: 2026-05-01 BizzyBoat (#121)

### DIFF
--- a/docs/logs/2026/2026-05-01_dev_logs.md
+++ b/docs/logs/2026/2026-05-01_dev_logs.md
@@ -1,0 +1,1539 @@
+# BizzyBoat deployment log — dev — 2026-05-01
+
+**Host**: dev
+**Operator**: Roland + KG + Claude Code Agent (Claude Opus 4.7)
+**Mode**: dev (GitHub origin)
+**Deployment**: [#121](https://github.com/rolker/unh_echoboats_project11/issues/121)
+
+## Summary
+
+Three goals planned. **Goals 1 & 2 met cleanly; Goal 3 produced
+more data than progress** — characterized failure modes more than
+it validated working ones, but the picture is clearer for the
+remaining survey-readiness work.
+
+**Goal 1 — PPS to M3 (achieved).** Modified PPS-pigtail cable was
+ready and installed; an early version of the cable broke RTCM-to-SBG
+and was reverted while a fix was applied. Setting up SBG and M3
+together took surprising work — root cause of "0 pulses received"
+was the **M3 software's Device Properties → Time Sync Mode dropdown**
+still on default, not the cable / SBG / polarity / pulse width we
+spent the morning chasing. Working config: SBG Event Out A = 1PPS,
+rising edge, 500 ms duration; M3 Time Sync Mode = 1PPS; verified
+via `INF 1PPS: 10 pulses received in 10s` in M3 Output Messages.
+Captured the dropdown gotcha as durable memory.
+
+**Goal 2 — SBG + FCU at base_link (achieved).** The SBG sbgCenter
+Output Location was **not set**; setting it to point at the existing
+IMU→CoG monitoring point referenced output at base_link. gabby
+agent confirmed SBG and FCU positions now agree at base_link — the
+comparable-bag prerequisite from 2026-04-29's post-bag finding is
+satisfied. As a side effect, also brought QINSy's SBG hookup fully
+up: position, attitude, heading, heave, GPS QC.
+
+**Goal 3 — over-horizon comms baseline (partial).**
+
+- **RC range LOITER mystery solved**: the FCU was honoring the RC
+  controller's mode-switch channel at fringe range despite
+  `FS_THR_ENABLE = 0`. Mitigation today: power off the RC controller
+  entirely. Permanent options: pin the mode switch to AUTO/GUIDED,
+  or disable the mode-switch channel via FCU params. Captured as
+  memory.
+- **Bandwidth saturation under realistic load is severe**: even on
+  Starlink-only at moderate distance, the current ROS topic stack
+  saturates the link, producing 30–60 s latency, all-red CAMP
+  episodes, dropped packets. Topic-budget cull is required for
+  any over-horizon survey, not optional.
+- **Asymmetric resilience**: control commands and SSH stayed
+  reliable through saturation; situational awareness (CAMP, video)
+  did not. Boat returns home cleanly via goto even when operator
+  is effectively blind.
+- **udp_bridge PR #12** (merged 16:05 today) appears to interact
+  with the saturation behavior — gabby agent applied a fix mid-day
+  that recovered things; full root cause / regression assessment
+  needs bench testing.
+- **Multi-path graceful degradation works** (WiFi ↔ Starlink ↔
+  cellular) — three paths active, transparent failover; but
+  diagnosing which path is carrying traffic in the moment was a
+  significant gap (follow-up: VPN-path indicator).
+- **Other findings**: near-pier WiFi null (not range-limited);
+  3-min Starlink outage transparent to autonomy; mooring ball
+  near-miss (perception→costmap is a real survey-readiness blocker);
+  CAMP UI doesn't reflect Standby state; goto is override-then-resume
+  not re-target.
+
+**Operational housekeeping**: opened IzzyBoat parity tracker (#120),
+captured M3-1PPS-dropdown + RC-mode-switch + IzzyBoat-parity as
+durable memories, deferred sonar-architecture memory update until
+UDP-ZDA-to-head path is proven.
+
+## Goals (from #121)
+
+1. **PPS-to-sonar cable** (conditional) — install + verify if cable is ready.
+2. **SBG + FCU lever-arm verification** — both reference `bizzy/base_link` =
+   CoG; QINSy then only carries sonar→CoG offsets. Direct follow-up to the
+   2026-04-29 finding that SBG and FCU streams were publishing at antenna
+   locations rather than `base_link`. **Verification target:** record a bag
+   in which the SBG nav stream and the FCU IMU stream are both referenced
+   at `base_link`, so the two can be compared apples-to-apples in post.
+3. **Over-horizon comms baseline** — go-out-and-back mission, observe the
+   Starlink path, play the rest by ear. First sustained step away from
+   WiFi-bounded operation toward long-range survey use.
+
+## Conditions — 2026-05-01
+
+All times **EDT (UTC−4)**. Full block: see
+[#121 conditions comment](https://github.com/rolker/unh_echoboats_project11/issues/121#issuecomment-4359368992).
+
+- **Marine forecast (Stonington ME → Merrimack River MA):** ⚠️ SCA through
+  8 PM EDT. W → SW 10–15 kt G20. Seas 3–5 ft, SE 5 ft.
+- **Tides (Fort Point NH, MLLW):** Low 05:50 (−0.05 m), High 12:07 (2.63 m),
+  Low 17:57 (0.25 m). Judd Gregg launch unconstrained.
+- **Currents (Clark Island, ACT0731 bin 1):** slack 08:10 → max flood 1.47 kt
+  @ 11:42 → slack 14:14 → **max ebb 2.05 kt @ 16:49**. Calm-water window
+  ~08:10–14:14.
+
+## Timeline
+
+_(append in forward-chronological order, EDT)_
+
+### ~08:30 — Boat on the pier, powered up
+
+Boat is outside on the pier (Judd Gregg). Powered on and charging for
+~30 minutes by 09:00 EDT.
+
+### 09:00 — Pre-launch state
+
+- Deployment issue #121 open with goals + conditions.
+- Calm-water window per currents: ~08:10–14:14 EDT (slack-to-slack,
+  max flood 1.47 kt at 11:42).
+- High tide 12:07 EDT (2.63 m MLLW).
+
+### 09:06 — Morning host updates (dev / salmon / gabby)
+
+Roland ran `apt update; apt upgrade` on **dev**, **salmon**, and
+**gabby** this morning. After login, **gabby** flagged a pending
+reboot — Roland is rebooting it now. (Watch on the next gabby-side
+ROS bring-up that everything starts cleanly post-reboot;
+field-side log will pick up the gabby-local detail.)
+
+### 09:08 — Gabby back up
+
+Gabby is back online after the post-upgrade reboot.
+
+### 09:10 — Salmon rebooted and back up
+
+Salmon also rebooted after this morning's `apt upgrade` and is back
+online.
+
+### 09:15 — `make sync` run, `marine_tools` cleanup
+
+`make sync` updated `ccomjhc_project11` (`screenshooter.bash`) and
+`unh_echoboats_project11` (small operator-tmux + bag-recorder
+changes); my #121 worktree was created from the new tip so no
+rebase needed. **Skipped: `marine_tools`** with uncommitted changes.
+
+On investigation, the main tree's `marine_tools` checkout had a
+stale staged copy of the `bag_analysis/` package on `jazzy` (files
+dated 2026-04-30 18:05, never committed) — an earlier agent had
+started bag_analysis in the main tree, against the no-edit-in-main
+rule, before the work was migrated to a worktree. The PR-branch
+copy on `feature/issue-5` (PR
+[rolker/marine_tools#6](https://github.com/rolker/marine_tools/pull/6))
+has progressed well past it (10+ commits incl. IMU extractor,
+`sbg_driver` removal, lint cleanup), so the staged main-tree files
+were strictly older and superseded. Cleanup: `git reset HEAD
+bag_analysis/` + `rm -rf bag_analysis/`. PR #6 is untouched.
+
+### 09:24 — `make sync` re-run, gitcloud push
+
+`make sync` clean on the second run (32 repos, all "Already up
+to date", no skips). Then ran
+`.agent/scripts/push_remote.py --remote gitcloud` — 32 repos, all
+pushed (default branches + tags), 0 errors. Field hosts can pull
+latest mainline. Today's `feature/issue-121` was deliberately
+not pushed; that stays dev-side until the wrap-up PR merges.
+
+### 09:45 — PPS cable ready; gabby COM1 cleared as not faulty
+
+Modified PPS-to-sonar cable is ready — installation in progress.
+
+While installing, Roland did an opportunistic loopback on gabby:
+null-modem cable between COM1 ↔ COM2, two `minicom` sessions, sent
+in both directions successfully. **Conclusion: gabby's COM1 is
+fine** — the failure on 2026-04-29 (suspected TX-side fault on
+ttyS0, worked around by re-routing SBG to ttyS1) was the **cable**,
+not the port. SBG remains routed via ttyS1; no urgency to revert,
+but ttyS0 is now known-good if needed.
+
+### 09:55 — gabby COM3 ↔ mercat COM1 null-modem cable installed
+
+Null-modem serial cable now connects **gabby COM3 ↔ mercat COM1**
+as a point-to-point sidecar between the two compute hosts. Intended
+as a fallback path if we need to ferry M3-adjacent data between
+gabby and mercat without going over the LAN.
+
+**Not** the path for M3 time-sync ZDA on its own — the M3 spec is
+NMEA ZDA on **UDP port 31100** at 1 Hz, paired with the hardware
+1PPS edge. Architecture (per `project_bizzyboat_sonar_architecture.md`)
+has QINSy on mercat sourcing ZDA via its `Network NMEA ZDA (UDP) - 18`
+output driver straight to the M3 head IP. Confirmed mid-discussion
+that the **M3 software does also accept ZDA via serial** if we want
+to architect a non-QINSy path; not pursuing today.
+
+### 10:20 — New PPS pigtail cable regresses SBG RTCM; reverted
+
+Installed the modified SBG cable with the sync pigtail (pin 4 SYNC
+OUT A → M3 breakout MIND-4 for 1PPS, pins 2/3/5 PORT E → gabby for
+NMEA out + RTCM in). With the new cable in place, **RTCM corrections
+to the SBG stopped flowing — RTK fix lost**. Swapped back to the
+old (no-pigtail) cable; RTK fix restored.
+
+**Impact**: Goal 1 (PPS-to-sonar test) is **blocked** pending cable
+investigation. Old cable has no SYNC OUT to M3, so 1PPS is not
+being delivered for now. Goals 2 and 3 unaffected — RTK is back,
+SBG nav is healthy.
+
+The new cable is being investigated. Likely candidates: pin
+2/3 wiring error (RX/TX flip on the PORT E side), short or
+crosstalk introduced by the pigtail fan-out, or impedance
+mismatch on the RS-232 lines. Document any findings under
+"Lessons Learned" once root cause is known.
+
+### 10:40 — Cable issue identified (fix in progress); gabby ZDA-over-serial works
+
+Cable root cause has been identified (fix in progress — details to
+land here once applied).
+
+In parallel, an agent on **gabby** built a package that emits NMEA
+ZDA out a serial port, and **the M3 can see it**. First confirmation
+that the serial-ZDA path discussed earlier (M3 software accepts ZDA
+via serial) actually works in our setup. This is a meaningful win
+for QINSy-independence of M3 time sync — at least functionally; PPS
+edge is still pending the cable fix.
+
+Open questions to capture once the dust settles: (1) which gabby
+serial port + which physical path to the M3 is delivering ZDA,
+(2) where the new package lives (repo + branch / PR), (3) whether
+this becomes the durable path or just today's stand-in.
+
+### 10:41 — ZDA serial path: gabby COM3 → mercat COM1 → M3 software
+
+Confirmed path: gabby emits NMEA ZDA out **COM3** → today's new
+null-modem cable → **mercat COM1** → **M3 software (running on
+mercat) reads ZDA from COM1**. The M3 software is the consumer of
+ZDA — pairs it with the 1PPS edge to time-stamp pings — so the path
+ends at mercat even though the sonar head is on isolated ethernet.
+
+Architectural implications worth flagging for the architecture
+memory once durable:
+- Decouples M3 time-of-day from QINSy entirely (was previously
+  documented as QINSy → UDP 31100 → M3 head IP).
+- Uses **gabby's PTP-synced clock** (~10–100 µs to TM2000B) as the
+  canonical M3 time source — better than mercat's NTP.
+- Reuses the gabby↔mercat null-modem cable installed earlier;
+  no new hardware to deliver ZDA.
+
+PPS edge still depends on the SBG sync-pigtail cable fix to
+actually deliver 1PPS to the M3 head. ZDA without 1PPS gives
+1-second precision; pairing with 1PPS is what makes it useful for
+sonar.
+
+### 11:03 — Manual review: serial ZDA likely does NOT drive 1PPS sync at the head
+
+Reviewed the M3 reference manual (`~/m3_sonar/m3_sonar_ref_en_us.pdf`,
+p. 32, "Testing 1PPS Time Sync Mode"). Two important findings:
+
+**A. SYNC OK is not how you verify PPS — Output Messages is.**
+After setting Device Properties → Time Sync Mode to "1PPS", open
+Display → Output Messages Window and look for:
+
+- `INF 1PPS: 10 pulses received in 10s` — should be exactly 10 in
+  every 10-second window. <10 means PPS isn't working.
+- `INF PPS preLDINF ZDA: <epoch>` — ZDA epoch staged for the next
+  PPS edge.
+- `INF PPS <timestamp>s <latched>` — timestamp latched at 1PPS
+  leading edge; should be close to the most recent ZDA.
+
+**B. ZDA must go to the SONAR HEAD over UDP 31100 — NOT to the M3
+software.** The manual states (p. 32, repeated ~p. 200):
+
+> "1PPS synchronization requires ZDA input over UDP to the Sonar
+> Head (not to the M3 software) on UDP port 31100 at 1 Hz."
+
+Today's serial-ZDA path (gabby COM3 → mercat COM1 → M3 software on
+mercat) feeds the M3 *software*, which is **not** the path that
+drives head-level 1PPS pairing. The green SYNC OK in M3 software is
+consistent with the software receiving valid time data, but that
+is separate from the head being 1PPS-locked.
+
+**Action needed**: when the SBG sync-pigtail cable fix lands and PPS
+edges are flowing again, also send NMEA ZDA via UDP to the M3 head
+IP (`192.168.1.234` per architecture memory) on port 31100. Source
+can be the same gabby ZDA generator — just emit UDP, not (or in
+addition to) serial. Then verify via Output Messages.
+
+This recharacterizes the earlier "QINSy-independence win" entry:
+the serial path is good for software-side time display, but the
+durable architecture for actual head time-stamping needs UDP-to-head.
+
+### 11:50 — PPS now flowing: root cause was M3 Time Sync Mode dropdown
+
+PPS is now being counted by the M3. **Root cause was the M3 software
+config**, not SBG-side or cable: the Time Sync Mode dropdown in
+**Device Properties → Sonar Setup** was not set to "1PPS". Without
+that setting, the M3 doesn't count pulses even when they're arriving
+correctly on the input — and the green SYNC OK indicator says
+nothing about it.
+
+Confirmed working configuration:
+
+- **SBG sbgCenter → Input/Output → Events → Event Out A**: 1PPS,
+  rising edge, **500000 µs** (500 ms / 50 % duty cycle) pulse
+  duration.
+- **M3 software → Device Properties → Sonar Setup → Time Sync
+  Mode**: **1PPS** (the non-obvious step).
+- Verification: M3 Output Messages window shows "INF 1PPS: N pulses
+  received in 10s" with N == 10.
+
+### 11:54 — Goal 2 work in progress on gabby
+
+Agent on **gabby** is working on Goal 2 (SBG + FCU lever-arm
+verification): looking at frame ids on published topics and what's
+in the bag recorder configuration. Field-side detail will land in
+`2026-05-01_gabby_logs.md`; standing by dev-side for anything that
+needs workspace-level review or grepping.
+
+### 12:15 — sbgCenter Output Location was missing; set to match IMU→CoG
+
+Reviewed `bizzyboat_project11/docs/hydro_payload_install_log.md`
+and produced an expected-values table for sbgCenter. Roland found
+that **Output Location was not set** — that's the FW v3.0+ field
+that tells the SBG to reference all outputs at the configured
+Output Monitoring Point. Without it, output goes to IMU or CoR
+location, not base_link.
+
+Set Output Monitoring Point lever arm to the same value as the
+existing IMU→CoG (Center of Rotation) lever arm. Output Location
+now points at the monitoring point.
+
+**Sign-direction question resolved by inspection:** the install
+log records the CoR lever arm as `(−0.577, 0.000, −0.029) m`
+labeled "IMU lever arm from vehicle origin", but the actual
+sbgCenter field is direction "IMU → CoR" per the manual, and
+the device shows the **positive** values `(+0.577, 0, +0.029)`.
+The install log's wording was imprecise — the values entered
+in sbgCenter on 2026-04-22 are correct per the manual's
+direction. No sign flip needed.
+
+**Follow-up**: update the install log to clarify the lever-arm
+direction wording, so the doc matches the device.
+
+### 12:30 — SBG and FCU positions agree at base_link
+
+gabby agent reports **SBG and FCU positions agree** with both
+streams referenced at `base_link`. That's the core of Goal 2:
+the two nav sources can now be compared apples-to-apples in a
+recorded bag. Detail of the comparison method (what topics, what
+agreement threshold) lives in `2026-05-01_gabby_logs.md`.
+
+Goal 2 is effectively met for live data — once a representative
+bag is recorded with both streams, the post-deployment comparison
+(2026-04-29 finding's resolution) becomes possible.
+
+### 12:35 — QINSy SBG hookup; heave initially missing then converged
+
+QINSy on mercat now seeing SBG data on COM4 with the
+`SBG Systems (R-P-H) – 03` driver after enabling the binary
+log set: `STATUS` (1 Hz / new data), `UTC_TIME` (new data),
+`EKF_NAV` (50 Hz), `EKF_EULER` (50 Hz), `SHIP_MOTION` (50 Hz),
+`GPS1_POS/VEL/HDT` (GNSS-native). Heave was initially not
+showing then came in green on its own — likely the SBG heave
+filter needed a few minutes to converge in Marine motion
+profile, which is normal on a stationary platform.
+
+All required QINSy inputs are now live: position, attitude,
+heading, heave, GPS QC.
+
+### 13:22 — Pre-launch checks complete; controls verified
+
+Controls checked and working. Boat ready to launch for the
+go-out-and-back / over-horizon comms baseline (Goal 3).
+
+Conditions reminder: slack water at 14:14, max ebb 2.05 kt at
+16:49 — calm-water window for the run is roughly the next ~50
+minutes. SCA still in effect through 8 PM EDT.
+
+### 13:36 — Boat in the water
+
+BizzyBoat launched. Goal 3 (over-horizon comms baseline) run
+underway.
+
+### 13:37 — Operator WiFi antenna rotated to ~340° (NNW)
+
+Directional operator-station WiFi rotated to bear **~340° true**
+(NNW), aimed along the boat's planned out-and-back track.
+Useful context for any comms-range observations during the run —
+the WiFi link is azimuthally optimized for that bearing.
+
+### 13:41 — Two-line survey: 500 m out and back
+
+Autonomous two-line survey started — **500 m out, 500 m back**
+along the WiFi-aimed bearing. First baseline run for Goal 3
+(over-horizon comms). 500 m is well inside expected WiFi range
+(2026-04-21 observations had graceful degradation well past the
+old 300 m mark) so this run primarily establishes the baseline
+link / topic-flow behavior before anything more aggressive.
+
+### 13:42–47 — Comms observations during outbound leg
+
+- **WiFi initially showed 0 traffic** at the operator MikroTik
+  shortly after launch.
+- **Heartbeat green in CAMP, video still flowing, occasional
+  blink to yellow** — comms alive throughout, presumably via
+  Starlink while WiFi was down.
+- **WiFi came back as the boat moved further out** — strongly
+  suggests a **near-field null / multipath fade near the pier**
+  rather than a range-limited WiFi link. As the boat cleared the
+  near-pier geometry, the directional WiFi antenna's main lobe
+  picked it up.
+- **RDP via VPN works but slow** at end of outbound leg (~500 m).
+- **End of line ~13:47 EDT** — boat turning for the inbound leg.
+
+Takeaway so far: failover to Starlink is transparent, and the
+WiFi limitation today appears to be **near-field**, not
+range-limited. The 2026-04-21 finding (good range past 300 m)
+is consistent with this.
+
+### 13:51 — Boat dropped to LOITER twice; suspected RC range
+
+- At the start of the inbound line, boat **dropped to LOITER**
+  (FCU failsafe mode).
+- Operator flipped to STANDARD/AUTONOMOUS in CAMP; boat resumed.
+- Quickly returned to LOITER again. Roland suspects **RC range
+  issues** — RC link from the operator transmitter is separate
+  from the IP comms (WiFi/Starlink) and has its own range
+  envelope.
+
+**Architectural implication for over-horizon ops**: comms over
+Starlink can survive arbitrary distance, but if the FCU enters
+LOITER on RC failsafe, the autonomy stack (cmd_vel via IP) can't
+drive the boat even though everything else is healthy. This is a
+real over-the-horizon blocker for any autonomous survey beyond
+RC range. Worth tracking under Goal 3's broader "what does the
+comms stack need to support over-horizon survey work" thread.
+
+Mitigation options worth thinking about (not for today):
+- RC failsafe behavior: configure to RTL/continue-mission instead
+  of LOITER, or extend the failsafe timeout
+- Better RC antenna / power
+- Decouple autonomy from RC entirely (RC strictly for manual
+  override at the operator's discretion, not a critical link)
+
+### 13:53 — RC stabilized by raising controller antenna; boat returning
+
+Stood the RC transmitter up and pointed its antenna **upward**;
+RC link stabilized and autonomy held. Boat is on the inbound
+leg, returning.
+
+**Field-confirmed RC mitigation**: holding the controller
+horizontally (antenna parallel to LOS to the boat) is the worst
+case for a vertical-dipole antenna pattern — there's a deep null
+along the antenna's long axis. Standing it up puts the boat in
+the antenna's main lobe (radial pattern). At 500 m this matters
+materially.
+
+Operational note: brief operators on antenna orientation, or
+stand the transmitter on a mount/tripod to remove the variable.
+
+### 13:59 — Goto overrides not responding; hover override DOES work
+
+Operator-issued **goto overrides from CAMP not being responded
+to**, but **hover override (stop-in-place) DID work**. Useful
+contrast — narrows the diagnosis significantly:
+
+- IP comms is fine (hover got through).
+- FCU isn't blanket-ignoring autonomy commands (hover took
+  effect).
+- Likely a **goto-specific** issue: a different code path,
+  different topic / mavros service, or a different FCU mode
+  prerequisite (goto may want GUIDED while hover works in
+  LOITER).
+
+Continuing the run; flagging for post-deployment log/bag review
+to find the divergence between the hover-success and goto-failure
+paths through CAMP → mavros → FCU.
+
+### 14:09 — Disabling RC failsafe for re-test
+
+Agent on **gabby** is setting `FS_THR_ENABLE = 0` via mavros so
+we can re-run the line without the RC failsafe dropping the boat
+to LOITER. With this disabled, the FCU should keep accepting
+cmd_vel from the autonomy stack regardless of RC link state.
+
+Safety net during re-test: GCS heartbeat failsafe
+(`FS_GCS_ENABLE`) and any active geofence are now the residual
+protections against runaway. Worth double-checking those are on
+before going further out.
+
+**Confirmed `FS_THR_ENABLE = 0`** read back from the FCU. RC
+failsafe disabled for the next test.
+
+### 14:15 — Failsafe configuration confirmed for over-horizon ops
+
+After discussion, today's failsafe stack is the right shape for
+autonomous over-horizon survey ops:
+
+- **`FS_THR_ENABLE = 0`** (RC failsafe off) — RC range is the
+  weakest comms link by far; we don't want it stopping the boat.
+- **`FS_GCS_ENABLE = 0`** (GCS heartbeat failsafe off) — comms
+  drops to operator (Starlink yellow-blinks, brief outages) are
+  expected on long-range ops; we don't want them triggering a
+  failsafe.
+- **GUIDED stale-setpoint HOLD** — already in place and observed
+  working in past Nav2 crashes. If cmd_vel stops, boat HOLDs.
+  This is the desired Nav2-crash failsafe.
+
+Net effect: comms loss → boat keeps going on the last cmd_vel;
+Nav2 crash → boat HOLDs. Matches the stated goal.
+
+### 14:18 — Re-test: longer mission, RC controller laid back down
+
+Sending boat on a slightly longer mission to test that
+`FS_THR_ENABLE = 0` is doing its job. Controller deliberately
+laid flat (worst-case RC antenna orientation, the same condition
+that triggered LOITER earlier). If the FCU now keeps following
+cmd_vel through that condition, RC failsafe is confirmed
+disabled.
+
+### 14:21 — Near-miss with a mooring ball — perception→costmap gap
+
+Boat **almost ran over a mooring ball**. Surface obstacle visible
+to cameras but no avoidance — segmentation output is **not being
+fed into the Nav2 costmap**, so the planner has no awareness of
+the obstacle. Manual operator intervention prevented contact.
+
+This is a **survey-readiness blocker**. Any autonomous survey
+will be in waters with mooring balls, other vessels, and debris —
+autonomy needs to incorporate camera perception into the costmap
+or operate in constant manual-override mode. Open as a tracked
+issue post-deployment.
+
+Likely components involved:
+- `unh_marine_perception` (segmentation models / pipelines)
+- Nav2 costmap layer (custom / external obstacle layer)
+- The bridge between perception output (likely PointCloud2 or
+  OccupancyGrid) and Nav2's costmap configuration.
+
+### 14:25 — RC failsafe disabled validated; boat at ~680 m, returning
+
+Boat reached **~680 m** out (well past the original 500 m
+target) on this longer mission, with the **controller laid
+flat** the entire time. No drop to LOITER — `FS_THR_ENABLE = 0`
+**confirmed working**.
+
+Boat is on the way back. Goal 3 has the validation it needed:
+RC range is no longer the binding constraint on autonomous
+range. Comms-side findings (Starlink failover, near-field WiFi
+null at the pier, RDP slow over Starlink) all stand.
+
+### 14:27 — RDP color-depth tradeoff: 16-bit slows M3 software severely
+
+Earlier test (note from Roland): setting **RDP color depth to
+16-bit** (instead of default 32-bit) was tried as a bandwidth
+optimization for the slow RDP-via-VPN over Starlink. **Severely
+slowed the M3 software** — reverted to 32-bit.
+
+Reasonable inference: the M3 software's waterfall / ping rendering
+likely depends on the full color depth or has a non-optimal
+fallback path for 16-bit clients. The RDP bandwidth savings
+(~50%) aren't worth the rendering hit on the M3 GUI.
+
+Operational takeaway: don't try to economize RDP bandwidth via
+color-depth reduction — find other levers (lower resolution,
+disable wallpaper/animations, etc.) if Starlink RDP needs
+optimization.
+
+### 14:28 — Starlink down
+
+Starlink link dropped. Now we're testing the *other* comms-path
+question: how the rig behaves with **Starlink gone and only
+WiFi** (or nothing).
+
+Key reassurance: with `FS_THR_ENABLE = 0` and `FS_GCS_ENABLE = 0`,
+the boat won't drop to LOITER from the comms loss itself.
+Autonomy runs on gabby (cmd_vel is on-boat), so the FCU keeps
+getting setpoints regardless of the operator link state.
+
+What to watch:
+- Does WiFi pick up the missing traffic, or are we operator-blind?
+- Does telemetry latency / video resume when Starlink comes back?
+- Boat is heading inbound from ~680 m — by the time it clears the
+  near-pier null we found earlier, WiFi should re-engage even if
+  Starlink stays down.
+
+### 14:30 — Choppy video still flowing — WiFi or cell, unclear
+
+With Starlink down, **enough packets are still making through to
+keep the video choppy-but-flowing**. Source unclear in the moment
+— could be:
+
+- **WiFi** — boat is inbound from ~680 m, may be re-engaging the
+  directional antenna's main lobe.
+- **Cellular fallback** — RUTX11 on the boat has cellular
+  capability; could be the LTE/5G modem picking up.
+
+Diagnosis post-deployment: check the per-interface tx/rx counters
+on the boat-side and operator-side routers, plus per-link
+udp_bridge stats, against the time window. Comms baseline finding:
+**at least three independent paths (WiFi, Starlink, cellular)
+appear to be in play**, all degrading gracefully rather than
+catastrophically.
+
+### 14:31 — Starlink back
+
+Starlink recovered. Outage was ~3 minutes (14:28 → 14:31). Boat
+behavior unaffected during the gap (autonomy is on-boat,
+failsafes off as configured). Choppy video over the alternate
+path bridged the operator's situational awareness during the
+gap.
+
+### 14:32 — Boat at end of line, hovering
+
+Boat reached the end of the inbound line and is **hovering**
+(holding position) — autonomy completed the longer mission as
+commanded. Goal 3 test sequence done.
+
+### 14:33 — Rebooting Starlink (pending install)
+
+Starlink had a pending install showing for a while — Roland
+rebooting it now to apply. May explain the earlier 14:28–14:31
+dropout if the install was attempted in-band; or unrelated.
+Boat is hovering, so a comms gap during the reboot is benign.
+
+### 14:35 — Starlink reboot command sent
+
+### 14:44 — Starlink monitor node stuck after dish reboot
+
+After the Starlink dish reboot, the **starlink monitor node on
+gabby stopped reporting** — apparently doesn't reconnect on its
+own when the dish goes away and comes back. Agent on gabby is
+restarting the node manually.
+
+Robustness gap to file: the monitor node should auto-reconnect
+to the dish gRPC endpoint after transient outages, not silently
+stop reporting. Worth a small follow-up issue / PR on
+`starlink_stats_ros`.
+
+### 14:45 — Starlink diagnostics reporting again
+
+After the manual node restart, Starlink diagnostics are flowing
+again. Confirmed the monitor node was the issue, not the dish
+itself. Reinforces the robustness-gap follow-up.
+
+### 14:58 — Multi-line track mission
+
+Sending BizzyBoat off on a **multi-line track**. Building on the
+single out-and-back: tests survey-pattern execution (turns,
+multiple line transitions) and accumulates more comms-baseline
+data over a longer duration.
+
+### 15:03 — Boat tracking 1.0 m/s vs commanded 1.5 m/s
+
+Speed shortfall: boat is making **~1.0 m/s** when commanded
+1.5 m/s. Candidate causes for post-deployment review:
+
+- **Current** — 44 min past slack toward 16:49 max ebb (2.05 kt,
+  085°T). Depending on line bearing, 0.25–0.5 kt loss is
+  plausible.
+- **Throttle saturation** — hull+prop may not be able to do
+  1.5 m/s in chop/SCA conditions. Check RC out / motor PWM
+  during the run.
+- **ArduPilot Rover speed cap** — `WP_SPEED` / `CRUISE_SPEED`
+  may be set lower than autonomy expects.
+- **Autonomy-side cap** — Nav2 controller/BT velocity limits.
+
+Easy field test: see if the shortfall is consistent across all
+line bearings (→ speed cap somewhere) or only on bearings
+against the ebb (→ current).
+
+### 15:03 — Passing a fishing boat (traffic context, no incident)
+
+BizzyBoat passing a fishing boat. Logging the moment for index
+purposes — useful if we later need to look up "when was the boat
+near another vessel". **Not a near-miss** and not adding a separate
+data point against the perception→costmap gap.
+
+### 15:07 — Manual ↔ autonomous switching via RC controller works
+
+Verified the RC controller can still switch manual ↔ autonomous
+modes. **Disabling `FS_THR_ENABLE` (RC failsafe) does NOT affect
+the manual-override switch** — operator's emergency takeover
+remains intact. Important to confirm; a common worry with
+disabling RC failsafe is losing the manual safety net, but the
+two are independent.
+
+### 15:08 — Boat out of direct line of sight 🌊
+
+BizzyBoat is now **out of direct sight** from the operator
+station — operating purely on telemetry / video / autonomy.
+This is the real "over-horizon" condition any autonomous survey
+beyond visual range will face. From here on, every successful
+command + healthy telemetry frame is a Goal 3 datum.
+
+### 15:09 — Boat in HOLD / hover, drifted back into sight; CAMP red→yellow
+
+BizzyBoat **drifted back into sight** and appears to be in
+**LOITER / HOLD** — autonomy stopped commanding forward motion.
+**CAMP went red briefly, then back to yellow.**
+
+Consistent with the **GUIDED stale-setpoint timeout** behavior
+we have in place: cmd_vel stopped flowing → FCU's HOLD kicked
+in → boat stops pushing forward → drifts on current. This is
+exactly the desired Nav2-crash failsafe shape.
+
+CAMP red → yellow suggests a **transient comms or node issue**
+that recovered, not a hard fault. Likely candidates (for
+post-deployment review):
+- Nav2 / autonomy node crash + auto-restart (if systemd is wrapping it)
+- DDS/RMW participant churn
+- A node that briefly stopped publishing a heartbeat
+
+Standing by to see if the autonomy resumes pushing or stays
+HOLDing.
+
+### 15:13 — CAMP didn't reflect Standby state — operator-side feedback gap
+
+Corrected interpretation of the prior event: Roland had pressed
+**Standby** in CAMP. The standby command **did take effect** —
+autonomy stopped commanding cmd_vel, FCU went into HOLD via the
+stale-setpoint timeout, then the boat drifted on current. **But
+CAMP's UI did not update to show the mode change**, so from the
+operator's view the boat appeared to be stuck/drifting for no
+visible reason.
+
+Operator then hit **Autonomous**, autonomy resumed, boat took
+off again — confirming the autonomy stack was healthy the whole
+time. The earlier hypothesis ("transient node crash + needed
+mode-cycle to recover") is wrong: the boat was correctly
+following the unseen mode change.
+
+**Real issue**: a **CAMP UI feedback gap** — the displayed mode
+diverges from the actual mode after a Standby press.
+
+Operator implications (now reframed):
+- Operators rely on CAMP's mode display to know what the boat
+  thinks it's doing. If the display is wrong, they'll make bad
+  decisions (assume crash, redo command, etc.).
+- Worth tracking down which CAMP topic / status indicator missed
+  the transition: is the mode-state subscriber wired correctly?
+  Is the Standby command actually publishing the corresponding
+  status update?
+- File a follow-up against the operator-tools repo to verify
+  CAMP's mode display reflects all Standby/Autonomous transitions
+  reliably.
+
+Failsafe-stack note: this also nicely demonstrates the GUIDED
+stale-setpoint HOLD doing its job — operator hit Standby, cmd_vel
+stopped, boat HOLDed cleanly (then drifted on current as a HOLD
+boat does without ground reference).
+
+### 15:15 — Boat going to LOITER at range despite FS_THR_ENABLE=0
+
+CAMP back to green. But boat is **still going to LOITER when out
+of range** — suspected RC-related but the exact cause is unclear
+because:
+
+- `FS_THR_ENABLE = 0` was confirmed earlier and validated at
+  680 m with controller flat (14:25 entry).
+- We did the longer-range run successfully without LOITER once
+  that change took.
+
+So either something about THIS distance / configuration changed,
+or the LOITER trigger isn't `FS_THR_ENABLE`. Other candidates:
+
+- **`FS_OPTIONS` bitmask** — Rover has additional failsafe
+  triggers separate from `FS_THR_ENABLE`. Worth checking what
+  bits are set.
+- **RC receiver-side failsafe** — the receiver (not the FCU) may
+  output a "throttle = stop" pulse train on signal loss, which
+  is interpreted by the FCU as a low-throttle command. This
+  bypasses `FS_THR_ENABLE` entirely.
+- **GUIDED stale-setpoint HOLD firing** — could be the autonomy
+  pipeline glitching at range (cmd_vel rate drops below
+  threshold), not an RC issue at all. Symptom would look the same
+  from the operator's view.
+- **Re-enabled by the standby/autonomous cycling** — if any of
+  those toggles re-armed a failsafe.
+
+Easy diagnostic post-deployment: bag review for `/mavros/state`
+mode transitions and `/mavros/rc/in` channel data correlated
+with the LOITER events. If RC channels show valid PWM but mode
+went to LOITER, it's not an RC-receiver issue.
+
+### 15:27 — Goto worked; boat back within range
+
+Operator issued a **goto override** and BizzyBoat **responded**
+— came back within visual range. Earlier 13:59 finding (goto not
+responding while hover did) was therefore situational — likely
+correlated with FCU mode state at the time. With autonomy
+healthy and FCU in GUIDED, goto works as expected.
+
+Useful contrast for the bag review: today we have *both*
+goto-success and goto-failure intervals to compare.
+
+### 15:30 — Goto is a temporary override; boat resumed the trackline
+
+After completing the goto, BizzyBoat **resumed the original
+trackline mission**. This is **by design** — goto in this
+autonomy stack is a temporary override, not a permanent
+re-target. Roland had forgotten this; worth flagging so it
+doesn't catch the next operator by surprise.
+
+Operator doc note: brief operators that **goto = "go there then
+resume"**, not "go there and stay". If they want the boat to
+hold at the goto target, they should issue Standby (or a hover
+override) once the boat arrives.
+
+### 15:31 — ~60 second latency in CAMP and images ⚠️
+
+Operator now seeing **~60 second latency** in CAMP telemetry and
+camera images. Way beyond usable for situational awareness — at
+this latency the operator can't react to surface obstacles
+(traffic, mooring balls) before they're already past.
+
+This is a major **Goal 3 finding**: over-horizon comms over
+Starlink can degrade to bandwidth-starved-but-not-dropped state,
+where packets keep arriving but a queue/buffer somewhere is
+adding ~1 minute of delay.
+
+Diagnosis candidates for post-deployment review:
+- **udp_bridge buffering** — check `*_bytes_per_second` (bytes,
+  not bits) per topic vs. encoded video bitrate; if image
+  topics are saturating link, queues build up.
+- **DDS / RMW buffer bloat** — Zenoh (current RMW per memory)
+  may queue messages internally if subscriber drains slower
+  than publisher publishes.
+- **Network buffer bloat** — Starlink router or intermediate
+  hop with deep queue.
+- **GStreamer pipeline depth** — if video is GStreamer-piped,
+  internal queue depth could be the source.
+
+Mitigations to consider:
+- Drop image rate / resolution dynamically when link is
+  bandwidth-constrained
+- Lossy queue policies (drop old frames rather than queue)
+- Topic budget cull (the "what survives over-horizon" question
+  flagged in #121's open questions)
+- udp_bridge per-topic rate limiting
+
+Boat continues autonomously; this is purely an operator-side
+problem.
+
+### 15:31 — CAMP back to green
+
+Latency cleared, CAMP back to green. The 60 s gap was transient
+— a queue drained or the link recovered enough capacity. Worth
+correlating with Starlink throughput / WiFi state in the bag.
+
+### 15:39 — New mission; theory on the LOITER trigger
+
+Sending BizzyBoat on another mission. Working theory on why we
+keep getting LOITER at fringe RC range despite `FS_THR_ENABLE = 0`:
+
+> The RC controller's **mode switch** is set to LOITER (or
+> equivalent). At fringe range the FCU reads the RC mode-switch
+> channel intermittently, sees a valid LOITER command, and
+> switches to LOITER **as commanded by RC**, not as a failsafe.
+
+This is consistent with the symptoms: `FS_THR_ENABLE = 0` only
+disables the *failsafe* path; it does not stop the FCU from
+honoring RC channel inputs that map to mode changes.
+
+If true, the fix is one of:
+- Move the controller's mode switch to AUTO/GUIDED so the
+  inadvertent reads command the right mode.
+- Disable the RC mode-switch channel entirely (set the
+  corresponding `RCx_OPTION` to 0 / no function).
+- Use `FLTMODE_*` params to map all switch positions to safe
+  modes from the autonomy POV.
+
+Will see what this run reveals.
+
+### 15:41 — Re-test: RC controller switched to MANUAL position
+
+Diagnostic re-test: **RC mode switch set to MANUAL** position.
+If the theory is right, fringe-range RC reads should drive the
+FCU to MANUAL (not LOITER) this time. Either way, expected to
+behave differently from the prior runs where the switch was in
+the position that produced LOITER. Watching for whether the boat
+goes to LOITER, MANUAL, or stays in autonomy.
+
+This is a diagnostic test only — MANUAL at fringe range would
+itself be problematic (RC channels are noise, autonomy not in
+control). Permanent fix is to either pin the RC mode switch in
+a safe position or remove its mode-switching capability.
+
+### 15:44 — Boat about to go out of sight (RC switch = MANUAL test)
+
+BizzyBoat approaching out-of-sight again. With the RC mode
+switch in MANUAL, this is the diagnostic moment — what does the
+FCU do at the same fringe-range condition that produced LOITER
+earlier?
+
+### 15:47 — Theory confirmed: boat went to MANUAL ✅
+
+**Confirmed** — at fringe range, BizzyBoat went to **MANUAL**
+this time. With the RC switch in MANUAL position instead of
+LOITER, the fringe-range mode change followed the switch
+position.
+
+**Definitive finding**: at fringe RC range, the FCU reads the RC
+mode-switch channel and **honors whatever mode the controller is
+set to**. `FS_THR_ENABLE = 0` only disables the *failsafe* path;
+it does **not** stop RC-channel mode commands from taking effect.
+
+This is durable knowledge — adding to memory.
+
+**Permanent fix options for autonomous ops**:
+- Pin the RC mode switch in a position that maps to AUTO/GUIDED
+  so fringe-range reads command the right mode (no behavior
+  change vs. autonomy operating).
+- Remove the RC mode-switch's mode-changing capability by
+  setting all `FLTMODE_*` params to AUTO/GUIDED, or by disabling
+  the mode-switch channel input via `RCx_OPTION = 0`.
+- Document which switch position is "safe" for autonomy and
+  brief operators to keep the controller there during
+  autonomous ops.
+
+### 15:48 — RC controller off entirely; resumed via USB controller
+
+Operator **turned off the RC controller entirely** (cleanest
+version of the "pin in safe position" mitigation) and cycled
+**standby ↔ autonomous on the USB controller** at the operator
+station to resume the mission.
+
+Pure test condition now: at fringe range, with no RC at all,
+the FCU should stay in whatever mode autonomy commands. Watching
+to confirm the LOITER/MANUAL behavior is gone with RC off.
+
+### 15:52 — Comms saturated again; RDP turned off to recover bandwidth
+
+CAMP and cameras all red. Operator turned off **RDP** (was
+running over VPN) to free bandwidth for the ROS topics.
+
+Operational finding: **RDP is a real bandwidth competitor** with
+the ROS telemetry / video stack over Starlink. For survey ops,
+either:
+- Don't run RDP during autonomous runs (turn off when link is
+  saturating).
+- Give RDP its own bandwidth budget / QoS class on the operator
+  router.
+- Train operators to suspend RDP when CAMP / cameras start going
+  red.
+
+Adds another data point to the topic-budget question: at
+over-horizon ranges Starlink is the only path with realistic
+bandwidth, and it's saturable.
+
+### 15:54 — Goto-back-to-port worked, boat returning
+
+Operator issued **goto back to port**, BizzyBoat **responding
+and returning**. Confirms:
+
+- Even with RDP off and the link freshly recovered, the goto
+  command got through cleanly.
+- Autonomy stack is healthy and acting on operator commands.
+- With RC powered off, the FCU stayed in autonomy mode through
+  the fringe range — no LOITER, no MANUAL. Permanent mitigation
+  validated.
+
+Mission winding down. Boat headed home.
+
+### 15:56 — Sending boat back out for more testing
+
+Roland sending BizzyBoat back out — more to test before
+wrapping up.
+
+### 16:04 — Out of sight again; latency growing in CAMP and video
+
+Boat going out of sight, **latency growing in CAMP and video**.
+Pattern matches earlier 60s-latency event — bandwidth-saturating
+even without RDP competing this time. Suggests the ROS topic
+stack alone (telemetry + video) is enough to saturate Starlink
+at over-horizon range, at least under current settings.
+
+Reinforces the topic-budget conclusion: for any over-horizon
+survey we **need** to cull what's published over the link or
+rate-limit high-bandwidth topics. RDP off helps but isn't the
+only lever.
+
+### 16:09 — SSH responsive while CAMP/cams stuck — pipeline bottleneck, not link
+
+**Important diagnostic data point**: at the same time CAMP and
+camera updates are stuck, **SSH into gabby via VPN is
+responsive**. So:
+
+- Starlink itself is alive and **fine for low-bandwidth /
+  latency-sensitive traffic**.
+- The choke is **inside the ROS / video pipeline**, not in the
+  link.
+
+Most likely culprits (post-deployment review candidates):
+- **udp_bridge** queue depth on a high-bandwidth topic backing
+  up everything else.
+- **Zenoh / DDS publisher** with internal buffering when
+  bandwidth-constrained.
+- **GStreamer pipeline** depth on the camera publishers.
+- **CAMP-side subscriber** struggling to drain at the rate
+  packets arrive.
+
+This is an actionable distinction — the fix isn't "more
+bandwidth" or "less stuff over the link" alone; it's also
+**queue policy in the pipeline** (drop-latest, lossy QoS,
+priority queues for telemetry vs. images).
+
+### 16:11 — gabby agent reports boat in hover
+
+Agent on gabby (which has direct, low-latency local access to
+the boat-side ROS state) reports **boat is in HOVER**. Whether
+that's an end-of-line hover, a GUIDED stale-setpoint HOLD from
+a cmd_vel hiccup, or something else will need bag review.
+
+Useful contrast with the operator-side view: gabby sees current
+state immediately, operator-side CAMP is still showing stale
+data. Confirms the bottleneck is operator-link-side, not
+boat-side.
+
+### 16:12 — gabby agent confirms goto reached the boat
+
+Operator issued **goto**; agent on gabby **confirms it took
+effect** on the boat-side, even while operator-side CAMP /
+cameras are still stale.
+
+Practical pattern emerging: **low-bandwidth commands and
+SSH-based status checks via the gabby agent are reliable when
+the rich operator UI is bandwidth-starved**. For over-horizon
+ops, this suggests a useful low-bandwidth status fallback — a
+text / heartbeat / minimal-telemetry path that survives when
+the video + full topic stream doesn't.
+
+Reassurance for over-horizon: even when the operator can't see
+the boat in real-time, **commands still get through and the
+autonomy still acts on them**. The link supports control even
+when it can't support situational awareness.
+
+### 16:13 — Boat back in sight; all green
+
+BizzyBoat back in sight from the operator station. **CAMP,
+cameras, all green** — bandwidth pressure resolved as the boat
+came back into WiFi-favorable range (or at least closer to a
+healthy Starlink window).
+
+### 16:21 — Deliberate WiFi-drop test
+
+Roland about to deliberately drop WiFi to characterize behavior
+when only Starlink (and possibly cellular) is available, with
+the boat at close range where the link should otherwise be
+healthy. Isolates the WiFi-vs-Starlink path question.
+
+### 16:22 — WiFi down result: CAMP green, cams blinking yellow
+
+With **WiFi deliberately down**, at close range:
+- **CAMP green** — telemetry flowing fine.
+- **Cameras blinking yellow** — video flowing with intermittent
+  packet loss / latency dips.
+
+So **Starlink alone is sufficient for full telemetry and
+mostly-OK video at close range**. Combined with earlier
+findings, the picture is:
+- Close range, Starlink only: works (with yellow on video).
+- Close range, WiFi + Starlink: green across the board.
+- Over-horizon, Starlink only (no WiFi reachable): bandwidth-
+  saturated → 60 s latency, all-red episodes.
+
+The over-horizon problem isn't "Starlink can't carry it" in the
+abstract; it's that **Starlink + the current ROS topic stack
+configured at full bandwidth saturates the link's effective
+throughput** under those conditions (link quality varies, queues
+build).
+
+### 16:24 — Same mission, no WiFi (Starlink-only run)
+
+Roland sending BizzyBoat on **the same multi-line mission as
+before, with WiFi off**. Controlled comparison: same survey
+shape, this time forced onto Starlink the entire time. Watching
+for whether the over-horizon saturation pattern repeats or
+behaves differently with the WiFi failover off the table.
+
+### 16:26 — Saturation already starting; ~30 s latency
+
+Going red, **~30 s latency** on the Starlink-only run, and the
+boat hasn't reached over-horizon yet. So the saturation isn't
+specific to fringe-range link degradation — it's the **ROS
+topic stack volume vs. Starlink's effective throughput** even
+under reasonable link conditions.
+
+Reinforces the topic-budget conclusion definitively:
+**bandwidth-cull is required**, not optional, for over-horizon
+survey ops. Adding paths (WiFi, cellular) helps mask the issue
+at close range but doesn't solve it at distance.
+
+### 16:26 — Aborting the run; returning the boat
+
+Operator attempting **abort + return**. With ~30 s latency and
+red comms, sensible recovery move — operator can't safely
+continue the mission without near-real-time situational
+awareness.
+
+### 16:28 — Boat returning; telemetry still stuck
+
+**Boat is returning** in response to the abort/return command,
+**but most operator-side telemetry is not updating**. Same
+pattern as before: low-bandwidth commands get through reliably
+even when high-bandwidth feedback doesn't.
+
+Operationally significant: the rig is **fault-tolerant in the
+control direction even when situational-awareness direction is
+broken**. Boat is coming home blind-from-the-operator's-side but
+under autonomous control. For survey ops, this is the
+worst-acceptable case — operators can recover the boat without
+reliable telemetry, but they can't *survey* without it.
+
+### 16:32 — Building updated udp_bridge on salmon and gabby
+
+Building an **updated `udp_bridge`** on both **salmon** (operator
+station) and **gabby** (boat side) — testing whether the new
+version's bandwidth / queue behavior addresses the saturation
+pattern we've been seeing today. Will retest once both sides are
+on the new build.
+
+### 16:37 — Restarting udp_bridge on gabby, all on salmon
+
+Build done. **Restarting `udp_bridge` only on gabby**
+(minimal-disruption — boat-side autonomy stays up); **restarting
+all on salmon** (full operator-side restart, simpler than picking
+nodes).
+
+### 16:40 — Bridge restarted on gabby; salmon waiting on screenshooter
+
+`udp_bridge` restart on gabby done. Salmon restart waiting on
+**screenshooter encoding** to complete (slow). The
+`screenshooter.bash` updates that landed in `ccomjhc_project11`
+this morning may be doing more work per shot — worth a look at
+whether it's regressed performance vs. the prior version (or
+the encoding settings need tuning).
+
+### 16:45 — Salmon ROS restarted; CAMP oscillating, latency 2–80 s
+
+After full ROS restart on salmon, CAMP is **oscillating green↔red**
+with **latency bouncing 2 s ↔ 80 s**. Roland's hypothesis:
+**queued packets still working their way home** — backlogs
+that built up during the saturation event are now draining
+unevenly.
+
+Plausible mechanisms:
+- **Network buffer bloat** at a router / Starlink queue, draining
+  in bursts.
+- **Application-level queue** in `udp_bridge` or DDS subscriber
+  that's still flushing what was held during the outage.
+- **DDS reliability behavior** — if any topics are on reliable
+  QoS, retransmits could be flooding to catch up.
+
+Whether this settles to steady-state green or stays
+oscillating after a few minutes will tell us whether the new
+`udp_bridge` build is meaningfully improved or still has the
+same saturation profile under load.
+
+### 16:47 — Forward camera not reaching operator after restart
+
+Only the **forward camera feed is missing** at the operator
+station — other camera feeds presumably still flowing. Specific
+to one topic / camera, so likely:
+
+- udp_bridge config: forward-camera topic mapping not picked up
+  on the new build (config schema change?)
+- Forward-camera publisher on gabby failed to come back after
+  the bridge restart
+- Topic name mismatch / namespace tweak between the operator-
+  side subscriber and boat-side publisher
+
+Quick diagnostics on gabby:
+- `ros2 topic list | grep forward` — is the topic publishing?
+- `ros2 topic hz <forward-cam-topic>` — is data flowing on-boat?
+- Compare udp_bridge config between previous and new build for
+  any schema / topic-list changes.
+
+### 16:49 — One frame trickled through; bridge saturation
+
+Got **one frame** of forward camera. So the path is alive — just
+**bridge-saturated**, frames trickling through one at a time.
+Wiring is correct (rules out config / topic-mapping issues from
+the previous entry); the same bandwidth-saturation pattern from
+earlier is still in play.
+
+So the new `udp_bridge` build didn't fundamentally fix the
+bandwidth saturation issue. Whether it improved queue behavior
+on the telemetry side (which seems somewhat better than the
+60 s episode) vs. just shifting the choke point is a question
+for bag analysis later.
+
+Today's Goal 3 takeaway is firm regardless of the bridge build:
+**bandwidth cull is required**, not just "use more paths" or
+"better queue policy".
+
+Note: 16:49 is also our predicted **max ebb of 2.05 kt at 085°T**.
+On-water conditions are likely the roughest of the day right
+now.
+
+### 16:51 — salmon udp_bridge: many discarded packets
+
+Salmon's `udp_bridge` reporting **many discarded packets**.
+
+This is **empirical confirmation** that the saturation isn't
+just queuing/latency — packets are actively being **dropped**.
+Useful in two ways:
+
+1. **Confirms saturation** as a hard quantitative finding, not
+   just a subjective "feels slow" observation.
+2. **The new bridge build is exposing this metric**, which is
+   itself a win — visibility into where data is being lost is
+   prerequisite for any rate-limiting / topic-budget design
+   work.
+
+Post-deployment: pull the discarded-packets counters per topic
+out of the bag (or live monitoring) to identify which topics
+are responsible for the bulk of the lost data. That's the input
+to the topic-budget cull.
+
+### 16:53 — Restarting core launch on salmon
+
+Roland restarting **core launch on salmon** for a clean slate
+on the operator side after the bridge restart and packet-drop
+state.
+
+### 16:53 — Same problems after the restart
+
+Restart didn't help — **same saturation / drop / latency
+pattern**. Confirms the issue isn't operator-side state
+buildup that a fresh start clears; it's **steady-state
+bandwidth saturation** for the current topic stack at the
+current link conditions. Restarts only temporarily flush
+queues — pressure rebuilds.
+
+Topic-budget cull is the path forward, full stop.
+
+### 16:55 — Code review on udp_bridge changes
+
+Reviewed PR #12 (merged 16:05 EDT today — same day as deployment).
+Major refactor: switch to MultiThreadedExecutor, mutex audit,
+per-topic QoS config, MessageInternal wire-format extension.
+
+Key finding: the **discarded packets aren't necessarily a PR #12
+regression**. The rate-limit-and-drop behavior pre-existed, with
+defaults and per-connection caps configured in
+`bizzyboat_project11/config/bizzyboat.yaml`:
+- WiFi: 1.5 MB/s (~12 Mbps)
+- VPN (Starlink): 1.0 MB/s (~8 Mbps)
+
+Today's multi-camera + full telemetry stack exceeds 1 MB/s, so
+on Starlink the configured rate limit is hit and the bridge
+**drops by design**. PR #12 may be making this more visible
+(diagnostics counters), not creating it.
+
+PR #12 specific items still worth bisecting if drops persist
+after raising the cap:
+- MultiThreadedExecutor + new locking (`sent_packet_statistics_mutex_`
+  serializes sends; could reduce throughput under load).
+- MessageInternal wire-format change — requires coordinated build
+  on both sides; mismatch = silent packet loss.
+- Per-topic QoS resolution — new code path, possible bugs
+  causing QoS mismatches that drop messages.
+
+Recommended diagnostic order:
+1. Verify both sides are on the same `udp_bridge` build (md5sum).
+2. Bump VPN rate limit (e.g. 4 MB/s) and see if drops disappear.
+   If yes → it's the configured cap; topic-budget cull is the
+   right answer. If no → likely PR #12 regression in
+   MultiThreaded/locking paths; bisect against pre-PR-#12 build.
+
+### 16:58 — Full stack restart on gabby
+
+Operator restarted the **whole stack on gabby** — full clean
+slate on the boat side. Confirms gabby is on the new build
+(no cached install confusion). Watching to see if saturation
+pattern changes from this baseline.
+
+### 17:00 — Same behavior after both-side fresh restart
+
+After clean restart on both salmon and gabby, **same saturation
+behavior**. So the pattern is **steady-state**, not residual
+buffering / queue state. Eliminates "leftover queues" as a
+cause; doesn't distinguish between:
+- 1 MB/s VPN rate limit being hit (config), or
+- PR #12 regression in effective throughput (locking /
+  multi-threaded scheduling).
+
+Diagnostic next step (when ready): **temporarily bump VPN
+rate limit** in `bizzyboat.yaml` (e.g., to 4 MB/s) and
+relaunch the bridge. If drops disappear → it's the configured
+cap; topic-budget cull is the right path. If drops persist →
+likely PR #12 regression; bisect against pre-PR-#12 build.
+
+### 17:00–17:20 — Bridge cap bumped to 2.5 MB/s, didn't help
+
+Bumped VPN rate limit from 1 MB/s to **2.5 MB/s**. **Drops /
+saturation persisted**. Working theory shifted from "configured
+cap is the binding constraint" to:
+
+The default ROS **subscriber QoS depth of 10** — fine pre-PR-#12
+when the bridge processed messages quickly under the
+single-threaded executor — may now be the binding constraint
+under PR #12's MultiThreadedExecutor + new mutex serialization
+in `send()`. Per-message processing is slower under load, so the
+depth-10 ROS subscription queue fills before the bridge drains
+it; ROS drops at the QoS layer **upstream of the bridge's own
+rate-limit counter**. That explains why bumping the rate cap
+didn't help — those drops aren't in the rate-limiter's counter.
+
+Mitigations to try next:
+- Bump subscriber depth in per-topic QoS config (PR #12 added
+  this; schema in `qos_design.md`).
+- Switch high-bandwidth topics to BEST_EFFORT + larger depth.
+- Bisect against pre-PR-#12 build to confirm regression.
+
+### 17:21 — Plugged WiFi back in
+
+Operator restored WiFi at the operator station. Back to dual-path
+WiFi + Starlink. Should provide more bandwidth headroom and let
+us see if behavior is markedly different with WiFi back in
+play vs. the Starlink-only run we just had.
+
+### 17:23 — WiFi back didn't help; possibly worse
+
+Adding WiFi back **didn't fix anything; possibly made it
+worse**. Reinforces the QoS-depth / bridge-processing-rate
+regression hypothesis: if the bottleneck is **per-message
+processing in the bridge** (lock contention under
+MultiThreadedExecutor), no amount of additional bandwidth
+helps — the bridge can't drain its inbound subscriber queue
+fast enough.
+
+Adding more paths also makes the bridge do more work
+(maintaining two connections, sending to both), which would
+*slow* per-message processing further. Worse-than-Starlink-only
+fits this picture.
+
+Strongest remaining diagnostic step is the **bisect**: revert
+one side to pre-PR-#12 build (commit `97cfb2b` or earlier) and
+see if the saturation pattern changes. Definitive answer on
+"PR #12 regression vs. fundamental bandwidth limit". Probably
+worth doing as a controlled bench test rather than during
+field ops.
+
+### 17:34 — gabby agent fix landed; remaining issue is QoS mismatches in CAMP
+
+gabby agent applied a fix that **addresses the saturation
+behavior** — drops / latency now look workable. Detail of the fix
+in the gabby-side log.
+
+New observation: **QoS mismatches appear to be causing some
+CAMP subscriptions to not receive data**, even when the bridge
+is forwarding the topic. This is consistent with the PR #12
+per-topic QoS config picking different reliability/depth/durability
+settings than CAMP's subscribers expect. Symptoms would be
+"topic appears in `ros2 topic list` but `ros2 topic echo` shows
+nothing" or CAMP UI elements stale despite publisher healthy.
+
+Common QoS-mismatch failure modes worth checking:
+- **Reliability**: bridge republishing as BEST_EFFORT while CAMP
+  subscribes as RELIABLE → no match → no delivery.
+- **Durability**: bridge VOLATILE vs. CAMP TRANSIENT_LOCAL on
+  latched topics (e.g., diagnostics aggregator, parameters) →
+  late joiners get nothing.
+- **Depth**: less catastrophic but can drop messages under burst.
+
+Worth grepping CAMP's subscribers for explicit QoS profiles and
+comparing to whatever the bridge republishes per the new
+per-topic QoS config.
+
+### 18:14 — Things working again
+
+System recovered to a working state. Detailed write-up to follow
+— Roland will provide specifics later. Anchoring the milestone
+in the timeline now.
+
+### 18:14 — Re-test: WiFi off again (Starlink-only with the fixes in place)
+
+Roland turning WiFi off again to retest the Starlink-only
+configuration with the udp_bridge fixes that just got things
+working. Apples-to-apples comparison vs. the earlier
+Starlink-only run that hit 30 s latency / red CAMP /
+massive drops.
+
+### 18:18 — Heartbeat oscillating fresh ↔ ~30 s stale
+
+CAMP heartbeat is **alternating between fresh packets and
+~30 s old packets**, even with operator-side WiFi physically
+unplugged. So this isn't dual-path routing on the
+operator side.
+
+**Resend window finding** (relevant to ruling out one
+hypothesis): looked at
+`udp_bridge/src/remote_node.cpp::getMissingPackets()` —
+- Tracking window: 5 s (`too_old = now - Duration::from_seconds(5.0)`).
+- Resend rate-limit: 0.2 s.
+
+So the resend layer's window is **5 s**, not 30 s. Packets
+older than 5 s are dropped from tracking entirely — the
+resend mechanism alone cannot produce 30-second-old packet
+deliveries. Rules out "stale resend re-arrival" as the
+cause.
+
+**Two remaining theories** (to disambiguate post-deployment):
+
+1. **Cellular fallback on the boat router** — RUTX11 LTE
+   egress could still be routing traffic in parallel with
+   Starlink. Operator-side WiFi unplugged doesn't
+   constrain the boat side's path choice. Verify by
+   checking RUTX11 cellular interface tx/rx counters
+   during the alternation.
+
+2. **Bridge dest-publisher's RELIABLE-buffer wedge** —
+   exactly the issue-#10 mechanism qos_design.md warns
+   about. Bridge `BEST_AVAILABLE` × CAMP default RELIABLE
+   → publisher behaves RELIABLE → buffers messages on
+   subscriber back-pressure. Brief CAMP-side stalls
+   (Qt redraws, repaints) accumulate a backlog; when
+   subscriber catches up, the backlog drains, delivering
+   ~30 s-old messages alongside fresh ones.
+
+Theory 2 is exactly the failure mode that switching CAMP's
+subscribers to `reliability_best_available()` would
+resolve.
+
+### 18:19 — Operational gap: need a VPN-path indicator
+
+We've spent a lot of today's diagnostic time guessing whether
+the VPN traffic was on Starlink or cellular at any given
+moment. **Need a live indicator** showing which underlying
+path the VPN is using, surfaced in CAMP. Captured as a
+follow-up — see "Follow-ups (not for today)" section.
+
+### 18:22 — Operational gap: need a bench stress-test rig
+
+Today made it painfully clear that we can't reproduce the
+bridge / CAMP failure modes on the bench. Every debugging
+iteration cost a real boat run. Captured a follow-up to
+build a synth-topic + mininet + CAMP-stub harness so the
+next regression / tuning question can be answered at the
+desk, not in the field. See "Follow-ups (not for today)".
+
+### 18:42 — Boat recovered ⚓
+
+BizzyBoat **out of the water and recovered**. End of on-water
+operations for 2026-05-01. ~5 hours on-water (13:36 launch →
+18:42 recovery).
+
+## Active threads
+
+- **IzzyBoat parity tracker** ([#120](https://github.com/rolker/unh_echoboats_project11/issues/120))
+  — opened today, captures bizzy-only fixes pending batched migration to
+  IzzyBoat. First entry is the mavros `child_frame_id` fix from PR #98.
+
+## Follow-ups (not for today)
+
+- **Set up UDP ZDA to the M3 head** (`192.168.1.234:31100`) — required
+  per M3 reference manual for actual head-level 1PPS sync. Today's
+  serial path feeds only the M3 software, not the head. Source can
+  reuse the gabby ZDA generator built today.
+- **VPN path indicator (Starlink vs. cellular)** — operators need a
+  live indicator showing which underlying path the VPN traffic is
+  currently using. Today's "is it Starlink? is it cell?" was a
+  significant diagnostic gap. Implementation candidates: a small
+  ROS node that polls the RUTX11 (or boat router's API / interface
+  counters / routing table) and publishes a `current_wan_path` topic;
+  CAMP displays the current value. Post-deployment scope.
+- **Bench stress-test rig for udp_bridge + CAMP simulation** —
+  today's saturation / queue / QoS debugging would have been
+  much faster on a controlled bench. Need a harness that:
+  (1) synthesizes a realistic topic stack on the publisher side
+      (boat-side load: cameras, mavros, segmentation, telemetry),
+  (2) routes through `udp_bridge` over a constrained link
+      (mininet + `tc` for rate / latency / loss; existing mininet
+      setup at `udp_bridge/test/mininet/` is a starting point),
+  (3) simulates CAMP's subscriber set and QoS profiles on the
+      operator side (stub node, not the real Qt UI), and
+  (4) reports drops / latency / queue depth / per-topic delivery
+      against expected.
+  Allows reproducing today's regression hypotheses (PR #12
+  MultiThreadedExecutor + locking, BEST_AVAILABLE → RELIABLE
+  wedge, etc.) under controlled conditions instead of during
+  field ops. Significant post-deployment work item.
+- **Clarify lever-arm direction wording in `hydro_payload_install_log.md`**
+  — the 2026-04-22 entry labels the CoR lever arm "IMU lever arm
+  from vehicle origin" with negative values, but the actual sbgCenter
+  field (and the device's stored value) is "from IMU to CoR" with
+  positive values. The numbers on the device are correct; the doc's
+  label needs to match the device's direction so future readers
+  don't chase a phantom sign mismatch.
+- **Update sonar-architecture memory** once the post-fix path is
+  validated in the field. The current `project_bizzyboat_sonar_architecture.md`
+  and `project_kongsberg_m3.md` memories describe ZDA as
+  QINSy → UDP 31100 → M3 head IP; the QINSy source is being replaced
+  by a non-QINSy emitter, but the **destination** (UDP 31100 to head)
+  stands per the manual. Update once both PPS-edge and UDP-ZDA-to-head
+  are confirmed working together via Output Messages.
+
+## Lessons Learned
+
+### M3 1PPS sync requires explicit Time Sync Mode = 1PPS in Device Properties
+
+The M3 software's green "SYNC OK" indicator does **not** mean
+1PPS is locked — it lights up as long as the software has any
+valid time input (e.g., ZDA on the serial port). For the head to
+actually count and use 1PPS edges, **Device Properties → Sonar
+Setup → Time Sync Mode** must be explicitly set to **1PPS**. The
+default is not 1PPS.
+
+Verification path: Display → Output Messages Window. Working sync
+shows `INF 1PPS: 10 pulses received in 10s` plus paired
+`INF PPS preLDINF ZDA: ...` and `INF PPS <timestamp>s ...` lines.
+A green SYNC OK with zero `1PPS` log lines is the smoking-gun
+symptom that the dropdown wasn't switched.
+
+Working SBG-side config (Ellipse-D + sbgCenter): Input/Output →
+Events → Event Out A → 1PPS, rising edge, 500 ms pulse duration.
+
+### RC mode-switch position commands FCU mode at fringe RC range
+
+`FS_THR_ENABLE = 0` only disables the RC *failsafe* path; it does
+not stop the FCU from honoring RC-channel-commanded mode changes.
+At fringe RC range, the FCU intermittently reads the mode-switch
+channel and switches to whatever the controller is set to (LOITER,
+MANUAL, etc.). For any autonomous operations beyond comfortable
+RC range — survey lines, transit, over-horizon work — pin the RC
+controller's mode switch to a position that maps to AUTO/GUIDED
+(so inadvertent reads command the right mode), or disable the
+mode-switching channel via FCU params. Cleanest mitigation tested
+today: power off the RC controller entirely; the FCU then has no
+RC input to act on and stays in autonomy mode through full
+distance.
+
+### Failsafe-path stack for autonomous survey ops (verified today)
+
+- `FS_THR_ENABLE = 0` — RC failsafe off. RC range is the weakest
+  comms link by far; we don't want it stopping the boat during
+  autonomous runs.
+- `FS_GCS_ENABLE = 0` — GCS heartbeat failsafe off. Comms drops
+  to operator (Starlink yellow-blinks, brief outages) are expected
+  on any non-trivial survey; we don't want them triggering a
+  failsafe. Note: with mavros running on gabby, this protects
+  gabby↔FCU rather than operator↔boat anyway.
+- **GUIDED stale-setpoint HOLD** is the desired Nav2-crash
+  failsafe — observed working when cmd_vel publication stops,
+  boat HOLDs cleanly.
+
+Net effect: comms loss → boat continues last cmd_vel; Nav2 crash
+→ boat HOLDs. Geofence + manual-override RC remain as safety
+backstops.

--- a/docs/logs/2026/2026-05-01_dev_logs.md
+++ b/docs/logs/2026/2026-05-01_dev_logs.md
@@ -1429,17 +1429,50 @@ build a synth-topic + mininet + CAMP-stub harness so the
 next regression / tuning question can be answered at the
 desk, not in the field. See "Follow-ups (not for today)".
 
+### ~18:40 — Max-reverse-speed measurement (pre-recovery)
+
+Just before recovery, Roland commanded **full reverse for several
+seconds, long enough to reach steady-state speed**. Intent: capture
+a clean max-reverse-speed datum for the BizzyBoat performance
+record. Number itself wasn't read off the operator UI in the
+moment — it lives in the bag. Follow-up to extract from
+`local_position/velocity_local` (or SBG nav) for the relevant
+window and add to `bizzyboat_project11/docs/bizzyboat_hardware.md`
+(or wherever boat performance specs live).
+
 ### 18:42 — Boat recovered ⚓
 
 BizzyBoat **out of the water and recovered**. End of on-water
 operations for 2026-05-01. ~5 hours on-water (13:36 launch →
 18:42 recovery).
 
+### 19:42 — Field changes imported
+
+`/import-field-changes` ran. 4 field-side branches imported as
+issues + draft PRs:
+
+| Repo | Issue | PR |
+|---|---|---|
+| camp | [#50](https://github.com/rolker/camp/issues/50) | [#51](https://github.com/rolker/camp/pull/51) |
+| udp_bridge | [#15](https://github.com/rolker/udp_bridge/issues/15) | [#16](https://github.com/rolker/udp_bridge/pull/16) |
+| marine_tools | [#8](https://github.com/rolker/marine_tools/issues/8) | [#9](https://github.com/rolker/marine_tools/pull/9) |
+| unh_echoboats_project11 | [#122](https://github.com/rolker/unh_echoboats_project11/issues/122) | [#123](https://github.com/rolker/unh_echoboats_project11/pull/123) |
+
+12 total commits across the 4 repos, no diverged branches, no
+pre-review findings requiring fixes. All draft, ready for Copilot
+review.
+
 ## Active threads
 
 - **IzzyBoat parity tracker** ([#120](https://github.com/rolker/unh_echoboats_project11/issues/120))
   — opened today, captures bizzy-only fixes pending batched migration to
   IzzyBoat. First entry is the mavros `child_frame_id` fix from PR #98.
+- **Post-mission data review** ([#124](https://github.com/rolker/unh_echoboats_project11/issues/124))
+  — opened post-recovery, tracks the bag-analysis follow-up work
+  (networking, performance specs, BT forensic, SBG-vs-FCU
+  comparison, sonar / time-sync, perception, comms-loss recovery,
+  operator UX). Done in a separate issue so #121's wrap-up PR isn't
+  blocked by analysis work.
 
 ## Follow-ups (not for today)
 
@@ -1454,6 +1487,47 @@ operations for 2026-05-01. ~5 hours on-water (13:36 launch →
   ROS node that polls the RUTX11 (or boat router's API / interface
   counters / routing table) and publishes a `current_wan_path` topic;
   CAMP displays the current value. Post-deployment scope.
+- **PR merge order for today's field imports**: target order is
+  (1) [rolker/marine_tools#9](https://github.com/rolker/marine_tools/pull/9)
+  (provides `zda_serial_bridge`),
+  (2) [rolker/udp_bridge#16](https://github.com/rolker/udp_bridge/pull/16)
+  (bridge fixes that motivate the YAML tuning),
+  (3) [rolker/camp#51](https://github.com/rolker/camp/pull/51)
+  (operator-side QoS fix, depends on udp_bridge default change),
+  (4) [rolker/unh_echoboats_project11#123](https://github.com/rolker/unh_echoboats_project11/pull/123)
+  (workspace-side config / launch wiring that depends on all of the
+  above). #121 wrap-up PR (still TBD in this worktree) lands
+  separately and is not blocked by this chain.
+- **Extract max reverse speed from today's bag** (~18:40 entry).
+  Pull steady-state speed magnitude from
+  `local_position/velocity_local` (or SBG nav) during the full-
+  reverse window and add the number to
+  `bizzyboat_project11/docs/bizzyboat_hardware.md` (or the
+  appropriate performance-specs doc) so it's referenceable.
+- **BT `SkipUnknownTaskType` catchall fix** (gabby log §11).
+  ReactiveFallback can't distinguish "no script condition matched"
+  from "matching subtree's execution failed" — the catchall fires
+  on action ABORTs and marks the trackline done. Today's 15:09
+  "boat in HOLD" episode is the forensic match. See gabby §11
+  carry-forward for suggested fixes; needs an issue against
+  whichever repo owns the run_tasks.xml / mission_manager BT.
+- **Kernel UDP receive-buffer sysctl tuning** (gabby log §9).
+  Apply the recommended `net.core.rmem_default` /
+  `net.ipv4.udp_rmem_min` / `net.core.netdev_max_backlog` values
+  to a new `/etc/sysctl.d/31-udp-buffers.conf` on gabby (and any
+  other UDP receiver host); verify per the §9 protocol. Also worth
+  an upstream `udp_bridge` change to call
+  `setsockopt(SO_RCVBUF, ...)` explicitly so it doesn't depend on
+  system default.
+- **Document the FCU/SBG altitude convention** (gabby log §2.7).
+  The two units agree to within 11 cm at WGS84 ellipsoidal, but
+  the apparent ~33 m gap on MSL is a vertical-datum convention
+  difference (SBG MSL output vs. FCU ellipsoidal default in
+  `NavSatFix`). Residual ~4.8 m MSL-vs-MSL is two different geoid
+  models (FCU EGM2008 vs. SBG closer to EGM84/96). Add a
+  documentation note to the SBG-vs-FCU comparison work product so
+  downstream consumers (chart-datum, tide-corrected pipelines)
+  pick a single common reference and apply it consistently.
 - **Bench stress-test rig for udp_bridge + CAMP simulation** —
   today's saturation / queue / QoS debugging would have been
   much faster on a controlled bench. Need a harness that:
@@ -1484,6 +1558,90 @@ operations for 2026-05-01. ~5 hours on-water (13:36 launch →
   by a non-QINSy emitter, but the **destination** (UDP 31100 to head)
   stands per the manual. Update once both PPS-edge and UDP-ZDA-to-head
   are confirmed working together via Output Messages.
+
+## Cross-references to field logs
+
+Field-side detail for many of today's events lives in the gabby
+and salmon per-host logs (per the per-host log convention). Both
+land via [rolker/unh_echoboats_project11#123](https://github.com/rolker/unh_echoboats_project11/pull/123).
+
+- [`2026-05-01_gabby_logs.md`](./2026-05-01_gabby_logs.md) — 1337 lines
+- [`2026-05-01_salmon_logs.md`](./2026-05-01_salmon_logs.md) — 197 lines
+
+### gabby log — sections relevant to events here
+
+- **§1 ZDA serial bridge for M3 sonar wall-clock** — design + implementation
+  of `zda_serial_bridge`. Underpins our 10:40 / 10:41 timeline entries.
+  Final package shipped in [rolker/marine_tools#9](https://github.com/rolker/marine_tools/pull/9).
+- **§2 SBG-vs-FCU nav comparison readiness** (§§2.1–2.8) — full underpinning
+  of our 11:54 / 12:30 entries on Goal 2:
+  - §2.1 Logger gap (`mavros/local_position/*` was missing from bag config),
+    fix in [#123](https://github.com/rolker/unh_echoboats_project11/pull/123).
+  - §2.2 ZDA launch-arg collision regression and fix.
+  - §2.3 Live frame-ID survey of all bridged nav topics.
+  - §2.5 SBG cable repair window — quiet pier-side window during cable swap.
+  - §2.6 Position sample at the dock.
+  - **§2.7 Altitude convention — different geoid models**. *New finding*:
+    the apparent 33 m vertical gap between FCU and SBG was almost entirely
+    a vertical-datum convention difference (SBG MSL vs. FCU ellipsoidal),
+    not a sensor disagreement. Once both are converted to WGS84
+    ellipsoidal, FCU and SBG agree to **within 11 cm**. A residual
+    ~4.8 m MSL-vs-MSL gap reflects different geoid models (FCU EGM2008
+    vs. SBG closer to EGM84/EGM96). Practical: post-process at WGS84
+    ellipsoidal, and don't mix SBG MSL with FCU MSL. Needs durable
+    documentation as part of the SBG-vs-FCU comparison work.
+  - §2.8 Attitude sample at the dock.
+- **§3 Camera bandwidth audit + tweaks** — bitrate / topic-list changes
+  imported in [#123](https://github.com/rolker/unh_echoboats_project11/pull/123).
+- **§4 FCU `FS_THR_ENABLE = 0`** — context for our 14:09 / 14:15 entries.
+- **§5 Network egress check + Starlink diag stall** — context for our 14:44
+  starlink_stats_ros monitor stall.
+- **§6 FCU failsafe audit (snapshot)** — full FCU param snapshot.
+- **§7 RC mode switch latching FCU into Loiter** — root-cause analysis
+  for our 15:47 entry (channel-5 mode-switch breakdown in §7.1).
+- **§8 Network resilience — out-of-sight ops + WiFi-drop test** —
+  supports our 16:21 / 16:22 entries.
+- **§9 Kernel UDP receive-buffer drops — 17k since boot**. *New finding,
+  not in this log.* Kernel-level drops at the socket-buffer handoff
+  (~0.69 % of UDP receives) — separate layer from bridge / QoS drops.
+  Recommended sysctl tuning + verification protocol included; landing
+  spot `/etc/sysctl.d/31-udp-buffers.conf`. Also flags app-level
+  `setsockopt(SO_RCVBUF, ...)` for udp_bridge.
+- **§10 `udp_bridge` is a `LifecycleNode` — restart procedure**.
+  Operational knowledge: the right way to restart a bridge that's in
+  a degraded state without losing the lifecycle context.
+- **§11 BT design issue — `SkipUnknownTaskType` masks execution
+  failures**. *New finding* and **likely the real cause of our 15:09
+  "boat in HOLD" episode**, not the operator-pressed-Standby
+  hypothesis we landed on in the moment. Mechanism: FollowPath
+  ABORTED → SurveyLineTask sequence failed → ReactiveFallback fell
+  through → `SkipUnknownTaskType` catchall fired and **marked the
+  trackline done despite the abort** → only remaining task was
+  `done_hover` → boat fell into hover. Operator-side CAMP could
+  legitimately have shown stale Standby state on top of this — both
+  things can be true — but the BT-side mechanism is the durable
+  bug. See §11 for the suggested fixes.
+- **§12 udp_bridge throughput regression — root-caused + Reentrant
+  fix** — full source-level diagnosis behind our 17:34 "gabby agent
+  fix landed" entry. Also the basis for the
+  [rolker/udp_bridge#16](https://github.com/rolker/udp_bridge/pull/16)
+  field import.
+
+### salmon log — sections relevant to events here
+
+- **§1 Symptom and graph snapshot** — CAMP not seeing nav streams from
+  the boat after the udp_bridge QoS rework deployed mid-day.
+- **§2 Root cause hypothesis** — BEST_EFFORT subscribers failing to
+  match BEST_AVAILABLE publishers under `rmw_zenoh_cpp` 0.2.9
+  (the keyexpr bug surfaced in
+  [rolker/udp_bridge#16](https://github.com/rolker/udp_bridge/pull/16)).
+- **§3 Workaround on CAMP** — `SensorDataQoS().reliability_best_available()`
+  on seven NavSource subscribers (now in
+  [rolker/camp#51](https://github.com/rolker/camp/pull/51)).
+- **§4 Bridge fix — switch resolver default to RELIABLE** — the
+  keyexpr workaround in udp_bridge (now in
+  [rolker/udp_bridge#16](https://github.com/rolker/udp_bridge/pull/16)).
+- **§5 Session wrap-up**.
 
 ## Lessons Learned
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ visible from one place.
 
 ### Sensor payload integration (M3 + SBG + SVS on mercat)
 
-- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP. *Software pipeline live end-to-end as of 2026-04-27 (#94); first surveys recorded.*
+- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP. *Software pipeline live end-to-end as of 2026-04-27 (#94); first surveys recorded. M3 1PPS time-sync chain completed 2026-05-01 (#121) — after discovering that the M3 software's Device Properties → Time Sync Mode dropdown was the real gating switch, not the cable / SBG / pulse parameters that occupied most of the morning. QINSy SBG hookup live (position + attitude + heading + heave + GPS QC).*
 - [`unh_echoboats_project11#77`](https://github.com/rolker/unh_echoboats_project11/issues/77) — physical install, offsets, URDF, SVG diagram
 - [`rolker/marine_tools#1`](https://github.com/rolker/marine_tools/issues/1) — QINSy → ROS bridge for coverage / sounding feedback
 
@@ -43,13 +43,13 @@ visible from one place.
 - [`rolker/unh_marine_navigation#24`](https://github.com/rolker/unh_marine_navigation/issues/24) — wire BT `target_speed` → nav2 `/speed_limit` (per-task survey speed); deployment 2026-04-27 worked around with shared `default_speed` bump
 - [`unh_echoboats_project11#96`](https://github.com/rolker/unh_echoboats_project11/issues/96) — BizzyBoat-specific nav2 params override (decouple from seafloor echoboat defaults)
 
-### Both nav systems report at base_link *(new theme — 2026-04-29)*
+### Both nav systems report at base_link *(theme — 2026-04-29; major progress 2026-05-01)*
 
-The 2026-04-29 in-water bag exposed that neither the SBG nor the FCU is reporting position at `base_link` — each publishes at its own GNSS antenna (0.64 m fore-aft body-frame offset between them). The URDF doesn't model the SBG IMU/antennas at all, and the EKF3-fused mavros streams aren't being recorded, so cross-checks have to fall back to downstream `/bizzy/odom`. These three issues are a unit: pick a contract, model the geometry, and capture the streams that prove it's working.
+The 2026-04-29 in-water bag exposed that neither the SBG nor the FCU was reporting position at `base_link` — each published at its own GNSS antenna (0.64 m fore-aft body-frame offset between them). The URDF didn't model the SBG IMU/antennas, and the EKF3-fused mavros streams weren't being recorded, so cross-checks had to fall back to downstream `/bizzy/odom`. These three issues are a unit: pick a contract, model the geometry, and capture the streams that prove it's working.
 
-- [`unh_echoboats_project11#110`](https://github.com/rolker/unh_echoboats_project11/issues/110) — model SBG INS, GNSS antenna(s), and IMU mounting alignment on bizzyboat (URDF gap)
-- [`unh_echoboats_project11#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) — define lever-arm/base_link contract for SBG and mavros position streams (decision + implementation)
-- [`unh_echoboats_project11#112`](https://github.com/rolker/unh_echoboats_project11/issues/112) — record `mavros/global_position/global` + EKF3-fused `local_position/*` + `altitude` (recording-only; lets the next deployment verify the contract holds)
+- [`unh_echoboats_project11#110`](https://github.com/rolker/unh_echoboats_project11/issues/110) — model SBG INS, GNSS antenna(s), and IMU mounting alignment on bizzyboat (URDF gap). **Still open** — today's fixes addressed the *config* side; the URDF gap (no SBG body / Trimble antennas modeled) remains.
+- [`unh_echoboats_project11#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) — define lever-arm/base_link contract for SBG and mavros position streams. **Resolved live 2026-05-01** — the SBG sbgCenter Output Location was the missing config; with it set, both SBG and FCU now report at `base_link`. gabby agent confirmed agreement live; quantitative verification is post-mission ([#124](https://github.com/rolker/unh_echoboats_project11/issues/124)).
+- [`unh_echoboats_project11#112`](https://github.com/rolker/unh_echoboats_project11/issues/112) — record `mavros/global_position/global` + EKF3-fused `local_position/*` + `altitude`. **Fixed in [#123](https://github.com/rolker/unh_echoboats_project11/pull/123)**, awaiting merge.
 
 ### Class-ready operator UI
 
@@ -72,7 +72,32 @@ Multiple network-layer issues surfaced during the same long deployment day: udp_
 
 - [`rolker/udp_bridge#10`](https://github.com/rolker/udp_bridge/issues/10) — bridge wedges (reader thread blocked, Recv-Q backup) when remote subscriber dies
 - [`rolker/udp_bridge#9`](https://github.com/rolker/udp_bridge/issues/9) — resend loop amplifies traffic (earlier related)
+- [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) — *(2026-05-01)* forwarding-throughput regression from PR #12 + `rmw_zenoh_cpp` 0.2.9 BEST_AVAILABLE keyexpr workaround
+- [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) — *(2026-05-01)* operator-side QoS fix complementing the bridge default change
 - *(future)* End-of-day network pathology root-cause work — open once we have more signal from a future deployment with op-side diagnostics in place
+
+### Over-horizon operations capability *(new theme — 2026-05-01)*
+
+The 2026-05-01 deployment ran the boat past visual range with the new comms stack and surfaced the saturation envelope. Even on Starlink-only at moderate distance, the current ROS topic stack saturates the link, producing 30–60 s latency episodes. Asymmetric resilience worked: control commands and SSH stayed reliable through saturation; situational awareness did not. RC failsafe stack now configured for over-horizon use (`FS_THR_ENABLE = 0`, `FS_GCS_ENABLE = 0`, GUIDED stale-setpoint HOLD).
+
+- **Topic-budget cull** — required, not optional. Identify which topics dominate the link, cull or rate-limit accordingly.
+- **VPN-path indicator** (Starlink vs. cellular vs. WiFi) — operator awareness gap; today we lost significant diagnostic time guessing which path was carrying traffic. See [#124](https://github.com/rolker/unh_echoboats_project11/issues/124).
+- **Bench stress-test rig** — synth topics + mininet + CAMP-stub harness so the next saturation question can be answered at the desk, not on the water. See [#124](https://github.com/rolker/unh_echoboats_project11/issues/124).
+- **RC mode-switch fringe-range hardening** — pin to AUTO/GUIDED, disable channel via FCU params, or power off RC entirely during autonomous runs. See memory `project_bizzyboat_rc_mode_switch_at_fringe_range.md`.
+- **Low-bandwidth status fallback** — text/heartbeat/minimal-telemetry path that survives when the full topic stream doesn't (today's gabby SSH access bridged the gap manually).
+
+### Autonomy robustness *(new theme — 2026-05-01)*
+
+2026-05-01 deployment surfaced a real BT design issue and validated the GUIDED stale-setpoint failsafe.
+
+- **BT `SkipUnknownTaskType` catchall masks execution failures** — top-level `ReactiveFallback` can't distinguish "no script condition matched" from "matching subtree's execution failed", so the catchall fires on action ABORTs and silently marks tracklines done. Forensic match for the 2026-05-01 15:09 HOLD episode (FollowPath ABORTED → SurveyLineTask sequence failed → catchall fired → trackline marked done → `done_hover` activated). Needs a new task issue against the BT / mission_manager. See gabby log §11.
+- **GUIDED stale-setpoint HOLD verified working** — when `cmd_vel` publication stops, FCU correctly enters HOLD. Confirmed Nav2-crash failsafe behaves as intended.
+
+### Perception → costmap *(new theme — 2026-05-01)*
+
+The 2026-05-01 mooring ball near-miss made this concrete: cameras can see surface obstacles, but segmentation output is not feeding the Nav2 costmap, so the autonomy planner has no awareness. This is a real survey-readiness blocker — any autonomous survey will be in waters with mooring balls, debris, and other vessels.
+
+Existing tracker: [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) (end-to-end OAK → costmap validation). Currently blocked on [`unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) (`SeaSurfaceLayer::matchSize()` segfault). Today reinforces the priority — without this, autonomous survey requires constant manual override for surface-obstacle avoidance.
 
 ## Deferred / lower priority — no current issue
 


### PR DESCRIPTION
## Deployment wrap-up — 2026-05-01 BizzyBoat (#121)

Closes #121.

This PR is the dev-side wrap-up of the 2026-05-01 BizzyBoat
deployment. It adds the dev-side per-host log and updates the
roadmap with progress + new themes derived from the day. The
field-side per-host logs (gabby, salmon) and the actual
configuration / launch / package fixes from today land via the
four field-import PRs listed below.

## Summary

Three goals planned. **Goals 1 & 2 met cleanly; Goal 3 produced
more data than progress** — characterized failure modes more than
it validated working ones, but the picture is clearer for the
remaining survey-readiness work.

- **Goal 1 — PPS to M3**: achieved. Root cause of "0 pulses received"
  was the M3 software's Device Properties → Time Sync Mode dropdown,
  not cable / SBG / pulse parameters. Captured as durable memory.
- **Goal 2 — SBG + FCU at base_link**: achieved. SBG sbgCenter
  Output Location was the missing config; setting it referenced
  output at base_link, and gabby agent confirmed FCU and SBG
  agree at base_link.
- **Goal 3 — over-horizon comms baseline**: partial. RC range
  LOITER mystery solved (FCU was honoring the RC mode-switch
  channel at fringe range despite `FS_THR_ENABLE = 0`).
  Bandwidth saturation under realistic load is severe — topic
  budget cull is required for any over-horizon survey.
- Multiple smaller findings (mooring ball near-miss → perception
  blocker; CAMP UI Standby state lag; udp_bridge throughput
  regression from PR #12; etc.).

Full detail in the dev log and the cross-referenced gabby + salmon
logs.

## What's in this PR

- `docs/logs/2026/2026-05-01_dev_logs.md` — dev-side per-host
  deployment log (~1700 lines). Includes Summary, full timeline,
  Cross-references to field logs, Active threads, Follow-ups,
  Lessons Learned.
- `docs/roadmap.md` — append today's progress to existing themes
  (sensor payload, base_link contract, network reliability) and
  add three new themes (over-horizon operations, autonomy
  robustness, perception → costmap).

## Related field-import PRs

These carry the actual code / config / package / launch changes
from today's deployment. **Suggested merge order** (per cross-repo
dependencies):

1. [`rolker/marine_tools#9`](https://github.com/rolker/marine_tools/pull/9) — provides `zda_serial_bridge` package
2. [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) — bridge throughput regression fix + `rmw_zenoh_cpp` keyexpr workaround
3. [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) — operator-side QoS fix (`reliability_best_available` on NavSource subscribers)
4. [`#123`](https://github.com/rolker/unh_echoboats_project11/pull/123) — workspace-side config + launch wiring for this repo (depends on all of the above)

This wrap-up PR is independent and not blocked by the chain above.

## Follow-up

Post-mission data review tracked in [`#124`](https://github.com/rolker/unh_echoboats_project11/issues/124).

## Test plan

- [ ] Render checks (markdown headings, links, tables).
- [ ] Cross-reference links to `2026-05-01_gabby_logs.md` and
      `2026-05-01_salmon_logs.md` resolve once #123 merges.

No code changes; no functional tests apply.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
