### PR TITLE
docs(analysis): land 2026-05-01 post-mission §1 networking analysis

### DIFF
--- a/docs/analysis/2026-05-01/README.md
+++ b/docs/analysis/2026-05-01/README.md
@@ -1,0 +1,48 @@
+# 2026-05-01 BizzyBoat deployment — post-mission analysis
+
+Companion to:
+
+- [#121](https://github.com/rolker/unh_echoboats_project11/issues/121) — the deployment
+- [#124](https://github.com/rolker/unh_echoboats_project11/issues/124) — post-mission review issue (this work covers §1 networking)
+- [`../../logs/2026/2026-05-01_dev_logs.md`](../../logs/2026/2026-05-01_dev_logs.md) — dev-side deployment log (analysis trail summarised in the "Post-mission analysis" section)
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| [`findings.md`](findings.md) | Full §1 networking analysis. Headlines: WiFi cap conservative by ~2× at pier; Starlink/VPN cap matched to lossy knee; 30% resend overhead is structural; one 9-min "all red" event explained as a resend storm triggered by mid-mission cap change. |
+| [`outage_events.md`](outage_events.md) | Catalog of all per-topic outages ≥30 s on CAMP-watched topics during the in-water window; clustered into "events." |
+| [`starlink_only_budget.md`](starlink_only_budget.md) | Camera vs essentials bandwidth split, decision matrix for Starlink-only over-horizon operation. |
+| [`bandwidth_test_2026-05-18.md`](bandwidth_test_2026-05-18.md) | Pier iperf3 + mtr calibration of WiFi and Starlink/VPN, run on 2026-05-18 to feed the §1 interpretation. |
+| [`network_queries.sql`](network_queries.sql) | SQL queries that produced §1.2 / §1.4 / §1.6 against the SQLite extract of the deployment bags. |
+| [`network_perlink_queries.sql`](network_perlink_queries.sql) | Per-topic and per-link queries (§1.1 / §1.3 / §1.5) against the supplementary `per_topic_stats` and `per_link_stats` tables. |
+
+## Issues filed from this analysis
+
+- [`unh_echoboats_project11#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) — Field validation: over-horizon Starlink-only operation
+- [`unh_echoboats_project11#131`](https://github.com/rolker/unh_echoboats_project11/issues/131) — gabby: apply sysctl UDP receive-buffer tuning
+- [`rolker/udp_bridge#19`](https://github.com/rolker/udp_bridge/issues/19) — Add per-topic priority/class scheduling to the rate-limiter
+
+## Reproducibility — local-only artifacts
+
+These files reference some artifacts that are **not** in this repo
+because they are derived or oversized:
+
+- **`2026-05-01_deployment.db`** (2.8 GB) — the merged SQLite extract
+  of the two deployment bags. Regenerate with
+  `ros2 run bag_analysis bag_to_sqlite` (and `--append` for the second
+  bag); the exact bag paths used are recorded in `_bag_meta.source_bag_paths`
+  inside the DB.
+- **`network_perlink.py`** — the bag-walker that populates the
+  supplementary `per_topic_stats` and `per_link_stats` tables. Currently
+  lives at `~/data/analysis/2026-05-01_network_perlink.py` on the dev
+  workstation; should move into
+  [`rolker/marine_tools`](https://github.com/rolker/marine_tools)'s
+  `bag_analysis` package as a reusable extractor (follow-up — see
+  #124).
+- **Bag files** — recorded on gabby during deployment; pulled to dev
+  workstation under `~/data/logs/bizzyboat/2026-05-01T*` for analysis.
+
+All of the analysis files in this directory are intended to be
+self-contained for read-only reference. The data the queries operate on
+can be regenerated; the prose conclusions stand on their own.

--- a/docs/analysis/2026-05-01/bandwidth_test_2026-05-18.md
+++ b/docs/analysis/2026-05-01/bandwidth_test_2026-05-18.md
@@ -1,0 +1,142 @@
+# 2026-05-18 BizzyBoat link bandwidth + loss calibration
+
+Companion to [`rolker/unh_echoboats_project11#124`](https://github.com/rolker/unh_echoboats_project11/issues/124).
+Out-of-band measurement to feed the §1 networking interpretation in
+[`findings.md`](findings.md).
+
+## Conditions
+
+- **Date/time**: 2026-05-18, ~20:00 EDT
+- **Boat**: powered up on the pier, idle (udp_bridge running but no
+  autonomy active, no cameras under load).
+- **Operator host**: salmon, `iperf3 -s -p 5201` (default port).
+- **Boat host**: gabby, iperf3 3.16 client.
+- **Boat motion**: stationary at pier. Best-case WiFi conditions; results
+  are **not representative of long-range / over-horizon operation**.
+
+## Path topology
+
+Both paths route from gabby through `enp7s0` to the boat router
+(`192.168.20.1`), which policy-routes the egress based on destination
+subnet.
+
+| Path | Target on salmon | Boat-side hostname | mtr hops | Avg RTT |
+|---|---|---|---|---|
+| **WiFi** | 192.168.13.142 (`salmon_bb`) | `gabby_bb` (192.168.20.5) | gabby → router → WiFi-bridge → salmon | **9 ms** |
+| **VPN / Starlink** | 192.168.22.142 (`salmon_bv`) | `gabby_v` (192.168.21.5, NETMAP) | gabby → router → bencloud (WireGuard relay) → salmon | **65 ms** |
+
+mtr raw output:
+
+```
+=== mtr WiFi ===
+  1.  router.lan.bizzy.p11.lan          0.0%  20    0.8   0.7   0.6   0.8   0.1
+  2.  router.bizzy.wifi.op.p11.lan      0.0%  20    1.6   4.7   1.5  36.4   7.7
+  3.  salmon.lan.op.p11.lan             0.0%  20   13.2   3.5   1.6  13.2   3.3
+
+=== mtr VPN ===
+  1.  router.lan.bizzy.p11.lan          0.0%  20    0.8   0.8   0.6   2.2   0.3
+  2.  bencloud.wg.p11.lan               0.0%  20   36.0  35.2  24.6  51.7   8.6
+  3.  salmon.vpn.bizzy.p11.lan          0.0%  20   58.3  65.1  48.7  83.2  10.8
+```
+
+## WiFi link (cap = 1.5 MB/s = 12 Mbps)
+
+### TCP
+
+| Test | Throughput | Retransmits |
+|---|---|---|
+| Single stream, 30 s, `-O 2` | **21.1 Mbps** sender / 21.0 Mbps receiver | 145 |
+| 4 parallel, 30 s | **20.8 Mbps** sender / 20.1 Mbps receiver | 0 |
+
+Per-stream parallel was 5 Mbps × 4 = 20.1 Mbps total; single-stream ran a
+bit harder at 21.1 Mbps. **Link, not protocol, is the limit at ~21 Mbps
+for TCP.**
+
+### UDP — `iperf3 -u -b $rate -t 15 -l 1400 --get-server-output`
+
+| Offered | Delivered | Loss | Jitter (one-way) |
+|---|---|---|---|
+| 5 Mbps | 5.00 Mbps | **0/6697 = 0%** | 0.74 ms |
+| 10 Mbps | 10.0 Mbps | **0/13393 = 0%** | 0.12 ms |
+| 15 Mbps | 15.0 Mbps | **1/20089 = 0.005%** | 0.47 ms |
+| 20 Mbps | 20.0 Mbps | **0/26785 = 0%** | 0.51 ms |
+| 25 Mbps | 25.0 Mbps | **0/33480 = 0%** | 0.45 ms |
+| 30 Mbps | 30.0 Mbps | **0/40177 = 0%** | 0.45 ms |
+
+`-l 1400` matches the udp_bridge wire-packet profile (1 MTU = realistic).
+
+### WiFi verdict
+
+- **Physical capacity at pier: ≥30 Mbps clean UDP, 21 Mbps TCP.**
+- Configured cap: 12 Mbps — **link can do ~2.5× more** at this distance.
+- Cap is *conservative on the pier*. The right cap-vs-distance behavior is
+  a separate question (MikroTik radio rate tapers with range; static cap
+  can't track).
+
+## VPN / Starlink link (cap = 1.0 MB/s = 8 Mbps; brief 2.5 MB/s window in deployment)
+
+### TCP
+
+| Test | Throughput | Retransmits |
+|---|---|---|
+| Single stream, 30 s, `-O 2` | **16.6 Mbps** sender / 16.5 Mbps receiver | **3,739** |
+
+The trailing 4 buckets ramped 15.7 → 32.5 Mbps as TCP discovered
+bandwidth; the test averages 16.6 Mbps because of high retransmit
+overhead.
+
+### UDP
+
+| Offered | Delivered | Loss | Jitter |
+|---|---|---|---|
+| 5 Mbps | 4.97 Mbps | **13/6697 = 0.19%** | 3.04 ms |
+| 10 Mbps | 9.89 Mbps | **81/13393 = 0.6%** | 1.78 ms |
+| 15 Mbps | 14.7 Mbps | **241/20088 = 1.2%** | 1.20 ms |
+| 20 Mbps | 19.6 Mbps | **388/26785 = 1.4%** | 0.85 ms |
+
+(Did not push to 25/30 Mbps — already clearly past the clean zone.)
+
+### VPN verdict
+
+- **Physical capacity exists past 20 Mbps** in burst, but with persistent
+  packet loss. TCP 16.6 Mbps with 3,739 retransmits = lossy congestion
+  control.
+- Configured cap 8 Mbps sits ~2/3 of the way between the 0.19% and 0.6%
+  loss points. **Interpolated loss at 8 Mbps ≈ 0.4%.**
+- Loss is **structural, not capacity-related**: 0.19% UDP loss exists at
+  5 Mbps, far below cap. Raising or lowering the cap won't eliminate it.
+- RTT 65 ms with 8–11 ms jitter, 83 ms worst. Path goes via `bencloud`
+  WireGuard relay (35 ms gabby → bencloud).
+
+## Implications
+
+1. **WiFi is heavily over-provisioned at close range.** A ~24 Mbps cap
+   would still have headroom over the measured TCP ceiling and would
+   give the camera streams meaningful breathing room (recall §1.1: OAK
+   ffmpeg streams account for ~99% of rate-limiter drops in the
+   2026-05-01 bag).
+2. **The Starlink/VPN cap is set near a physical-link knee, not an
+   arbitrary number.** Loss starts measurable at 5 Mbps and rises with
+   offered rate. The 8 Mbps choice is a defensible "loss budget" point.
+3. **The deployment's ~30% resend overhead is the expected steady state**
+   for a 0.4% baseline-loss link under udp_bridge's existing
+   retransmit design — not a bug, not an environmental anomaly. Reducing
+   it requires either:
+   - A different recovery strategy than resend (FEC, prioritized drop)
+   - Reducing offered VPN load below the lossy knee (~5 Mbps), or
+   - The in-progress udp_bridge resend-layer rework (out of scope here).
+
+## Caveats and follow-up tests worth doing
+
+- **Range sweep**: repeat at 100 / 300 / 500 / 800 m off the pier. The
+  static WiFi cap is conservative *here* but may be aggressive at
+  range. Without this data, raising the cap is not safe for autonomy.
+- **Boat-load test**: repeat with udp_bridge actively pushing the four
+  OAK ffmpeg streams. iperf3 vs. contention shows the rate-limiter's
+  fairness behavior under real workload.
+- **Sustained Starlink test**: 5-minute UDP at 5 Mbps and 8 Mbps to
+  catch periodic loss bursts (single 15 s window may miss
+  satellite-handoff events).
+- **bencloud relay sanity**: the WireGuard relay is the only hop with
+  more than ~5 ms latency; worth a quick bencloud-side iperf3 to
+  confirm the relay isn't itself the lossy hop.

--- a/docs/analysis/2026-05-01/findings.md
+++ b/docs/analysis/2026-05-01/findings.md
@@ -1,0 +1,277 @@
+# 2026-05-01 BizzyBoat deployment — analysis findings
+
+Companion to [`rolker/unh_echoboats_project11#124`](https://github.com/rolker/unh_echoboats_project11/issues/124).
+
+## Setup
+- **DB**: `~/data/analysis/2026-05-01_deployment.db` (2.8 GB, 6,457,037 messages from two bags merged via `bag_to_sqlite --append`).
+- **Detected in-water window** (from `bag_analysis.launch_recovery` altitude detector):
+  - Launch: **2026-05-01T17:48:29Z = 13:48:29 EDT**
+  - Recovery: **2026-05-01T22:34:53Z = 18:34:53 EDT**
+  - Duration: **4h 46m 24s**
+- Issue body bracket: 13:36–18:42 EDT. Detector's window is contained inside — the deltas are crane-down (12 min) and crane-up (8 min) periods where altitude was still elevated.
+
+## §1 Networking
+
+### §1.6 Bridge bandwidth vs. configured cap
+
+Boat-side aggregate wire-out across **all** outbound connections (WiFi + Starlink + cellular + VPN summed):
+
+| Band (boat → all peers) | n samples | % of time in-water |
+|---|---:|---:|
+| <100 kB/s | 4 | 0.06% |
+| 100–500 kB/s | 81 | 1.1% |
+| 500–1000 kB/s | 3242 | 46% |
+| 1000–1400 kB/s | 1547 | 22% |
+| **≥1400 kB/s** | 2179 | **31%** |
+
+- Boat-side avg: **1.24 MB/s**, peak: **4.33 MB/s** (sum across all connections).
+- Operator-side echo avg: 12 kB/s, peak 123 kB/s — tiny by comparison.
+- **Caveat**: The 1.5 MB/s WiFi cap doesn't apply to this aggregate — it's the sum across multiple physical links. Per-link saturation needs the per-link table (`per_link_stats`, populated by `2026-05-01_network_perlink.py`).
+
+Time evolution (60 s buckets, partial — full 255-min CSV in `/tmp/q6a.csv`):
+
+- **Minutes 0–8** (13:48–13:57 EDT): 1.0–1.3 MB/s avg with sporadic peaks >1.5 MB/s; small but persistent drops (3–15 kB/s avg, peaks 38–73 kB/s).
+- **Minutes 9–13** (13:57–14:02 EDT): calm — ~950 kB/s avg, **zero drops**.
+- **Minutes 277–286** (~18:25–18:35 EDT, late deployment): aggressive — 1.3–1.9 MB/s avg with peaks above 2 MB/s; **drops climbing to 100–265 kB/s avg, peaks 150–265 kB/s**. Rate-limiter actively thrashing right before recovery.
+
+### §1.4 Latency-event characterization ("all red" episodes)
+
+**Aggregate detector didn't find anything ≥20 s — but that's the wrong signal.** `messages_per_second` is dominated by 100 Hz SBG IMU and never drops below ~13, so an aggregate-zero detector is blind to per-topic-stale episodes (which is what "all red" means in CAMP UI).
+
+Three NULL `messages_per_second` rows + one zero-row exist (instantaneous gaps in the bridge report) — to investigate but those are sub-second, not 30/60 s episodes.
+
+**Re-run §1.4 after the perlink script populates `per_topic_stats`** — there we can detect per-topic outages of ≥30 s/60 s for the topics CAMP cares about (heartbeat, mission_manager status, platforms, etc.).
+
+### §1.2 Rate-vs-distance correlation
+
+Per-minute bucket, distance from launch (equirectangular ≈) vs. aggregate boat-side wire bandwidth.
+
+- **Peak distance: 615 m** at bucket_min 280. **Boat stayed close throughout** — never long-range.
+- Most of the run was at 200–600 m from launch.
+- No clear monotonic correlation: bandwidth varied 686 k – 3.0 MB/s essentially independent of distance.
+- **Notable** — `duplicate_bytes_per_second` drops to ~0 starting around bucket_min 167 (~16:35 EDT) and stays low. Before that, 1–10 kB/s of duplicate bytes (multi-path redundancy active). After, near-zero. **A redundant path went away mid-deployment.** Worth correlating with the §1.3 per-link data once available.
+
+Full timeline CSV: `/tmp/q2.csv`.
+
+### Per-link & per-topic schema (populated by `2026-05-01_network_perlink.py`)
+
+- **`per_topic_stats`** — 1,508,890 rows over 39 distinct `source_topic` values
+- **`per_link_stats`** — 32,473 rows; 2 distinct `connection_id` values
+- **`connection_id` is the physical-link label itself** (`wifi`, `vpn`), no hand-curated mapping needed for §1.3
+- **No cellular connection in this deployment** — only `wifi` and `vpn`
+- **Per-link caps from `RemoteConnection.maximum_bytes_per_second`**:
+  - `wifi`: 1,500,000 B/s (1.5 MB/s)
+  - `vpn`: 1,000,000 B/s (1.0 MB/s) — except for a brief 11.6-min window at **launch+197min ≈ 17:05 EDT to launch+209min ≈ 17:17 EDT** when vpn cap was **2,500,000 B/s** (2.5 MB/s). Coincides with the bag boundary; presumably a manual rate-cap bump between the two recording sessions.
+
+### §1.3 Path attribution
+
+Per-link bandwidth as percentage of cap (boat→operator, 60 s buckets, in-water window):
+
+| Link | Avg of cap | Peak | n_buckets |
+|---|---|---|---|
+| wifi | **54%** | 133% (cap=1.5MB/s) | 255 |
+| vpn  | **46%** | 129% (cap=1.0MB/s) | 255 |
+
+The >100% peaks are bucket-averaged samples; instantaneous values can exceed cap because the limiter operates per-packet but stats are reported over a window.
+
+**Notable bucket events** (boat-side wire-out, percent of link cap):
+
+| Min after launch | EDT | WiFi % | VPN % | Note |
+|---|---|---|---|---|
+| 83 | 15:11 | 93% | 92% | Both links near cap simultaneously — peak load |
+| 118 | 15:46 | 96% | 26% | WiFi dominant |
+| 131 | 15:59 | 94% | 33% | WiFi dominant |
+| 162 | 16:30 | 96% | 29% | WiFi dominant |
+| **174** | **16:42** | **21%** | **7%** | **Collapse** — likely one of the "all red" episodes |
+| 184 | 16:52 | 49% | 51% | VPN took over WiFi |
+| 222 | 17:30 | 21% | 42% | WiFi struggling, VPN taking over |
+| 202 | 17:10 | 76% | 107% | VPN exceeding 1.0 cap → in the 2.5-cap window (43% of 2.5MB/s) |
+
+Full timeline CSV: `/tmp/q3a.csv`.
+
+### §1.1 Per-topic discarded-packet counts
+
+**The four OAK camera ffmpeg streams dominate drops** by ~3 orders of magnitude over everything else:
+
+| Topic | Avg drop B/s | Peak drop B/s | Avg msg B/s | Peak msg B/s |
+|---|---:|---:|---:|---:|
+| `oak_starboard/image_raw/ffmpeg` | 2,326 | **1,061,983** | 100,065 | 1,496,900 |
+| `oak_port/image_raw/ffmpeg`      | 1,587 | 241,254       | 93,136  | 776,080   |
+| `oak_forward/image_raw/ffmpeg`   | 1,537 | 384,638       | 88,957  | 1,891,066 |
+| `oak_aft/image_raw/ffmpeg`       | 1,292 | 184,692       | 94,178  | 1,133,976 |
+| `local_costmap/costmap`          | 274   | 24,580        | 2,534,479 | 43,554,180 |
+| (everything else)                | <100  | <50,000       | -       | -         |
+
+**Key insight**: PR #123's `queue_size: 100` tuning addresses publisher-queue overflow drops, but `send_dropped_bps` here is the **rate-limiter-killed** bytes — a different mechanism. The ffmpeg streams are competing for the per-link bandwidth budget and the limiter is throwing away over 1 MB/s of starboard camera data at peak.
+
+### §1.5 Resend-layer activity
+
+**~1/3 of wire bandwidth was retransmits, not original messages**:
+
+| Link | Avg resend B/s | Peak resend B/s | Avg dropped-resend B/s | Avg resend / total |
+|---|---:|---:|---:|---:|
+| wifi | 294,647 | 1,720,754 | 568,388 | **38%** |
+| vpn  | 125,453 | 2,158,084 | 421,636 | **28%** |
+
+- `resend_failed_bps = 0` on both links — when a resend was sent, it succeeded.
+- **`resend_dropped_bps` is huge** (568 kB/s WiFi, 421 kB/s VPN). The rate-limiter killed resend attempts before they could send, on top of the original drops.
+- Confirms the deployment log's hypothesis that the resend window was firing constantly, not occasionally. The heartbeat 30 s alternation was almost certainly a resend storm — when the original arrival path was lossy enough, half the link's effective capacity went to retries, choking the heartbeat too.
+
+### §1.4 (re-do) — Per-topic outages on CAMP-watched topics
+
+**Major "all red" cluster around 17:26–17:30 EDT** (min 217–222 after launch). Nearly all CAMP-watched topics went silent simultaneously for 1–3 minutes:
+
+| Topic | Longest outage (s) | Start (min after launch) |
+|---|---:|---:|
+| `/bizzy/odom` | **185.7** | 217.9 |
+| `/bizzy/local_costmap/costmap` | 165.0 | 218.4 |
+| `/bizzy/marine/heartbeat` | 147.0 | 218.3 |
+| `/bizzy/marine/status/mission_manager` | 143.1 | 218.7 |
+| `/bizzy/hover_visualization` | 141.2 | 217.4 |
+| `/bizzy/local_costmap/published_footprint` | 108.3 | 222.7 |
+| `/marine/platforms` | 74.0 | 219.6 |
+
+These align with the per-link collapse at min 174 (16:42 EDT) which was a separate, earlier episode — the 17:26–17:30 outage is a fresh one. There are likely multiple "all red" episodes; this query just returns each topic's longest one. A follow-up should enumerate all ≥30s episodes per topic.
+
+**Non-events** (low-rate topics that only publish during specific operations):
+- `/bizzy/plan` — 1513 s "outage" at min 44.7 = no active plan during that period
+- `/bizzy/path_follower_visualization` — 375 s at min 103.5 = not following a path
+
+### §1.4 — Full all-episodes sweep on 7 CAMP topics
+
+Clustering all ≥30 s per-topic outages with a 30 s gap tolerance (output:
+`~/data/analysis/outage_events.md` from `/tmp/all_outages.py`):
+
+| # | Start (EDT) | End (EDT) | Span (s) | N topics | Class |
+|---|---|---|---:|---:|---|
+| 1 | 16:51:09 | 16:51:46 | 37.0 | 2 | yellow (costmap, odom) |
+| 2 | 16:54:59 | 16:55:36 | 37.0 | 1 | yellow (costmap) |
+| 3 | 17:22:41 | 17:23:18 | 37.0 | 2 | yellow (heartbeat, hover_visualization) |
+| **4** | **17:24:06** | **17:32:57** | **531.2** | **7** | **🔴 ALL RED — every CAMP topic affected** |
+
+Event 4 contains 19 distinct per-topic outage instances. Longest individual gaps:
+- `/bizzy/odom` 185.7 s (17:26:23 → 17:29:29)
+- `/bizzy/local_costmap/costmap` 165.0 s (17:26:55 → 17:29:40)
+- `/bizzy/marine/heartbeat` 147.0 s (17:26:49 → 17:29:16)
+- `/bizzy/marine/status/mission_manager` 143.1 s (17:27:11 → 17:29:34)
+- `/bizzy/hover_visualization` 141.2 s (17:25:54 → 17:28:16)
+
+### Event 4 mechanism — confirmed resend storm
+
+Per-link state during the 17:24–17:33 EDT window (per-minute averages):
+
+| min into event | conn | wire B/s | resend B/s | **resend_dropped B/s** | received B/s |
+|---:|---|---:|---:|---:|---:|
+| 0 | vpn  | 672,160 | 625,782 |  8,335,318 | 8,471 |
+| 0 | wifi | 357,153 | 291,186 |  5,640,621 | 11,544 |
+| 3 | vpn  | 713,987 | 667,147 |  **8,944,834** | 11,006 |
+| 3 | wifi | 309,741 | 246,924 |  5,093,373 | 10,243 |
+| **4** | vpn  | 792,186 | 757,178 |  **13,016,094** | 11,869 |
+| **4** | wifi | 430,601 | 383,535 |  **7,795,532** | 13,525 |
+| 7 | vpn  | 623,679 | 582,347 |  8,226,714 | 7,707 |
+| 7 | wifi | 358,655 | 300,476 |  4,826,951 | 9,931 |
+
+**Mechanism**: `resend_dropped_bps` reached **13 MB/s** on VPN while the link cap is only 1 MB/s. The system was attempting to retransmit ~13× link capacity worth of bytes, and the rate-limiter shed 90%+ of those retry attempts. **The wire wasn't dead** — wire_bps was still 260–790 kB/s — but **>90% of every byte sent was a retransmit**, choking the original payload through.
+
+This is a textbook resend storm. Wires fill with retries → originals starve → originals time out → retried → cycle continues. Receive throughput (received_bps ~7–12 kB/s) confirms the operator side was getting almost nothing.
+
+### Event 4 trigger (hypothesis)
+
+The VPN cap reverted **2.5 → 1.0 MB/s at min 209 (17:17:38 EDT)**. Event 4 started 7 min later at 17:24:06. During the 17:05–17:17 window with VPN at 2.5 MB/s, the system was running at 1.0–2.0 MB/s VPN (within new cap). When the cap dropped, queued traffic from the brief high-cap window may have overflowed available capacity, triggering retries → resend storm → Event 4.
+
+This is operationally significant: **the symptomatic recovery would be just waiting for the resend storm to drain**, not a network-side fix. The actionable preventive: avoid mid-deployment rate-cap changes, or design the resend layer to back off aggressively when `resend_dropped_bps` exceeds wire capacity.
+
+## §1.7 Kernel UDP drops on gabby
+
+Confirmed from `docs/logs/2026/2026-05-01_gabby_logs.md` §9 (16:00 EDT
+snapshot, ~2h into deployment):
+
+```
+UdpInDatagrams      2,462,334
+UdpInErrors            17,023   (almost all RcvbufErrors)
+UdpRcvbufErrors        17,018   ≈ 0.69% of UDP receives dropped
+UdpSndbufErrors             0
+```
+
+- **NIC-level `rx_dropped/tx_dropped` are 0** on both `enp7s0` and the ZeroTier interface. Bottleneck is **after** the NIC, at the kernel→app socket-buffer handoff.
+- `net.core.rmem_max` is already 16 MiB, but defaults are conservative:
+  - `rmem_default` = 208 KiB
+  - `udp_rmem_min` = 4 KiB
+  - `netdev_max_backlog` = 5,000
+
+**Status of the sysctl tuning hypothesis**: retrospectively confirms the 17k snapshot was real and the cause was socket-buffer-side (not NIC). The proposed tuning (in log §9) is reproducible. Forward-validation requires the next deployment with the tuning applied + a re-snapshot (verification command is already documented in the log).
+
+---
+
+## Cross-cutting themes from §1
+
+1. **Bandwidth budget is dominated by camera ffmpeg streams.** They drive nearly all rate-limiter drops; everything else combined is <5% of drop volume.
+2. **Resend overhead is structural, not incidental.** Even outside Event 4, ~30% of all wire bandwidth was retransmits during in-water operation. The link isn't lossy by accident — the offered camera load is so close to capacity that any packet loss triggers self-amplifying retries.
+3. **The mid-deployment cap change (VPN 2.5 → 1.0 MB/s) almost certainly triggered Event 4.** Avoid mid-mission rate-cap changes.
+4. **Kernel UDP drops on gabby exist (0.69%) but are not the dominant fault.** Sysctl tuning is in scope as a follow-up; not a Day-1 blocker.
+
+## Recommended follow-ups (issues to file)
+
+- `udp_bridge` (or `bizzyboat_project11`): camera-bandwidth budgeting — at offered camera rates the rate-limiter is the dominant fault. Either reduce camera bitrates, drop a stream, or implement per-topic rate-limit fairness so cameras don't starve heartbeat/odom.
+- **`udp_bridge` resend layer**: rework **already in progress** (per Roland 2026-05-18). The 30% resend overhead and Event 4 resend storm dynamic are addressed there; no separate issue needed.
+- `bizzyboat_project11` operations doc: warn against mid-deployment rate-cap changes; if needed, ramp down rather than cut.
+- `unh_echoboats_project11` (or `bizzyboat_project11`): apply sysctl tuning from gabby log §9 on next deployment, snapshot the counters after 5 min of traffic.
+
+## §1 cross-reference — 2026-05-18 link calibration
+
+Out-of-band iperf3 + mtr against both paths from the pier
+(see [`bandwidth_test_2026-05-18.md`](bandwidth_test_2026-05-18.md) for
+the full report). Conditions: boat idle on pier, udp_bridge running but
+no autonomy load.
+
+| Link | Configured cap | Measured (TCP) | Measured (UDP clean) | UDP loss at cap | Avg RTT |
+|---|---|---|---|---|---|
+| WiFi | 12 Mbps | **21 Mbps** | **≥30 Mbps @ 0%** | ~0% | **9 ms** |
+| VPN/Starlink | 8 Mbps | 16.6 Mbps (3,739 retr) | up to 1.4% @ 20 Mbps | **~0.4%** (interp) | **65 ms** |
+
+What this calibration tells us about the deployment data:
+
+1. **The WiFi cap is conservative by ~2×** on the pier. Most of the
+   `oak_starboard/image_raw/ffmpeg` peak drops in §1.1 (up to 1.06 MB/s
+   killed per second) would not have occurred at a 24 Mbps cap — the
+   link can carry them. Caveat: that's at pier; at 615 m peak distance
+   from the deployment, the WiFi physical capacity is unmeasured and
+   the static-cap problem becomes a range problem.
+
+2. **The Starlink/VPN cap is matched to the link's lossy knee**, not
+   arbitrary. UDP loss starts at 0.19% at 5 Mbps and rises with rate.
+   At the 8 Mbps cap, interpolated baseline loss ≈ 0.4%.
+
+3. **The 30% steady-state resend fraction observed in the deployment
+   bag (§1.5) is the expected output** of a 0.4% baseline-loss link
+   under the existing udp_bridge resend design. The in-progress resend
+   rework will address this; no need for a separate "resend storm
+   safeguard" issue.
+
+4. **The bencloud WireGuard relay is the dominant VPN latency** (35 ms
+   of the 65 ms RTT). Not a problem in itself but worth knowing as
+   architectural context.
+
+5. **Path identification confirmed** — `gabby_bb` = WiFi over MikroTik
+   bridge to operator router; `gabby_v` = NETMAP'd through Starlink
+   via WireGuard. No cellular path in this deployment.
+
+## Open follow-ups
+
+- Range sweep of the bandwidth test (100 / 300 / 500 / 800 m) to
+  characterize the WiFi cap-vs-distance curve. Without this data, the
+  static cap can't be safely raised for autonomy.
+- Load test of the bandwidth sweep with udp_bridge actively running
+  the OAK streams. Tells us how the rate-limiter fares under
+  contention.
+- 5-minute sustained Starlink UDP test to catch periodic burst-loss
+  events (satellite handoffs, etc.) that a 15 s window may miss.
+
+## Off-bag
+
+- §1.7 kernel UDP drops on gabby — gabby log §9 already has the 17k snapshot; needs sysctl-tuning follow-up issue if confirmed.
+
+## Open questions
+
+- Around bucket_min 167 (~16:35 EDT), duplicate_bps dropped to zero. Did one of the redundant connections go away around then? Cross-check against the deployment log for that timestamp.
+- Late-deployment drop activity (minutes 277+) at the very end: is this the boat-recovery phase where camera bitrate or operator pings increased? Or a known event?

--- a/docs/analysis/2026-05-01/findings.md
+++ b/docs/analysis/2026-05-01/findings.md
@@ -104,6 +104,21 @@ Full timeline CSV: `/tmp/q3a.csv`.
 
 **Key insight**: PR #123's `queue_size: 100` tuning addresses publisher-queue overflow drops, but `send_dropped_bps` here is the **rate-limiter-killed** bytes — a different mechanism. The ffmpeg streams are competing for the per-link bandwidth budget and the limiter is throwing away over 1 MB/s of starboard camera data at peak.
 
+**Configured bitrate context**: all four OAK cameras are set to
+`h265_bitrate_kbps: 800` in
+[`bizzyboat_project11/launch/oak_cameras_launch.py`](../../../bizzyboat_project11/launch/oak_cameras_launch.py)
+(L9–18), running at the camera_base default **fps=5** (no override). The
+88–100 kB/s observed averages above are ~800 kbps — the encoder is
+faithfully hitting its CBR target. The 1.06 MB/s starboard peak drop is
+therefore an **IDR-keyframe burst within a CBR budget**, not encoder
+runaway. At fps=5 the default `h265_keyframe_frequency_frames=30` is a
+**6 s GOP**, and depthai's CBR averages over a window — single IDR frames
+can still be many × the per-frame mean. (Rate-control mode is not set in
+the launch, so it inherits the depthai property default — `CBR`.)
+See [#133](https://github.com/rolker/unh_echoboats_project11/issues/133)
+and PR [#134](https://github.com/rolker/unh_echoboats_project11/pull/134)
+for the coprime-stagger remediation.
+
 ### §1.5 Resend-layer activity
 
 **~1/3 of wire bandwidth was retransmits, not original messages**:

--- a/docs/analysis/2026-05-01/network_perlink_queries.sql
+++ b/docs/analysis/2026-05-01/network_perlink_queries.sql
@@ -149,14 +149,24 @@ flagged AS (
   WHERE t_ns BETWEEN win.lo AND win.hi
     AND sample_origin = 'boat'
     AND remote_name = 'operator'
+),
+runs AS (
+  -- Tabibitosan run-grouping: per_link_stats publishes at ~1 Hz, so
+  -- t_ns - ROW_NUMBER()*1e9 is constant across consecutive samples in
+  -- a run. Matches the pattern in network_queries.sql Q4a (line 95).
+  -- Computed in a CTE because SQLite doesn't allow window functions
+  -- directly inside GROUP BY expressions.
+  SELECT t_ns, connection_id,
+         t_ns - ROW_NUMBER() OVER (PARTITION BY connection_id ORDER BY t_ns) * 1000000000 AS run_key
+  FROM flagged
+  WHERE hot = 1
 )
 SELECT
   connection_id,
   MIN(t_ns) AS start_t_ns,
   MAX(t_ns) AS end_t_ns,
   ROUND((MAX(t_ns) - MIN(t_ns)) / 1e9, 1) AS duration_s
-FROM flagged
-WHERE hot = 1
-GROUP BY connection_id, (t_ns - ROW_NUMBER() OVER (PARTITION BY connection_id, hot ORDER BY t_ns))
+FROM runs
+GROUP BY connection_id, run_key
 HAVING duration_s >= 30
 ORDER BY start_t_ns;

--- a/docs/analysis/2026-05-01/network_perlink_queries.sql
+++ b/docs/analysis/2026-05-01/network_perlink_queries.sql
@@ -1,0 +1,162 @@
+-- Per-topic / per-link / resend queries.
+-- Run after 2026-05-01_network_perlink.py has populated:
+--   per_topic_stats   (one row per (t_ns, source_topic) sample)
+--   per_link_stats    (one row per (t_ns, remote_name, connection_id) sample)
+
+-- ============================================================================
+-- §1.1  Per-topic discarded-packet counts
+-- ============================================================================
+-- Q1a: ranked list of topics by total send_dropped bytes during in-water window.
+-- send_dropped_bps is "rate-limiter killed these before they hit the wire".
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+)
+SELECT
+  source_topic,
+  COUNT(*)                              AS samples,
+  ROUND(AVG(message_bytes_per_second), 0) AS avg_msg_bps,
+  ROUND(MAX(message_bytes_per_second), 0) AS peak_msg_bps,
+  ROUND(AVG(send_dropped_bps), 0)       AS avg_dropped_bps,
+  ROUND(MAX(send_dropped_bps), 0)       AS peak_dropped_bps,
+  ROUND(SUM(send_dropped_bps), 0)       AS total_dropped_byte_seconds,  -- proxy for "total dropped volume"
+  ROUND(AVG(send_failed_bps), 0)        AS avg_failed_bps
+FROM per_topic_stats, win
+WHERE t_ns BETWEEN win.lo AND win.hi
+  AND sample_origin = 'boat'  -- boat-side mirror is authoritative for outbound drops
+GROUP BY source_topic
+HAVING SUM(send_dropped_bps) > 0 OR SUM(send_failed_bps) > 0
+ORDER BY total_dropped_byte_seconds DESC, peak_dropped_bps DESC
+LIMIT 25;
+
+-- Q1b: same idea but for topics that were *attempted* but barely got through
+-- (high message_bps with high dropped_bps — the rate-limit pressure points).
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+)
+SELECT
+  source_topic,
+  ROUND(AVG(send_dropped_bps) / NULLIF(AVG(message_bytes_per_second + send_dropped_bps), 0), 3)
+    AS drop_fraction,
+  ROUND(AVG(message_bytes_per_second), 0) AS avg_thru_bps,
+  ROUND(AVG(send_dropped_bps), 0)         AS avg_drop_bps,
+  COUNT(*)                                AS samples
+FROM per_topic_stats, win
+WHERE t_ns BETWEEN win.lo AND win.hi
+  AND sample_origin = 'boat'
+GROUP BY source_topic
+HAVING AVG(message_bytes_per_second + send_dropped_bps) > 100  -- ignore inactive topics
+ORDER BY drop_fraction DESC, avg_drop_bps DESC
+LIMIT 25;
+
+-- ============================================================================
+-- §1.3  Path attribution per minute (which physical link carried traffic)
+-- ============================================================================
+-- BridgeInfo's per-connection breakdown carries the link identity via
+-- (host, ip_address, port) on each RemoteConnection. The connection_id is
+-- the stable name we can group by. We don't have direct WiFi/Starlink/cellular
+-- labels — Q3b is the lookup table you'd hand-curate once.
+
+-- Q3a: minute-bucketed bandwidth per connection_id.
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+)
+SELECT
+  CAST((t_ns - win.lo) / 60e9 AS INTEGER)              AS bucket_min,
+  connection_id,
+  ip_address,
+  ROUND(AVG(message_success_bps + overhead_success_bps + resend_success_bps), 0)
+    AS wire_bps_avg,
+  ROUND(MAX(message_success_bps + overhead_success_bps + resend_success_bps), 0)
+    AS wire_bps_max,
+  ROUND(AVG(received_bps), 0)         AS received_bps_avg,
+  ROUND(AVG(duplicate_bps), 0)        AS duplicate_bps_avg
+FROM per_link_stats, win
+WHERE t_ns BETWEEN win.lo AND win.hi
+  AND sample_origin = 'boat'
+  AND remote_name = 'operator'
+GROUP BY bucket_min, connection_id
+ORDER BY bucket_min, wire_bps_avg DESC;
+
+-- Q3b: distinct connections seen during the deployment + their share of total
+-- wire bytes. Use this to label which connection_id corresponds to which
+-- physical link (cross-reference with the bizzyboat.yaml `connections:` block).
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+)
+SELECT
+  connection_id,
+  ip_address,
+  host,
+  port,
+  maximum_bytes_per_second  AS cap_bps,
+  COUNT(*)                  AS samples,
+  ROUND(AVG(message_success_bps + overhead_success_bps + resend_success_bps), 0)
+    AS avg_wire_bps,
+  ROUND(MAX(message_success_bps + overhead_success_bps + resend_success_bps), 0)
+    AS peak_wire_bps
+FROM per_link_stats, win
+WHERE t_ns BETWEEN win.lo AND win.hi
+  AND sample_origin = 'boat'
+GROUP BY connection_id
+ORDER BY avg_wire_bps DESC;
+
+-- ============================================================================
+-- §1.5  Resend-layer activity
+-- ============================================================================
+-- The resend layer kicks in for missing-packet recovery (5 s window default).
+-- Hypothesis from the deployment story: heartbeat 30 s alternation was caused
+-- by the resend window firing on a flaky link. Confirm/refute by showing
+-- resend bps as a fraction of total wire bps, time-bucketed.
+
+-- Q5a: minute-bucketed resend bytes per connection.
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+)
+SELECT
+  CAST((t_ns - win.lo) / 60e9 AS INTEGER) AS bucket_min,
+  connection_id,
+  ROUND(AVG(resend_success_bps), 0)       AS resend_success_bps,
+  ROUND(AVG(resend_failed_bps), 0)        AS resend_failed_bps,
+  ROUND(AVG(resend_dropped_bps), 0)       AS resend_dropped_bps,
+  ROUND(AVG(resend_success_bps) /
+        NULLIF(AVG(message_success_bps + overhead_success_bps + resend_success_bps), 0), 3)
+    AS resend_fraction
+FROM per_link_stats, win
+WHERE t_ns BETWEEN win.lo AND win.hi
+  AND sample_origin = 'boat'
+  AND remote_name = 'operator'
+GROUP BY bucket_min, connection_id
+HAVING resend_success_bps > 0
+ORDER BY bucket_min, resend_fraction DESC;
+
+-- Q5b: episodes of sustained heavy resend (>= 10% of wire for >= 30 s).
+-- Helps test the heartbeat-alternation hypothesis: when resend was hot,
+-- did heartbeat publication go quiet on the other side?
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+),
+flagged AS (
+  SELECT t_ns, connection_id,
+         (resend_success_bps >
+          0.10 * NULLIF(message_success_bps + overhead_success_bps + resend_success_bps, 0)) AS hot
+  FROM per_link_stats, win
+  WHERE t_ns BETWEEN win.lo AND win.hi
+    AND sample_origin = 'boat'
+    AND remote_name = 'operator'
+)
+SELECT
+  connection_id,
+  MIN(t_ns) AS start_t_ns,
+  MAX(t_ns) AS end_t_ns,
+  ROUND((MAX(t_ns) - MIN(t_ns)) / 1e9, 1) AS duration_s
+FROM flagged
+WHERE hot = 1
+GROUP BY connection_id, (t_ns - ROW_NUMBER() OVER (PARTITION BY connection_id, hot ORDER BY t_ns))
+HAVING duration_s >= 30
+ORDER BY start_t_ns;

--- a/docs/analysis/2026-05-01/network_queries.sql
+++ b/docs/analysis/2026-05-01/network_queries.sql
@@ -1,0 +1,167 @@
+-- Network analysis queries for 2026-05-01 BizzyBoat deployment.
+-- Companion to unh_echoboats_project11#124 §1 (Networking / udp_bridge).
+--
+-- Run against: ~/data/analysis/2026-05-01_deployment.db
+-- All time values are nanoseconds since Unix epoch (UTC) in t_ns columns.
+-- The in-water window is _bag_meta.launch_t_ns ... _bag_meta.recovery_t_ns;
+-- every analysis query filters to that window unless explicitly noted.
+--
+-- Convention: bps = bytes per second (×8 for bits per second). The udp_bridge
+-- *_bytes_per_second fields are bytes/sec, NOT bits/sec.
+
+-- ============================================================================
+-- Setup: window bounds, named for reuse below.
+-- ============================================================================
+
+-- Sanity check — show the detected in-water window and bag inventory.
+SELECT key, value FROM _bag_meta WHERE key IN
+  ('launch_t_ns', 'recovery_t_ns', 'bag_count', 'robot_namespace');
+SELECT * FROM _bags;
+
+-- ============================================================================
+-- §1.6  Bridge bandwidth vs. configured cap (SQLite-only)
+-- ============================================================================
+-- bizzyboat.yaml caps:
+--   wifi:     1_500_000 B/s (12 Mbps)
+--   vpn:        300_000 B/s ( 2.4 Mbps)   -- TODO: confirm exact figure
+--   cellular:    50_000 B/s (   0.4 Mbps) -- TODO: confirm exact figure
+-- wire_out_bytes_per_second already excludes the rate-limiter's dropped
+-- bytes (per extractor docstring), so this is what actually hit the wire.
+
+-- Q6a: 60-second-bucketed wire bandwidth + drop rate, full deployment.
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+)
+SELECT
+  CAST((bi.t_ns - win.lo) / 60e9 AS INTEGER) AS bucket_min,
+  ROUND(AVG(bi.wire_out_bytes_per_second), 0)      AS wire_out_bps_avg,
+  ROUND(MAX(bi.wire_out_bytes_per_second), 0)      AS wire_out_bps_max,
+  ROUND(AVG(ts.send_dropped_bytes_per_second), 0)  AS dropped_bps_avg,
+  ROUND(MAX(ts.send_dropped_bytes_per_second), 0)  AS dropped_bps_max,
+  ROUND(AVG(ts.send_failed_bytes_per_second), 0)   AS failed_bps_avg,
+  COUNT(*)                                         AS n_samples
+FROM t_bizzy_udp_bridge_bridge_info bi
+JOIN t_bizzy_udp_bridge_topic_statistics ts
+  ON ts.t_ns BETWEEN bi.t_ns - 500000000 AND bi.t_ns + 500000000
+JOIN win
+WHERE bi.t_ns BETWEEN win.lo AND win.hi
+GROUP BY bucket_min
+ORDER BY bucket_min;
+
+-- Q6b: count of seconds spent in each wire-bandwidth band.
+-- Helps visualise "how often did we saturate".
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+),
+banded AS (
+  SELECT
+    CASE
+      WHEN wire_out_bytes_per_second <  100000 THEN '0  <100  kB/s'
+      WHEN wire_out_bytes_per_second <  500000 THEN '1  100-500 kB/s'
+      WHEN wire_out_bytes_per_second < 1000000 THEN '2  500-1000 kB/s'
+      WHEN wire_out_bytes_per_second < 1400000 THEN '3  1000-1400 kB/s'
+      ELSE                                          '4  >=1400 kB/s (saturated)'
+    END AS band
+  FROM t_bizzy_udp_bridge_bridge_info, win
+  WHERE t_ns BETWEEN win.lo AND win.hi
+)
+SELECT band, COUNT(*) AS n_seconds
+FROM banded
+GROUP BY band
+ORDER BY band;
+
+-- ============================================================================
+-- §1.4  Latency-event characterization (SQLite-only)
+-- ============================================================================
+-- "All red" episodes: stretches where outbound traffic collapsed.
+-- Definition: messages_per_second went to near-zero for >= 20 s.
+
+-- Q4a: continuous outage spans (>= 20 s with messages_per_second < 1.0).
+-- Uses the windowing trick: rank by run id derived from gap-detection.
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+),
+flagged AS (
+  SELECT t_ns, messages_per_second,
+         (messages_per_second < 1.0) AS in_outage
+  FROM t_bizzy_udp_bridge_topic_statistics, win
+  WHERE t_ns BETWEEN win.lo AND win.hi
+),
+runs AS (
+  SELECT t_ns, messages_per_second, in_outage,
+         t_ns - ROW_NUMBER() OVER (PARTITION BY in_outage ORDER BY t_ns) * 1000000000 AS run_key
+  FROM flagged
+)
+SELECT
+  in_outage,
+  MIN(t_ns)                                 AS start_t_ns,
+  MAX(t_ns)                                 AS end_t_ns,
+  ROUND((MAX(t_ns) - MIN(t_ns)) / 1e9, 1)   AS duration_s,
+  COUNT(*)                                  AS samples,
+  ROUND(AVG(messages_per_second), 2)        AS avg_msgs_per_s
+FROM runs
+WHERE in_outage = 1
+GROUP BY in_outage, run_key
+HAVING duration_s >= 20
+ORDER BY start_t_ns;
+
+-- Q4b: bandwidth + drops just before, during, and after each detected outage.
+-- (Run after Q4a to pick specific start_t_ns values to drill into.)
+-- Template — substitute :outage_start_t_ns:
+--   SELECT t_ns, messages_per_second, message_bytes_per_second,
+--          send_dropped_bytes_per_second, send_failed_bytes_per_second
+--   FROM t_bizzy_udp_bridge_topic_statistics
+--   WHERE t_ns BETWEEN :outage_start_t_ns - 30000000000
+--                  AND :outage_start_t_ns + 90000000000
+--   ORDER BY t_ns;
+
+-- ============================================================================
+-- §1.2  Rate-vs-distance correlation (SQLite-only)
+-- ============================================================================
+-- Distance from launch position vs. bridge bandwidth.
+-- Uses mavros/global_position/global to compute geodesic distance from the
+-- launch fix. ASSUMES launch position ≈ first FIX_2D-or-better sample.
+
+-- Q2: 60-s bucketed distance from launch vs. average bridge bandwidth.
+-- Note: SQLite has no haversine — approximate with equirectangular at
+-- this latitude (Portsmouth NH, ~43.07°N, 1° lat ≈ 111 km, 1° lon ≈
+-- cos(43.07°) × 111 km ≈ 81 km). Good to ±0.5% for sub-km distances.
+WITH win AS (
+  SELECT (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='launch_t_ns')   AS lo,
+         (SELECT CAST(value AS INTEGER) FROM _bag_meta WHERE key='recovery_t_ns') AS hi
+),
+fix AS (
+  SELECT t_ns, latitude, longitude
+  FROM t_bizzy_mavros_global_position_global, win
+  WHERE t_ns BETWEEN win.lo AND win.hi
+    AND latitude IS NOT NULL AND longitude IS NOT NULL
+    AND ABS(latitude) > 0.001 AND ABS(longitude) > 0.001
+),
+launch_fix AS (
+  SELECT latitude AS lat0, longitude AS lon0 FROM fix ORDER BY t_ns LIMIT 1
+),
+dist AS (
+  SELECT
+    f.t_ns,
+    -- equirectangular distance in metres
+    SQRT(
+      POWER((f.latitude  - lf.lat0) * 111000, 2) +
+      POWER((f.longitude - lf.lon0) * 111000 * 0.731, 2)
+    ) AS dist_m
+  FROM fix f, launch_fix lf
+)
+SELECT
+  CAST((bi.t_ns - win.lo) / 60e9 AS INTEGER) AS bucket_min,
+  ROUND(AVG(d.dist_m), 1)                          AS dist_m_avg,
+  ROUND(MAX(d.dist_m), 1)                          AS dist_m_max,
+  ROUND(AVG(bi.wire_out_bytes_per_second), 0)      AS wire_out_bps_avg,
+  ROUND(AVG(bi.duplicate_bytes_per_second), 0)     AS duplicate_bps_avg
+FROM t_bizzy_udp_bridge_bridge_info bi
+JOIN dist d ON d.t_ns BETWEEN bi.t_ns - 500000000 AND bi.t_ns + 500000000
+JOIN win
+WHERE bi.t_ns BETWEEN win.lo AND win.hi
+GROUP BY bucket_min
+ORDER BY bucket_min;

--- a/docs/analysis/2026-05-01/network_queries.sql
+++ b/docs/analysis/2026-05-01/network_queries.sql
@@ -21,10 +21,16 @@ SELECT * FROM _bags;
 -- ============================================================================
 -- §1.6  Bridge bandwidth vs. configured cap (SQLite-only)
 -- ============================================================================
--- bizzyboat.yaml caps:
+-- bizzyboat.yaml caps as of the 2026-05-01 deployment snapshot:
 --   wifi:     1_500_000 B/s (12 Mbps)
---   vpn:        300_000 B/s ( 2.4 Mbps)   -- TODO: confirm exact figure
---   cellular:    50_000 B/s (   0.4 Mbps) -- TODO: confirm exact figure
+--   vpn:        300_000 B/s ( 2.4 Mbps)
+--   cellular:    50_000 B/s (   0.4 Mbps)
+-- These reflect the config that was actually deployed on 2026-05-01;
+-- the live `bizzyboat.yaml` has since drifted (vpn raised to
+-- 1_000_000 B/s post-2026-05-01). For reproducibility, check out the
+-- repo at the 2026-05-01 deployment commit when re-running these
+-- queries against this bag, or update the values to the snapshot
+-- you're actually analysing.
 -- wire_out_bytes_per_second already excludes the rate-limiter's dropped
 -- bytes (per extractor docstring), so this is what actually hit the wire.
 

--- a/docs/analysis/2026-05-01/outage_events.md
+++ b/docs/analysis/2026-05-01/outage_events.md
@@ -1,0 +1,53 @@
+# All outages ≥30s on CAMP-watched topics
+
+In-water window: launch_t_ns=1777657709000000000, recovery_t_ns=1777674893000000000, duration=286.4 min
+Topics scanned: 7
+Total outage instances: 24
+
+## Per-topic outage counts
+
+| Topic | Count | Total s | Median s | Max s |
+|---|---:|---:|---:|---:|
+| `/bizzy/marine/heartbeat` | 4 | 303 | 71.9 | 147.0 |
+| `/bizzy/marine/status/mission_manager` | 2 | 178 | 143.1 | 143.1 |
+| `/marine/platforms` | 2 | 122 | 74.0 | 74.0 |
+| `/bizzy/odom` | 4 | 412 | 108.2 | 185.7 |
+| `/bizzy/hover_visualization` | 4 | 307 | 85.5 | 141.2 |
+| `/bizzy/local_costmap/costmap` | 5 | 321 | 37.0 | 165.0 |
+| `/bizzy/local_costmap/published_footprint` | 3 | 219 | 68.4 | 108.3 |
+
+## Clustered 'all-red' events (4)
+
+Outages within 30 s of each other are merged into one event.
+
+| # | Start (EDT) | End (EDT) | Total dur (s) | N topics affected | Topics |
+|---|---|---|---:|---:|---|
+| 1 | 16:51:09 | 16:51:46 | 37.0 | 2 | costmap, odom |
+| 2 | 16:54:59 | 16:55:36 | 37.0 | 1 | costmap |
+| 3 | 17:22:41 | 17:23:18 | 37.0 | 2 | heartbeat, hover_visualization |
+| 4 | 17:24:06 | 17:32:57 | 531.2 | 7 | costmap, heartbeat, hover_visualization, mission_manager, odom, platforms, published_footprint |
+
+## Detail — events affecting ≥4 CAMP topics
+
+
+### Event 1: 17:24:06 → 17:32:57 (min 216 after launch)
+
+- `hover_visualization`: 17:24:50 → 17:25:36  (46.0 s)
+- `hover_visualization`: 17:25:54 → 17:28:16  (141.2 s)
+- `hover_visualization`: 17:31:09 → 17:32:34  (85.5 s)
+- `costmap`: 17:24:06 → 17:24:39  (33.1 s)
+- `costmap`: 17:26:55 → 17:29:40  (165.0 s)
+- `costmap`: 17:32:02 → 17:32:53  (50.9 s)
+- `published_footprint`: 17:28:17 → 17:29:25  (68.4 s)
+- `published_footprint`: 17:30:07 → 17:30:49  (42.0 s)
+- `published_footprint`: 17:31:09 → 17:32:57  (108.3 s)
+- `heartbeat`: 17:24:50 → 17:25:37  (47.0 s)
+- `heartbeat`: 17:26:49 → 17:29:16  (147.0 s)
+- `heartbeat`: 17:31:41 → 17:32:53  (71.9 s)
+- `mission_manager`: 17:26:26 → 17:27:00  (34.6 s)
+- `mission_manager`: 17:27:11 → 17:29:34  (143.1 s)
+- `odom`: 17:24:14 → 17:25:42  (87.4 s)
+- `odom`: 17:26:23 → 17:29:29  (185.7 s)
+- `odom`: 17:30:46 → 17:32:34  (108.2 s)
+- `platforms`: 17:28:03 → 17:29:17  (74.0 s)
+- `platforms`: 17:31:31 → 17:32:20  (48.5 s)

--- a/docs/analysis/2026-05-01/starlink_only_budget.md
+++ b/docs/analysis/2026-05-01/starlink_only_budget.md
@@ -1,0 +1,127 @@
+# Starlink-only operation budget — over-horizon survey
+
+Companion analysis to:
+- [`rolker/unh_echoboats_project11#124`](https://github.com/rolker/unh_echoboats_project11/issues/124) — post-mission review of the 2026-05-01 deployment
+- [`findings.md`](findings.md) — networking findings
+- [`bandwidth_test_2026-05-18.md`](bandwidth_test_2026-05-18.md) — link calibration
+
+**Goal context**: over-horizon survey work requires the boat to operate over Starlink only — WiFi will be out of range and we cannot count on it for control or visibility.
+
+## What was measured (2026-05-01 deployment, VPN connection)
+
+Demand split by category, summed across topics in each bucket. Numbers are
+per-topic averages summed within the bucket; peaks per individual topic can
+be ~10× higher because of H.264/H.265 IDR keyframes.
+
+| Bucket | Topics on VPN | Avg offered | Drop % | Notes |
+|---|---:|---:|---:|---|
+| **A. camera ffmpeg** (forward, starboard, port) | 3 | **2.27 Mbps** | 2–3% | aft was WiFi-only |
+| B. segmentation overlay (compressed) | 4 | 0.08 Mbps | <1% | low-rate |
+| C. seg `camera_info` | 1 | 0.015 Mbps | 0% | trivial |
+| E. mavros (FCU state) | 7 | 0.069 Mbps | <1% | |
+| F. mission / heartbeat / status | 4 | 0.018 Mbps | <1% | |
+| G. odom | 1 | 0.050 Mbps | 0% | |
+| I. tf | 1 | 0.044 Mbps | 1% | |
+| J. diagnostics | 1 | 0.133 Mbps | <1% | |
+| K. plan / viz / hover | 2 | 0.057 Mbps | 0% | only when active |
+| **Total VPN offered** | — | **~2.75 Mbps** | — | average; ignores keyframe-coincident peaks |
+
+`/bizzy/local_costmap/*` (~6.4 Mbps avg combined) was **WiFi-only** by config; not
+currently a Starlink-essential. Same for `oak_aft_ffmpeg` and several segmentation
+streams.
+
+## What Starlink delivers (2026-05-18 pier calibration)
+
+`iperf3 -u -l 1400` UDP loss curve, 65 ms RTT (gabby → bencloud WireGuard → salmon):
+
+| Offered | Loss |
+|---:|---:|
+| 5 Mbps | 0.19% |
+| 8 Mbps (configured cap) | ~0.4% interpolated |
+| 10 Mbps | 0.6% |
+| 15 Mbps | 1.2% |
+| 20 Mbps | 1.4% |
+
+Loss is structural (present even far below cap), not capacity-bound. Loss rate climbs
+roughly linearly with offered rate.
+
+## Headroom analysis — what fits, what doesn't
+
+Average demand (2.75 Mbps) sits well below the lossy knee (~5 Mbps). The problem is
+peaks. Each individual ffmpeg camera *peaked* (single-second worst) at:
+
+- oak_forward: 14.8 Mbps
+- oak_port: 7.9 Mbps
+- oak_starboard: 20.0 Mbps
+
+These are H.264/H.265 IDR keyframes. Three cameras keyframing simultaneously can
+spike combined demand to 30–40 Mbps on a link with ~10 Mbps "no-significant-loss"
+capacity — which is exactly what produced the §1.1 starboard 1.06 MB/s peak drop in
+the deployment data.
+
+Keyframe-burst mitigations (lowest to highest effort):
+
+1. **Stagger keyframes** across cameras — OAK encoder config tweak; doesn't change
+   bitrates, just decorrelates the spikes.
+2. **Longer GOP** — fewer keyframes per second; same total bytes, smoother in time.
+3. **CBR / capped-VBR** instead of unconstrained VBR — flattens peaks at the cost of
+   some motion-scene quality.
+4. **Lower per-camera bitrate** — current target is ~800 kbps each (PR #123 set
+   forward to 800; others may differ). 500 kbps × 3 = 1.5 Mbps avg, proportionally
+   smaller peaks.
+
+## Decision matrix — Starlink-only operating modes
+
+| Mode | Avg demand | Fits Starlink? | Operator visibility |
+|---|---:|---|---|
+| **Essentials only** (no video) | ~0.4 Mbps | comfortable at any range | dashboards + plan + heartbeat |
+| **Essentials + 1 camera** @ 800 kbps | ~1.2 Mbps | comfortable; minor keyframe drops | one camera live |
+| **Essentials + 1 camera** @ 500 kbps | ~0.9 Mbps | very comfortable | one camera live |
+| **Essentials + 3 cameras** (current config) | ~2.75 Mbps avg | works on average; keyframe coincidences blow past cap | all three live |
+| **Essentials + segmentation overlays only** (no full video) | ~0.5 Mbps | very comfortable | segmentation rendered as overlay; no raw video |
+
+**Operational essentials alone (0.4 Mbps) clear the Starlink budget by ~5× even
+at the lossy 20 Mbps zone.** Control / telemetry over Starlink is not the
+bottleneck — cameras are.
+
+## Caveats — what this analysis doesn't know
+
+1. **Pier ≠ underway.** Today's calibration was on the pier. Starlink Roam's
+   well-known weakness is satellite-handoff events (5–60 s burst-loss). The pier
+   sweep is 15 s windows; it won't catch handoffs.
+2. **2026-05-01 had WiFi.** udp_bridge ran with both paths active and the design
+   does not currently failover cleanly between paths. The deployment data tells us
+   how the *combined* system behaved; it does not tell us how Starlink-only would
+   behave with WiFi administratively unavailable.
+3. **Resend-layer rework is in flight.** The 30% steady-state resend overhead from
+   the deployment data is being addressed in a separate udp_bridge effort. After
+   that lands, the effective wire-overhead picture changes and these budgets may
+   need re-evaluation.
+4. **bencloud is the dominant VPN latency**, not Starlink itself (35 ms of the
+   65 ms RTT). If bencloud is overloaded or down, "Starlink only" doesn't apply
+   the way we expect. Worth a bencloud-side iperf3 for an independent sanity check.
+
+## Recommended next steps
+
+1. **Sustained Starlink UDP test** — 5–10 min iperf3 at 1 Mbps and at 5 Mbps to
+   characterize burst-loss events. Single 15 s windows hide satellite-handoff
+   periodicity.
+2. **WiFi-disabled rehearsal** — boat at pier, WiFi administratively down at the
+   MikroTik, udp_bridge restricted to VPN only. Observe what dies, what survives,
+   and what comes back after a forced 30 s VPN-only outage (simulated by killing
+   bencloud reachability briefly).
+3. **Keyframe-stagger config** — small win, immediate. Configure the OAK encoders
+   so the three cameras' GOP starts are offset by ⅓ GOP. Reduces keyframe-coincident
+   peaks without touching bitrates.
+4. **Define the Starlink-only profile** — explicit config (separate `bizzyboat.yaml`
+   profile or a runtime override) that turns off all non-essential topics and
+   restricts the VPN topics list to the "essentials + 0/1 camera" set. Default is
+   today's "everything everywhere"; an explicit profile makes Starlink-only ops
+   a one-config-flag change rather than a per-deployment hand-curation.
+5. **Operate-on-Starlink survey rehearsal** — pick a short hop (200 m, line of
+   sight to operator), deploy with the Starlink-only profile, recover. Compare to
+   today's per-topic outage budget.
+
+The substantive blocker to over-horizon survey is item 4 — the **explicit
+Starlink-only configuration profile**. Items 1–3 are calibration; item 5 is
+validation.

--- a/docs/analysis/2026-05-01/starlink_only_budget.md
+++ b/docs/analysis/2026-05-01/starlink_only_budget.md
@@ -59,16 +59,39 @@ spike combined demand to 30–40 Mbps on a link with ~10 Mbps "no-significant-lo
 capacity — which is exactly what produced the §1.1 starboard 1.06 MB/s peak drop in
 the deployment data.
 
-Keyframe-burst mitigations (lowest to highest effort):
+Current encoder config (verified 2026-05-19 in
+[`bizzyboat_project11/launch/oak_cameras_launch.py`](../../../bizzyboat_project11/launch/oak_cameras_launch.py)
+L9–18): **all four OAK cameras are at `h265_bitrate_kbps: 800`**, default
+`h265_keyframe_frequency_frames: 30` and **`fps: 5`** (`camera_base.hpp:21`
+default, no override) → **6 s GOP**, profile `H265_MAIN`. Rate control mode
+is not set, inherits depthai property default **CBR**. The 2.27 Mbps VPN
+average matches the configured target faithfully — the encoder is hitting
+CBR, the peaks are IDR-keyframe bursts within the CBR budget (depthai's
+CBR averages over a window, not per-frame; at 5 fps each frame carries
+~160 kbits mean, and IDRs for busy scenes can run many ×).
 
-1. **Stagger keyframes** across cameras — OAK encoder config tweak; doesn't change
-   bitrates, just decorrelates the spikes.
-2. **Longer GOP** — fewer keyframes per second; same total bytes, smoother in time.
-3. **CBR / capped-VBR** instead of unconstrained VBR — flattens peaks at the cost of
-   some motion-scene quality.
-4. **Lower per-camera bitrate** — current target is ~800 kbps each (PR #123 set
-   forward to 800; others may differ). 500 kbps × 3 = 1.5 Mbps avg, proportionally
-   smaller peaks.
+Keyframe-burst mitigations:
+
+1. **Stagger keyframes** across cameras via coprime
+   `h265_keyframe_frequency_frames` — the depthai v2.x API has no explicit
+   GOP-phase offset, but coprime intervals make IDR coincidences essentially
+   impossible. Doesn't change average bitrate. At fps=5 this is **the
+   primary lever**. **Landed in PR
+   [#134](https://github.com/rolker/unh_echoboats_project11/pull/134)**
+   (issue [#133](https://github.com/rolker/unh_echoboats_project11/issues/133))
+   with per-camera intervals 23/29/31/37 frames (forward shortest, aft
+   longest).
+2. **Longer GOP** — already at 6 s. Going further (12+ s) is unattractive
+   because viewer-recovery on packet loss is already at the upper edge of
+   usable.
+3. **CBR strictness** — already on CBR by default. No `capped-VBR` mode
+   exists in depthai's API (`VideoEncoderProperties::RateControlMode` is
+   `{CBR, VBR}` only; `maxBitrate` field exists but has no setter). No
+   further lever here.
+4. **Lower per-camera bitrate** — diminishing returns given averages already
+   match the 800 kbps target. The win would be proportionally smaller IDR
+   keyframes (rough rule of thumb: IDR ≈ 5–15× per-frame mean), not lower
+   averages.
 
 ## Decision matrix — Starlink-only operating modes
 

--- a/docs/logs/2026/2026-05-01_dev_logs.md
+++ b/docs/logs/2026/2026-05-01_dev_logs.md
@@ -1719,3 +1719,48 @@ distance.
 Net effect: comms loss → boat continues last cmd_vel; Nav2 crash
 → boat HOLDs. Geofence + manual-override RC remain as safety
 backstops.
+
+## Post-mission analysis (2026-05-18)
+
+Analysis pass against [#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §1 (Networking).
+Full trail at [`docs/analysis/2026-05-01/`](../../analysis/2026-05-01/) — start with
+[`README.md`](../../analysis/2026-05-01/README.md). Bag → SQLite via
+`ros2 run bag_analysis bag_to_sqlite` (now installed from
+[`rolker/marine_tools`](https://github.com/rolker/marine_tools)).
+
+### Headline findings
+
+- **WiFi cap is conservative by ~2×** at the pier — 12 Mbps configured
+  vs. ≥30 Mbps clean UDP measured (`bandwidth_test_2026-05-18.md`).
+  Cap-vs-distance behavior unmeasured; static raise is not safe for
+  long-range autonomy without dynamic adjustment.
+- **Starlink/VPN cap is matched to the link's lossy knee**, not
+  arbitrary — 0.19% UDP loss at 5 Mbps, climbing to 1.4% at 20 Mbps;
+  configured 8 Mbps cap sits at ~0.4% baseline loss.
+- **The 30% steady-state resend overhead seen across the deployment
+  is structural** — expected output of a 0.4%-baseline-loss link
+  under udp_bridge's current resend design. Not a bug. Already-in-flight
+  udp_bridge resend rework addresses it.
+- **One major "all red" event** (17:24–17:33 EDT, 9 minutes): all 7
+  CAMP-watched topics went silent simultaneously. Mechanism confirmed
+  as a resend storm —
+  `resend_dropped_bps` reached 13 MB/s on the 1.0 MB/s VPN link.
+  Almost certainly triggered by the mid-deployment VPN cap revert
+  (2.5 → 1.0 MB/s at 17:17 EDT, 7 min before the event).
+- **Operational essentials total ~0.4 Mbps** (heartbeat / mission /
+  mavros / odom / tf / diagnostics / plan) — comfortably within
+  Starlink's clean budget at any range. **Cameras are the bandwidth
+  bottleneck for over-horizon work**, not control or telemetry.
+
+### Issues filed from this analysis
+
+- [#130](https://github.com/rolker/unh_echoboats_project11/issues/130) — Field validation: over-horizon Starlink-only operation
+- [#131](https://github.com/rolker/unh_echoboats_project11/issues/131) — gabby: apply sysctl UDP receive-buffer tuning
+- [`rolker/udp_bridge#19`](https://github.com/rolker/udp_bridge/issues/19) — Add per-topic priority/class scheduling to the rate-limiter
+
+### Not yet done — §2 through §9 of #124
+
+Performance, power, autonomy/BT, SBG-vs-FCU, sonar, perception,
+comms-loss, operator UX. The bag → SQLite DB is in place; queries
+against the deployment data should be straightforward continuations
+of the §1 pattern (see [`network_queries.sql`](../../analysis/2026-05-01/network_queries.sql)).


### PR DESCRIPTION
## Summary

Lands the 2026-05-01 BizzyBoat deployment post-mission analysis into
the repo as a deployment-co-located artifact, and adds a summary
section to the dev log so the analysis trail lives with that day's
logs.

Part of [#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §1 (Networking).

## What's in the PR

1. **New directory** `docs/analysis/2026-05-01/`:
   - `README.md` — index + reproducibility notes
   - `findings.md` — full §1 analysis
   - `outage_events.md` — per-topic outage catalog
   - `starlink_only_budget.md` — over-horizon bandwidth analysis
   - `bandwidth_test_2026-05-18.md` — pier link calibration
   - `network_queries.sql` + `network_perlink_queries.sql` — query library

2. **New section** in `docs/logs/2026/2026-05-01_dev_logs.md`:
   `## Post-mission analysis (2026-05-18)` with TL;DR findings and links
   to the analysis directory and the three issues filed from it
   ([#130](https://github.com/rolker/unh_echoboats_project11/issues/130),
   [#131](https://github.com/rolker/unh_echoboats_project11/issues/131),
   [`rolker/udp_bridge#19`](https://github.com/rolker/udp_bridge/issues/19)).

## What's not in the PR (intentional)

- `2026-05-01_deployment.db` (2.8 GB) — derived SQLite extract,
  regeneratable from the bags. README explains the regen recipe.
- `network_perlink.py` — bag-walker that populates the per-topic /
  per-link tables. Currently lives on the dev workstation; should
  graduate into [`rolker/marine_tools`](https://github.com/rolker/marine_tools)'s
  `bag_analysis` package as a reusable extractor. Follow-up.

## Test plan

Docs-only PR. Verification by visual review:

- [ ] `docs/analysis/2026-05-01/README.md` renders cleanly on GitHub
      and its inline links resolve to siblings in the same directory.
- [ ] `docs/analysis/2026-05-01/findings.md` cross-links to
      `bandwidth_test_2026-05-18.md` and `outage_events.md` resolve.
- [ ] Dev-log "Post-mission analysis" section links to
      `../../analysis/2026-05-01/` resolve to the new directory.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
