### PR TITLE
docs(logs): 2026-05-01 dev log corrections + README field-session guardrails

### DIFF
--- a/docs/logs/2026/2026-05-01_dev_logs.md
+++ b/docs/logs/2026/2026-05-01_dev_logs.md
@@ -716,9 +716,9 @@ post-deployment review):~~
 
 Corrected interpretation of the prior event: Roland had pressed
 **Standby** in CAMP. The standby command **did take effect** —
-autonomy stopped commanding cmd_vel and **set mavros state to
-MANUAL**. In MANUAL the FCU is not station-keeping, so the boat
-drifted on current.
+autonomy stopped commanding cmd_vel and **commanded the FCU
+into MANUAL via mavros**. In MANUAL the FCU is not
+station-keeping, so the boat drifted on current.
 
 Operator then hit **Autonomous**, autonomy resumed, boat took
 off again — confirming the autonomy stack was healthy the whole

--- a/docs/logs/2026/2026-05-01_dev_logs.md
+++ b/docs/logs/2026/2026-05-01_dev_logs.md
@@ -664,14 +664,20 @@ purposes — useful if we later need to look up "when was the boat
 near another vessel". **Not a near-miss** and not adding a separate
 data point against the perception→costmap gap.
 
-### 15:07 — Manual ↔ autonomous switching via RC controller works
+### 15:07 — Manual ↔ autonomous switching via USB joystick works
 
-Verified the RC controller can still switch manual ↔ autonomous
-modes. **Disabling `FS_THR_ENABLE` (RC failsafe) does NOT affect
-the manual-override switch** — operator's emergency takeover
-remains intact. Important to confirm; a common worry with
-disabling RC failsafe is losing the manual safety net, but the
-two are independent.
+Verified the **USB joystick** at the operator station can still
+switch manual ↔ autonomous modes via the software path
+(`joy` → `joy_to_helm` → `udp_bridge` → boat-side helm handling).
+With `FS_THR_ENABLE = 0`, software-path manual takeover remains
+intact — as expected, since the operator joystick does not
+depend on the FCU's RC failsafe.
+
+**RC-based manual takeover under `FS_THR_ENABLE = 0` was NOT
+separately verified in this scope.** A common worry with
+disabling RC failsafe is losing the manual safety net via the
+RC transmitter; this entry does not address that question.
+The two paths are independent and would need their own test.
 
 ### 15:08 — Boat out of direct line of sight 🌊
 
@@ -681,62 +687,72 @@ This is the real "over-horizon" condition any autonomous survey
 beyond visual range will face. From here on, every successful
 command + healthy telemetry frame is a Goal 3 datum.
 
-### 15:09 — Boat in HOLD / hover, drifted back into sight; CAMP red→yellow
+### 15:09 — Boat drifted back into sight; appeared to be in HOLD; CAMP red→yellow
 
-BizzyBoat **drifted back into sight** and appears to be in
-**LOITER / HOLD** — autonomy stopped commanding forward motion.
-**CAMP went red briefly, then back to yellow.**
+BizzyBoat **drifted back into sight** and *appeared* to be in
+**LOITER / HOLD** — autonomy seemed to have stopped commanding
+forward motion. **CAMP went red briefly, then back to yellow.**
 
-Consistent with the **GUIDED stale-setpoint timeout** behavior
-we have in place: cmd_vel stopped flowing → FCU's HOLD kicked
-in → boat stops pushing forward → drifts on current. This is
-exactly the desired Nav2-crash failsafe shape.
+(In-the-moment interpretation; corrected at §15:13 — the boat
+was actually in MANUAL after a Standby press, not HOLD. The
+hypotheses below were wrong; preserved with strikethrough as a
+record of in-the-moment thinking.)
 
-CAMP red → yellow suggests a **transient comms or node issue**
+~~Consistent with the GUIDED stale-setpoint timeout behavior we
+have in place: cmd_vel stopped flowing → FCU's HOLD kicked in →
+boat stops pushing forward → drifts on current. This is exactly
+the desired Nav2-crash failsafe shape.~~
+
+~~CAMP red → yellow suggests a transient comms or node issue
 that recovered, not a hard fault. Likely candidates (for
-post-deployment review):
-- Nav2 / autonomy node crash + auto-restart (if systemd is wrapping it)
-- DDS/RMW participant churn
-- A node that briefly stopped publishing a heartbeat
+post-deployment review):~~
+- ~~Nav2 / autonomy node crash + auto-restart (if systemd is wrapping it)~~
+- ~~DDS/RMW participant churn~~
+- ~~A node that briefly stopped publishing a heartbeat~~
 
-Standing by to see if the autonomy resumes pushing or stays
-HOLDing.
+~~Standing by to see if the autonomy resumes pushing or stays HOLDing.~~
 
-### 15:13 — CAMP didn't reflect Standby state — operator-side feedback gap
+### 15:13 — Standby took effect; perceived gap was heartbeat latency from link saturation
 
 Corrected interpretation of the prior event: Roland had pressed
 **Standby** in CAMP. The standby command **did take effect** —
