### PR TITLE
Set coprime keyframe intervals on OAK cameras (#133)

### DIFF
--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 133
+---
+
+# Issue #133 — OAK cameras: coprime keyframe intervals to decorrelate IDR peaks for Starlink-only ops
+
+## External Review
+**Status**: complete
+**When**: 2026-05-19 09:55
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #134 — 1 Copilot review, 1 inline comment, 0 valid, 1 false positive.
+**CI**: copilot-pull-request-reviewer success (single check).
+
+### Actions
+- [ ] (Optional) Dismiss the Copilot review on #134 — the single inline
+  comment asks for redundant WHAT documentation that conflicts with the
+  workspace's "WHY-not-WHAT" comment rule (CLAUDE.md). The per-camera
+  mapping is authoritative in the dict literal at
+  `bizzyboat_project11/launch/oak_cameras_launch.py:19–32`; duplicating
+  it in the rationale comment would create a drift-prone second source
+  of truth.
+- [ ] Merge #134 once approved; remove worktree with
+  `.agent/scripts/worktree_remove.sh --issue 133`.
+- [ ] Bench-verify the new keyframe cadences on a dev OAK before
+  field deployment (test plan in PR body).

--- a/bizzyboat_project11/launch/oak_cameras_launch.py
+++ b/bizzyboat_project11/launch/oak_cameras_launch.py
@@ -6,15 +6,29 @@ from launch_ros.substitutions import FindPackageShare
 
 # BizzyBoat OAK camera MXIDs (verified 2026-03-30). Each entry may carry
 # optional flags; absent flags fall back to sea_surface_segmentation defaults.
+#
+# Coprime `h265_keyframe_frequency_frames` (23/29/31/37) decorrelate H.265
+# IDR keyframes across cameras so simultaneous IDR bursts don't overrun the
+# Starlink uplink (~5 Mbps lossy knee). The depthai v2.x VideoEncoder has
+# no GOP-phase offset or runtime forceIntraRequest, so pairwise-coprime
+# intervals are the only API-supported decorrelation. Aft has the longest
+# GOP since slower error-recovery hurts least on the least-critical view;
+# forward (primary nav view) has the shortest. At fps=5 the per-camera
+# GOPs are 4.6 / 5.8 / 6.2 / 7.4 s; the joint period (LCM) is ~42 hours,
+# so coincidences are effectively eliminated within a single deployment.
 CAMERAS = {
     'oak_forward':   {'mx_id': '19443010D117872D00', 'enable_video': False,
-                      'h265_enable': True, 'h265_bitrate_kbps': 800},
+                      'h265_enable': True, 'h265_bitrate_kbps': 800,
+                      'h265_keyframe_frequency_frames': 23},
     'oak_starboard': {'mx_id': '19443010E11A872D00', 'enable_video': False,
-                      'h265_enable': True, 'h265_bitrate_kbps': 800},
+                      'h265_enable': True, 'h265_bitrate_kbps': 800,
+                      'h265_keyframe_frequency_frames': 31},
     'oak_aft':       {'mx_id': '14442C10917D8DD700', 'enable_video': False,
-                      'h265_enable': True, 'h265_bitrate_kbps': 800},
+                      'h265_enable': True, 'h265_bitrate_kbps': 800,
+                      'h265_keyframe_frequency_frames': 37},
     'oak_port':      {'mx_id': '194430106121872D00', 'enable_video': False,
-                      'h265_enable': True, 'h265_bitrate_kbps': 800},
+                      'h265_enable': True, 'h265_bitrate_kbps': 800,
+                      'h265_keyframe_frequency_frames': 29},
 }
 
 


### PR DESCRIPTION
## Summary

Sets per-camera coprime `h265_keyframe_frequency_frames` on the four
OAK cameras so H.265 IDR keyframes don't burst simultaneously and
overrun the Starlink uplink (~5 Mbps lossy knee, per the 2026-05-18
pier calibration).

| Camera | Priority | Frames | GOP @ 5 fps |
|---|---|---:|---:|
| oak_forward   | highest (primary nav view) | **23** | 4.6 s |
| oak_port      | situational awareness      | **29** | 5.8 s |
| oak_starboard | situational awareness      | **31** | 6.2 s |
| oak_aft       | lowest (least critical)    | **37** | 7.4 s |

23/29/31/37 are pairwise coprime primes; joint period (LCM) is
~42 hours at fps=5, so per-camera IDRs effectively never coincide
within a single deployment. Aft gets the longest GOP since slower
viewer-recovery on packet loss matters least there.

The only knob touched is `h265_keyframe_frequency_frames` in the
`CAMERAS` dict literal of `bizzyboat_project11/launch/oak_cameras_launch.py`.
The launch file's existing param-copy loop already includes this key,
and `depthai_marine::CameraBase` already exposes it as a ROS param,
so no other code changes are needed.

### Why coprime (not explicit stagger)

The depthai v2.x `VideoEncoder` node has no GOP-phase offset and no
runtime `forceIntraRequest`. Coprime intervals across independent
encoder instances are the only API-supported decorrelation.

### Note on review math

The original issue (#133) cited the LCM as ~30 hours. The correct
value is **~42 hours** (LCM(23,29,31,37) = 765,049 frames ÷ 5 fps =
153,010 s). The conclusion is unchanged — coincidences are still
effectively eliminated within a single deployment. The comment in
this PR uses the corrected figure.

## Test plan

- [ ] Bench: launch all four cameras on a dev OAK; confirm the
      per-camera keyframe intervals stick by parsing `flags` /
      `is_keyframe` from the `ffmpeg_image_transport` packets on
      `/bizzy/sensors/cameras/oak_*/image_raw/ffmpeg`.
- [ ] Bag a short underway segment (or pier with motion in the
      scene), re-run the `2026-05-01_network_perlink.py`-style
      per-second peak query, and confirm coincident high-peak
      events drop to near-zero across the four cameras.
- [ ] Verify viewer recovery time after an induced packet loss is
      within the per-camera GOP budget (aft up to ~7.5 s; forward
      ~4.6 s).

Closes #133.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