-autonomy stopped commanding cmd_vel, FCU went into HOLD via the
-stale-setpoint timeout, then the boat drifted on current. **But
-CAMP's UI did not update to show the mode change**, so from the
-operator's view the boat appeared to be stuck/drifting for no
-visible reason.
+autonomy stopped commanding cmd_vel and **set mavros state to
+MANUAL**. In MANUAL the FCU is not station-keeping, so the boat
+drifted on current.
 
 Operator then hit **Autonomous**, autonomy resumed, boat took
 off again — confirming the autonomy stack was healthy the whole
 time. The earlier hypothesis ("transient node crash + needed
 mode-cycle to recover") is wrong: the boat was correctly
-following the unseen mode change.
+following the commanded mode change.
 
-**Real issue**: a **CAMP UI feedback gap** — the displayed mode
-diverges from the actual mode after a Standby press.
+**Root cause**: **network latency, most likely from link
+saturation.** The heartbeat carrying the new mode is already
+the ack for "Standby applied" — mode change → next heartbeat
+→ CAMP display update — but with the link saturated, that
+heartbeat arrived with significant lag. CAMP's mode-display
+staleness indication is clear, so the operator knew the value
+might be stale; what was hard to tell was whether "no fresh
+update yet" meant "command landed and ack is queued" or
+"command was dropped." Both look the same under high latency.
 
-Operator implications (now reframed):
-- Operators rely on CAMP's mode display to know what the boat
-  thinks it's doing. If the display is wrong, they'll make bad
-  decisions (assume crash, redo command, etc.).
-- Worth tracking down which CAMP topic / status indicator missed
-  the transition: is the mode-state subscriber wired correctly?
-  Is the Standby command actually publishing the corresponding
-  status update?
-- File a follow-up against the operator-tools repo to verify
-  CAMP's mode display reflects all Standby/Autonomous transitions
-  reliably.
+Operator implications:
+- A dedicated, lightweight command-ack channel would still
+  help — smaller and more latency-tolerant than waiting for
+  the next heartbeat — but it's a mitigation, not the fix.
+  The fix is addressing whatever's saturating the link.
+- Connects directly to #124 §1 (networking review): per-topic
+  drops, rate-vs-distance correlation, resend-layer activity,
+  bridge bandwidth vs cap. The saturation here is the same
+  saturation those bullets are characterizing.
 
-Failsafe-stack note: this also nicely demonstrates the GUIDED
-stale-setpoint HOLD doing its job — operator hit Standby, cmd_vel
-stopped, boat HOLDed cleanly (then drifted on current as a HOLD
-boat does without ground reference).
+Design note: Standby → **MANUAL** (not GUIDED-HOLD) is
+intentional. MANUAL is the FCU mode the RC transmitter drives
+directly, so as soon as Standby is selected the operator can
+grab the RC and take over with **no switch flip** — instant
+handoff. Cost: in MANUAL the FCU is not station-keeping, so
+the boat drifts on current/wind until commanded otherwise.
+That's working as designed, not a stale-setpoint HOLD artifact.
 
 ### 15:15 — Boat going to LOITER at range despite FS_THR_ENABLE=0
 
@@ -782,18 +798,29 @@ healthy and FCU in GUIDED, goto works as expected.
 Useful contrast for the bag review: today we have *both*
 goto-success and goto-failure intervals to compare.
 
-### 15:30 — Goto is a temporary override; boat resumed the trackline
+### 15:30 — Goto completed; boat resumed mission (operator should have used Hover Override)
 
 After completing the goto, BizzyBoat **resumed the original
 trackline mission**. This is **by design** — goto in this
 autonomy stack is a temporary override, not a permanent
-re-target. Roland had forgotten this; worth flagging so it
-doesn't catch the next operator by surprise.
+re-target.
 
-Operator doc note: brief operators that **goto = "go there then
-resume"**, not "go there and stay". If they want the boat to
-hold at the goto target, they should issue Standby (or a hover
-override) once the boat arrives.
+Operator self-note: Roland's actual intent was for the boat to
+stay at the goto target, which is what **Hover Override** is
+for. He fell back to goto out of habit because **Hover Override
+has not always worked reliably**, and goto + "no active
+mission" happens to produce the same "park here" outcome
+(post-completion hover at the destination). With a mission
+active, goto's resume-on-completion behavior surprised him
+even though it's by design.
+
+Operator doc note: brief operators that
+- **Hover Override** = "transit there, hover until I cancel,
+  then resume the mission" — the right tool when intent is
+  to park the boat.
+- **Goto override** = "transit there, then resume mission" if
+  one is active, or "transit there and hover" if none.
+- The two are not interchangeable when a mission is active.
 
 ### 15:31 — ~60 second latency in CAMP and images ⚠️
 
@@ -816,8 +843,6 @@ Diagnosis candidates for post-deployment review:
   than publisher publishes.
 - **Network buffer bloat** — Starlink router or intermediate
   hop with deep queue.
-- **GStreamer pipeline depth** — if video is GStreamer-piped,
-  internal queue depth could be the source.
 
 Mitigations to consider:
 - Drop image rate / resolution dynamically when link is
@@ -984,7 +1009,6 @@ Most likely culprits (post-deployment review candidates):
   up everything else.
 - **Zenoh / DDS publisher** with internal buffering when
   bandwidth-constrained.
-- **GStreamer pipeline** depth on the camera publishers.
 - **CAMP-side subscriber** struggling to drain at the rate
   packets arrive.
 

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -218,6 +218,11 @@ Avoid:
   raw data stays in `~/data/logs/`
 - Multi-paragraph design discussions — those belong on the
   deployment issue or a focused task issue
+- Naming components or mechanisms that aren't in the actual stack
+  as candidate causes (e.g., listing GStreamer as a buffer-bloat
+  candidate when video isn't GStreamer-piped). When proposing
+  diagnoses, list only components you've verified are deployed;
+  ask the operator or omit if unsure.
 
 ### Timestamp every entry
 
@@ -235,6 +240,35 @@ Even editorial summaries get timestamps — knowing **when** a
 summary was written can matter as much as the summary itself. Use
 **minute precision by default**; bump to seconds when correlating
 tightly to a bag or a ROS event.
+
+### Logging during live field operations
+
+During an active deployment the operator is steering the boat —
+their attention is on the helm, traffic, and wind, not on producing
+tidy log copy. Two patterns recur:
+
+**Operator notes are often quick and incomplete.** The operator
+drops short observations into the session ("the boat went into
+HOLD", "~60 s of latency", "pressed Standby") for
+capture-and-later-review. The agent's job is to record these
+faithfully and add **only factual context** — timestamps, current
+mode/state, references to prior log entries. Do **not** invent
+mechanisms, attribute causes the operator didn't state, or fill in
+missing detail with plausible-sounding speculation. If the picture
+is unclear, log the observation as-is and flag it for follow-up.
+
+**Troubleshooting suggestions are conversation, not log entries.**
+The agent should proactively suggest diagnostic steps in real time
+("want me to grab `dmesg` on gabby?", "should we check the
+udp_bridge stats topic?"). The operator may be too busy to try
+them, or already running something else. **Log only what was
+actually attempted and its outcome** — skip suggestions that
+didn't get acted on.
+
+Together these mean: the agent is a real-time scribe and a
+conversational helper. The scribe captures verified facts; the
+helper offers options without polluting the log with proposals
+that weren't picked up.
 
 ### Task-specific deep-dive logs
 


### PR DESCRIPTION
## Summary

Corrects six entries in the 2026-05-01 BizzyBoat dev log
(`docs/logs/2026/2026-05-01_dev_logs.md`) where the agent
mis-attributed mechanisms or named components not in the stack,
then adds README guardrails to prevent recurrence.

## Dev log corrections (commit `3ee682f`)

- **§15:07** — controller used in the manual ↔ autonomous
  switching test was the **USB joystick**
  (`joy` → `joy_to_helm` → `udp_bridge` → boat-side helm), not
  the RC transmitter. Takeaway about `FS_THR_ENABLE` narrowed to
  what was actually tested; RC-based takeover under that param
  noted as unverified.
- **§15:09** — softened to in-the-moment perception; the wrong
  hypotheses (GUIDED stale-setpoint HOLD; node-crash candidates)
  preserved with strikethrough as historical record.
  Forward-link to §15:13 added.
- **§15:13** — fully rewritten. Standby intentionally sets
  mavros to **MANUAL** (not GUIDED-HOLD via stale-setpoint
  timeout); drift is by design. Root cause of the perceived
  feedback gap is **heartbeat latency from link saturation**,
  not a CAMP UI wiring bug. Design note explains the
  Standby→MANUAL choice (instant RC handoff, no switch flip).
- **§15:30** — goto behavior description was correct; expanded
  the operator self-note: actual intent was to park the boat
  (Hover Override is the right primitive). Operator
  goto-fallback habit traces to Hover Override unreliability
  (tracked at rolker/unh_marine_autonomy#125). Doc note
  rewritten as a 3-bullet contrast between Hover Override and
  Goto override.
- **§15:31 / §16:09** — dropped GStreamer references from
  candidate-cause lists. GStreamer is not part of the stack.

## README guardrails (commit `01c9cba`)

`docs/logs/README.md`:

- New **Avoid** bullet: do not name non-stack components as
  candidate causes; verify or omit.
- New **Logging during live field operations** subsection:
  - Operator notes are often quick and incomplete: record
    faithfully with factual context, do not invent mechanisms.
  - Troubleshooting suggestions are conversation, not log
    entries: log only what was actually attempted.

## Spawned follow-up issues

- rolker/unh_marine_autonomy#125 — Investigate Hover Override
  robustness (operator's goto-fallback habit traces back here).
- rolker/udp_bridge#17 — Review stats gathering; consider bit/s
  vs byte/s for bandwidth-comparison fields.

## Test plan

- [x] `git diff --stat`: 84 ins / 60 del in dev_logs.md, 34 ins
      in README.md
- [x] Pre-commit hooks pass (no `--no-verify`)
- [ ] Visual review of strikethrough rendering in §15:09 on
      GitHub
- [ ] Cross-link sanity check (#124, #125 / autonomy#125,
      #126, udp_bridge#17)

Closes #126.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
