### PR TITLE
Deployment 2026-05-19: Starlink-only operation + OTH survey test

### DIFF
--- a/.agent/work-plans/issue-135/progress.md
+++ b/.agent/work-plans/issue-135/progress.md
@@ -13,16 +13,16 @@ issue: 135
 **CI**: no checks configured for this PR (matches existing project repo pattern)
 
 ### Actions
-- [ ] **C1-3** — Update `bizzyboat_project11/config/bizzyboat.yaml` line 234 comment to reflect the current `gps_vel` config (or strike the velocity-body claim; the durable answer rides on #138 reconfig)
-- [ ] **C16-20** — Add `#135` GitHub link to `docs/logs/2026/2026-05-19_gabby_logs.md` `**Deployment**:` header (dev-side curator action; field-mode host couldn't add it at write-time)
-- [ ] **C25-29** — Add `#135` GitHub link to `docs/logs/2026/2026-05-19_salmon_logs.md` `**Deployment**:` header (same as gabby)
-- [ ] **C23-24** — Reconcile gabby log's Phase 2 "complete / first-OTH" outcome wording (line 56) + `~14:30` mission timestamp (line 549) with dev-log reframe (line-of-sight, partial credit, recovered 14:09). Either edit gabby log directly or add a curator's reconciliation note pointing to dev log 20:48.
-- [ ] **C21-22** — Decide: operator-curate gabby Summary (line 18) + Lessons Learned (line 46), OR accept as agent-draft state
-- [ ] **C30-31** — Decide: operator-curate salmon Summary (line 14) + Lessons Learned (line 18), OR accept as agent-draft state
-- [ ] **C32** — Add to `docs/logs/README.md` near line 13: brief clarification that field-host logs without GitHub credentials may use the git-bug ID alone, with the GitHub link added at wrap-up
-- [ ] **C33** — Clarify `docs/logs/README.md` wrap-up step 3 (line 134): cherry-pick field-host commits from gitcloud into the deployment PR branch (`make sync` alone only updates the local `gitcloud/jazzy` ref, doesn't publish to GitHub)
-- [ ] (Optional) Address editorial nits C6-C10 (tide/current heights + TZ tagging convention), C13-C15 (forward-references / wrap-up bullet predating reframe)
-- [ ] (Optional) Dismiss C11 on the PR (false-positive flag against the canonical agent-team email)
+- [x] **C1-3** — bizzyboat.yaml line 234 comment reconciled (commit `d563ca4`)
+- [x] **C16-20** — gabby log header gains `#135` link (commit `23161c1`)
+- [x] **C25-29** — salmon log header gains `#135` link (commit `9859a58`)
+- [x] **C23-24** — gabby log Phase 2 reconciliation notes appended (commit `8d7308d`)
+- [ ] **C21-22** — Decide: operator-curate gabby Summary (line 18) + Lessons Learned (line 46), OR accept as agent-draft state — deferred (accept as living-record state for merge)
+- [ ] **C30-31** — Decide: operator-curate salmon Summary (line 14) + Lessons Learned (line 18), OR accept as agent-draft state — deferred (accept as living-record state for merge)
+- [ ] **C32** — Add to `docs/logs/README.md` near line 13: brief clarification that field-host logs without GitHub credentials may use the git-bug ID alone, with the GitHub link added at wrap-up — deferred to follow-up
+- [ ] **C33** — Clarify `docs/logs/README.md` wrap-up step 3 (line 134): cherry-pick field-host commits from gitcloud into the deployment PR branch — deferred to follow-up
+- [ ] (Deferred) Editorial nits C6-C10, C13-C15 — historical-author-voice, leave
+- [ ] (Optional) Dismiss C11 on the PR — false-positive flag against canonical agent-team email
 
 ### Already addressed (no action needed)
 - C4, C5 — dev log Summary + Lessons Learned (populated in commit `df40805`)

--- a/.agent/work-plans/issue-135/progress.md
+++ b/.agent/work-plans/issue-135/progress.md
@@ -1,0 +1,33 @@
+---
+issue: 135
+---
+
+# Issue #135 — Deployment 2026-05-19: Starlink-only operation + OTH survey test
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 17:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #136 — 9 review(s), 8 valid clusters, 1 false positive, 3 already addressed, 5 editorial
+**CI**: no checks configured for this PR (matches existing project repo pattern)
+
+### Actions
+- [ ] **C1-3** — Update `bizzyboat_project11/config/bizzyboat.yaml` line 234 comment to reflect the current `gps_vel` config (or strike the velocity-body claim; the durable answer rides on #138 reconfig)
+- [ ] **C16-20** — Add `#135` GitHub link to `docs/logs/2026/2026-05-19_gabby_logs.md` `**Deployment**:` header (dev-side curator action; field-mode host couldn't add it at write-time)
+- [ ] **C25-29** — Add `#135` GitHub link to `docs/logs/2026/2026-05-19_salmon_logs.md` `**Deployment**:` header (same as gabby)
+- [ ] **C23-24** — Reconcile gabby log's Phase 2 "complete / first-OTH" outcome wording (line 56) + `~14:30` mission timestamp (line 549) with dev-log reframe (line-of-sight, partial credit, recovered 14:09). Either edit gabby log directly or add a curator's reconciliation note pointing to dev log 20:48.
+- [ ] **C21-22** — Decide: operator-curate gabby Summary (line 18) + Lessons Learned (line 46), OR accept as agent-draft state
+- [ ] **C30-31** — Decide: operator-curate salmon Summary (line 14) + Lessons Learned (line 18), OR accept as agent-draft state
+- [ ] **C32** — Add to `docs/logs/README.md` near line 13: brief clarification that field-host logs without GitHub credentials may use the git-bug ID alone, with the GitHub link added at wrap-up
+- [ ] **C33** — Clarify `docs/logs/README.md` wrap-up step 3 (line 134): cherry-pick field-host commits from gitcloud into the deployment PR branch (`make sync` alone only updates the local `gitcloud/jazzy` ref, doesn't publish to GitHub)
+- [ ] (Optional) Address editorial nits C6-C10 (tide/current heights + TZ tagging convention), C13-C15 (forward-references / wrap-up bullet predating reframe)
+- [ ] (Optional) Dismiss C11 on the PR (false-positive flag against the canonical agent-team email)
+
+### Already addressed (no action needed)
+- C4, C5 — dev log Summary + Lessons Learned (populated in commit `df40805`)
+- C12 — phase/window/activity table (current file has clean 3-column table)
+- C34 — roadmap.md `#110` vs `#111` reference (full roadmap rewrite this session correctly distinguishes them)
+
+### False positives
+- C11 — git-bug identity email `roland+claude-code@ccom.unh.edu` is the canonical agent-team role-based address (`+claude-code` suffix), intentionally public in commit signatures per `.agent/scripts/set_git_identity_env.sh`. Not PII in this context.

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -231,8 +231,10 @@
       # FCU EKF3-fused nav at CG (mavros local_position plugin). These
       # are the FCU-side counterparts to SBG's ekf_nav / ekf_quat /
       # imu_data so SBG-vs-FCU comparison at base_link is reproducible
-      # from the bag. velocity_body is also what mru_transform consumes
-      # to produce /bizzy/odom.
+      # from the bag. velocity_body was the mru_transform velocity
+      # input under the 2026-04-28 config; the 2026-05-19 field revert
+      # restored raw/gps_vel (see mru_transform block above). Durable
+      # nav-input choice tracked in #138 (FCU reconfig).
       - /bizzy/mavros/local_position/odom
       - /bizzy/mavros/local_position/pose
       - /bizzy/mavros/local_position/velocity_local

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -22,8 +22,8 @@
         mru:
           topics:
             orientation: "mavros/imu/data"
-            position: "mavros/global_position/global"
-            velocity: "mavros/local_position/velocity_body"
+            position: "mavros/global_position/raw/fix"
+            velocity: "mavros/global_position/raw/gps_vel"
 
 /**/deltat:
   ros__parameters:
@@ -40,8 +40,8 @@
       mru:
         topics:
           orientation: "mavros/imu/data"
-          position: "mavros/global_position/global"
-          velocity: "mavros/local_position/velocity_body"
+          position: "mavros/global_position/raw/fix"
+          velocity: "mavros/global_position/raw/gps_vel"
     sensor_names:
     - mru
 

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -343,3 +343,149 @@ Left to do when session resumes:
 - Operator-curated **Summary** and **Lessons Learned** sections at
   the top of this log.
 - Merge the wrap-up PR (#136) to close #135.
+
+**2026-05-19T20:48-04:00** — Roland + Claude Code (resume cont.):
+follow-up triage complete. Walked through 16 candidate findings
+surfaced by the dev + gabby + salmon logs and decided each
+individually. Net: 11 new issues filed, 3 comments on existing
+issues, 2 captured here as dev-log-only observations (not worth
+their own issue), and the brainstorm at the end produced one
+design issue.
+
+### Phase outcome reframe
+
+Original framing in the timeline above was "Phase 1 ✓, Phase 2
+deferred." With Roland's clarification: Phase 2 was substantially
+attempted, not deferred. A partial survey pattern was initiated
+(cut short on time) before the cross-harbour trackline, and the
+entire on-water phase ran with operator-side WiFi off — so the
+Starlink-only data-path test (the comms-half of Phase 2's intent)
+was substantively validated. Three Phase 2 elements per #135:
+
+- ✓ Starlink-only
+- ✗ Out of line of sight (boat stayed in harbor)
+- ✓ Survey initiated (partial — cut short on time)
+
+`#130` (Field validation: over-horizon Starlink-only operation)
+gets substantial partial-credit data from today but stays open —
+a true OOL + completed-survey attempt still has to happen.
+
+### Follow-up issues filed (11 new)
+
+| # | Source finding | Repo | Issue |
+|---|---|---|---|
+| 1 | M3 sonar missing pings (suspected ping-rate × depth) | `unh_echoboats_project11` | [#137](https://github.com/rolker/unh_echoboats_project11/issues/137) |
+| 2 | `mru_transform` durable nav-input choice (mavros raw / SBG / mavros + geoid) | `unh_echoboats_project11` | [#138](https://github.com/rolker/unh_echoboats_project11/issues/138) |
+| 3a | `mikrotik_monitor` + `teltonika_monitor` crash on startup (try/except needed) | `ros2_network_monitor` | [#23](https://github.com/rolker/ros2_network_monitor/issues/23) |
+| 3b | Replace `output='screen'` with `output='both'` in BizzyBoat launches | `unh_echoboats_project11` | [#139](https://github.com/rolker/unh_echoboats_project11/issues/139) |
+| 4 | udp_bridge stats-timer stall during Starlink-only ops | `udp_bridge` | [#20](https://github.com/rolker/udp_bridge/issues/20) |
+| 5 | udp_bridge resend-give-up "after N attempts" N=5/6/1 — meaningful or counter glitch? | `udp_bridge` | [#21](https://github.com/rolker/udp_bridge/issues/21) |
+| 6 | Remove stale `bencloud` ping target (doesn't reflect WG link) | `unh_echoboats_project11` | [#140](https://github.com/rolker/unh_echoboats_project11/issues/140) |
+| 7 | `/Operator/*` aggregator buckets STALE (path mismatch with `/Other/*` publishers) | `unh_echoboats_project11` | [#141](https://github.com/rolker/unh_echoboats_project11/issues/141) |
+| 10 | Operator-side local costmap display (transmission cost + design path to CAMP) | `unh_marine_autonomy` | [#127](https://github.com/rolker/unh_marine_autonomy/issues/127) |
+| 11 | Host thermals as `DiagnosticStatus` (lm-sensors + NVMe SMART) | `unh_echoboats_project11` | [#142](https://github.com/rolker/unh_echoboats_project11/issues/142) |
+| 12 | Install pre-commit hooks on salmon's workspace clone (`make lint` never run) | `unh_echoboats_project11` | [#143](https://github.com/rolker/unh_echoboats_project11/issues/143) |
+
+### Comments on existing issues (3)
+
+| Source finding | Existing issue | Comment |
+|---|---|---|
+| gabby SSH_AUTH_SOCK gap at agent startup (git-bug needs ssh-agent) | `ros2_agent_workspace#423` | [comment](https://github.com/rolker/ros2_agent_workspace/issues/423#issuecomment-4492896368) |
+| (Initial) "git-bug field-side `github-url` metadata missing" — later retracted | `ros2_agent_workspace#423` | [original](https://github.com/rolker/ros2_agent_workspace/issues/423#issuecomment-4492975868) + [correction](https://github.com/rolker/ros2_agent_workspace/issues/423#issuecomment-4493225349) |
+| `git_bug_setup.sh`: configure GitHub bridge per-repo (filed as separate issue, then partially retracted in correction comment) | `ros2_agent_workspace#476` | [filed](https://github.com/rolker/ros2_agent_workspace/issues/476) + [correction](https://github.com/rolker/ros2_agent_workspace/issues/476#issuecomment-4493225257) |
+
+### Captured here only (not separately filed)
+
+- **Duplicate `/bizzy/sensors/sbg_device` graph entry.** Gabby
+  log §2 — one real PID (19244), second name registration is a
+  graph-level ghost from a prior lifecycle. Service-call routing
+  could be ambiguous. Not deploy-blocking; no clean fix path
+  available right now (likely RMW/Zenoh discovery-state quirk).
+  Watch for recurrence; revisit if it causes a real failure.
+
+- **NVMe Sensor 1 at 71.8 °C on gabby.** Gabby log §11 — inside
+  the consumer-SSD thermal-throttle band (~70–75 °C), but well
+  below NVMe critical (114.8 °C) and no climb across the 10-min
+  cron window. Pure observation; the actionable response to "SSD
+  might throttle" is exactly what [#142](https://github.com/rolker/unh_echoboats_project11/issues/142)
+  is for — once host thermals are a `DiagnosticStatus`, the trend
+  becomes bag-recordable and a real threshold crossing will surface
+  as a diagnostic.
+
+- **SBG `ros_standard: true` not producing standard ROS topics.**
+  Gabby log §2 — already tracked as the open git-bug bug
+  `7c94549` (= `rolker/unh_echoboats_project11#117`). Not
+  re-filing; existing issue is the right place to discuss.
+
+### git-bug "orphan" investigation post-mortem
+
+I cascaded a chain of wrong issues based on salmon agent's
+diagnosis that "`github-url` metadata is not populated for git-bug
+`e3c373a`." Built on that, ending up about to push 3 supposed
+orphans to GitHub. Verifying just before running revealed: of 34
+open bugs in `unh_echoboats_project11`'s git-bug store, **all 34
+are linked to GitHub issues with `github-url` metadata correctly
+populated**. The salmon agent's observation (and mine) was based
+on `git bug bug show --format=json` not surfacing the metadata
+field in its JSON shape — but the data IS there, visible via
+`git bug bug --format=json` (the LIST command). Pure tooling
+artifact, not a real workflow gap.
+
+Cascading corrections went to `ros2_agent_workspace#476` (issue
+left intact with corrective comment so the trail is traceable
+rather than rewritten) and `ros2_agent_workspace#423` (correction
+comment under the bad one). Lesson recorded as durable feedback in
+agent memory: when a previous agent diagnoses "X is missing from
+output Y", verify against a case where X is known to be present
+before building on it.
+
+The remaining valid ideas from the (otherwise wrong-premise) `#476`
+body: extending `git_bug_setup.sh`'s per-repo loop to also
+configure the GitHub bridge for github-origin repos would be
+preventive infrastructure (no orphans exist today, but if anyone
+ever did use `git bug bug new` in a bridgeless project repo,
+they'd create one); and adding a host suffix to git-bug identity
+(`Claude Code Agent (gabby)` vs `(salmon)` vs `(deadpool)`) would
+make future investigations like this one considerably faster.
+Those ideas stay in `#476` for follow-up.
+
+### Brainstorm: workspace observability design
+
+Ran `/brainstorm` against today's three observability gaps
+(silent Nav2 lifecycle abort, silent operator-monitor startup
+crashes, silent udp_bridge stats stall) and landed on a
+defense-in-depth approach using existing ROS 2 primitives rather
+than a new lifecycle manager.
+
+Filed [`rolker/ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5)
+— *Add observability mode: emit DiagnosticStatus for tracked
+processes and lifecycle nodes*. Design captures:
+
+1. Process-death detection on tracked `ExecuteProcess` actions →
+   `DiagnosticStatus` (catches today's monitor-crash shape).
+2. Lifecycle node `~/transition_event` subscription →
+   `DiagnosticStatus` on aborts (catches today's Nav2 abort shape).
+3. `ros2launch_session run <launch_file>` CLI entry-point so
+   existing launches adopt by changing the invocation, not the
+   launch file (Path C).
+
+Topic-staleness detection (built-in ROS 2 `topic_statistics` +
+aggregator analyzers, catches the udp_bridge-stats-stall shape) is
+the same brainstorm's separate concern, deferred to its own
+session — most natural home is `unh_marine_autonomy`. Not filed
+yet.
+
+CAMP doesn't consume diagnostics today (verified by grep), but
+the existing operator setup already surfaces them via a separate
+rqt instance running annunciator + robot_monitor — no gap to file
+for CAMP.
+
+### Still pending for full wrap-up
+
+- Operator-curated **Summary** and **Lessons Learned** sections
+  at the top of this log.
+- Complete mercat QPS data pull from where the transfer stopped.
+- `docs/roadmap.md` updates for the partial Phase 2 +
+  what got deferred today.
+- Full carry-forward audit per `docs/logs/README.md` (next).
+- Mark PR #136 ready for review + merge to close #135.

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -288,3 +288,32 @@ through the deployment PR** — gabby and mercat are field-mode
 gitcloud; deadpool picks them up via `make sync` and they land on
 local `jazzy` directly. Only the dev log goes through #136. (Earlier
 dev-agent assertion to the contrary corrected here.)
+
+**2026-05-19T14:37-04:00** — Roland: gabby + salmon logs transferred;
+mercat QPS data only **partially transferred**. Operator stopping
+here; will resume later. Total in `~/data/logs/` today after 12:00
+EDT: ~3.4 GB across ROS bags (image, sonar, operator) and the
+operator session bag. Biggest single artifact: 2.0 GB image bag
+(`bag_2026-05-19T13.13.20_ffmpeg_seg`) covering Phase 1 + the long
+trackline.
+
+## Wrap-up — paused
+
+Left to do when session resumes:
+
+- Complete mercat QPS data pull from where the transfer stopped.
+- Full carry-forward audit per `docs/logs/README.md` wrap-up
+  checklist.
+- Follow-up issues to consider filing:
+  - **M3 → mercat local-network drops** (was mis-framed today; the
+    drops are on the boat's own LAN, NOT Starlink — investigate
+    mercat NIC / socket-buffer / resource contention).
+  - **mru_transform position-source ellipsoidal-vs-MSL mismatch**
+    — today's revert was a workaround; root cause still in place.
+  - **mikrotik_monitor not running on salmon** — possible
+    operator-side observability gap.
+- `docs/roadmap.md` updates for anything deferred (phase 2 OTH
+  survey didn't happen today; remains a future-deployment item).
+- Operator-curated **Summary** and **Lessons Learned** sections at
+  the top of this log.
+- Merge the wrap-up PR (#136) to close #135.

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -1,0 +1,34 @@
+# BizzyBoat deployment log — dev — 2026-05-19
+
+**Host**: dev
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
+**Mode**: dev (GitHub origin)
+**Deployment**: [#135](https://github.com/rolker/unh_echoboats_project11/issues/135)
+
+## Summary
+
+_(user-curated at wrap-up — what today was about with the benefit of
+hindsight)_
+
+## Lessons Learned
+
+_(user-curated at wrap-up — durable operator-level take-home messages)_
+
+## Scope (from #135)
+
+Two-phase test:
+
+1. **Starlink-only operation at close range.** WiFi disabled at
+   operator station; validate fixes since 2026-05-01 (#134 keyframe
+   stagger; udp_bridge#16 throughput regression fix; camp#51 NavSource
+   QoS workaround) actually deliver the expected Starlink budget.
+2. **Over-horizon survey attempt.** Conditional on phase 1.
+
+## Tides + weather
+
+_(to fill in once operator confirms — tide heights in metres, tide
+times explicitly TZ-tagged)_
+
+## Timeline
+
+_(append in forward-chronological order, EDT)_

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -656,3 +656,169 @@ for CAMP.
   what got deferred today.
 - Full carry-forward audit per `docs/logs/README.md` (next).
 - Mark PR #136 ready for review + merge to close #135.
+
+## Post-mission data review
+
+**2026-05-19T22:57-04:00** — Roland + Claude Code: operator
+flagged before close-out that the previous deployment's
+post-mission analysis list ([#124](https://github.com/rolker/unh_echoboats_project11/issues/124))
+had an SBG-vs-FCU comparison checkbox that, had it been run, would
+likely have caught today's `mru_transform` issue at the
+2026-04-28 commit. Running the same shape of analysis today
+before close-out to surface anything that would otherwise drift
+into the next deployment unnoticed.
+
+### Setup
+
+Both boat-side bags extracted to one SQLite DB via
+`python3 -m bag_analysis.cli.bag_to_sqlite ... --append`:
+
+```
+~/data/logs/analysis/2026-05-19/bizzyboat.db  (1.1 GB, 2.51M msgs)
+```
+
+Covers both bag #1 (12:07–13:30 EDT, pre-launch + Phase 1 first
+portion incl. mru_transform failure) and bag #2 (13:30–14:16
+EDT, post-revert long trackline + survey attempt + recovery) in
+a single queryable surface.
+
+### 1. Diagnostics anomalies → bigger finding than expected
+
+**Nav2's `lifecycle_manager_navigation` already publishes ERROR
+`DiagnosticStatus`.** During the 13:14:40–13:29:13 EDT failure
+window, `lifecycle_manager_navigation: Nav2 Health` ERROR fired
+**873 times at 1 Hz**. The "silent failure" framing of the
+earlier brainstorm was incomplete — the signal exists. The gap is
+**downstream chronic noise**.
+
+ERROR-level diagnostic names today, by persistence:
+
+| Name | ERROR count | Window | Notes |
+|---|---|---|---|
+| `udp_bridge: bizzy: operator: wifi` | 5147 | 12:21–14:15 | Chronic — ERROR even when WiFi is up |
+| `ping_monitor: ping.bizzy: salmon_direct` | 2520 | 12:21–13:55 | Chronic unreachable |
+| `ping_monitor: ping.bizzy: router_op_direct` | 2488 | 12:21–13:52 | Chronic unreachable |
+| `lifecycle_manager_navigation: Nav2 Health` | **873** | **13:14:40–13:29:13** | **The signal that should have stood out** |
+| `starlink_diagnostics: starlink.bizzy: link` | 37 | 12:24–13:45 | Brief, real transitions |
+| `mavros: System / UAS / Heartbeat / GPS / Battery` | 2–21 each | 12:07–13:30 | Startup transients (normal) |
+
+The chronic-noise ERROR names had the operator's toplevel rollup
+permanently in ERROR; the new `Nav2 Health` ERROR transition was
+indistinguishable from the existing baseline noise. WARN-level
+noise is similarly chronic (`mavros: Mount` 7651; unused router
+ports 7640 each; unused cellular interfaces 7638 each).
+
+**Action**: folded into [`#141`](https://github.com/rolker/unh_echoboats_project11/issues/141#issuecomment-4494089615)
+(scope expanded from `/Operator/*` STALE-buckets to broader
+diagnostics aggregator config hygiene). Also revised the brainstorm
+direction on [`rolker/ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5#issuecomment-4494089803)
+— the lifecycle-subscription sub-task is partially redundant for
+Nav2 (already published); the PID-watchdog + CLI sub-tasks stay.
+
+### 2. udp_bridge with vs. without WiFi
+
+**Boat-side stats publication did NOT stall.** `/bizzy/udp_bridge/topic_statistics`
+kept publishing steadily at ~60 samples/min through every phase,
+including the entire ≈1h17m of Starlink-only operation. So the
+operator-side stall (salmon log §14) is **operator-side-bridge
+specific**, not a bridge-wide condition. Answers the open question
+on [`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20#issuecomment-4494089749).
+
+**Resend storm scales 23× when autonomy is active over half-broken
+comms, not when WiFi is cut alone.** Per-minute boat-side
+throughput, focusing on the WiFi-off window (min = minutes from
+bag start at 12:07):
+
+| Min | EDT | msg/s | send_OK kB/s | Note |
+|---|---|---|---|---|
+| 42–64 | 12:49–13:11 | ~540 | ~830 | Normal: WiFi-on + recent cut (no mission) |
+| 65 | 13:12 | 16,372 | 2,838 | **Roland tries to run mission — storm onset** |
+| 66–68 | 13:13–13:15 | 11k–22k | 2k–3k | Nav stack bringup fails, restarts |
+| 69–82 | 13:16–13:29 | **132,627** | **19,200** | **Storm peak — 23× normal msg rate, 19 MB/s through bridge** |
+| 83 | 13:30 | 456 | 414 | Storm collapses with full-stack relaunch |
+| 84–100 | 13:31–13:47 | ~590 | ~830 | Normal again (mission running cleanly) |
+
+WiFi cut alone (min 46 = 12:53 EDT) only modestly shifted
+throughput. The 23× explosion only happens when **mission
+execution + half-broken comms** coincide. Storm collapses
+*exactly* with the full-stack relaunch at 13:30.
+
+### 3. mavros (raw + EKF) vs SBG — smoking gun for #138
+
+`mavros/global_position/global` doesn't just have a frame-reference
+problem (EKF origin / home vs ellipsoidal). It has a **monotonic
+upward Z drift of ~5 m/hour**, demonstrated cleanly across the
+deployment. Per-minute altitude (m) across sources:
+
+| EDT | mav_raw_alt | mav_global_alt | bizzy_odom_z | sbg+undulation |
+|---|---|---|---|---|
+| 12:10 | -21.05 | -21.41 | -21.41 | -21.56 |
+| 12:30 | -24.11 | -21.63 | -21.63 | -24.68 |
+| 13:00 | -23.93 | -14.27 | -14.27 | -24.46 |
+| 13:10 | -23.89 | -12.78 | -12.78 | -24.46 |
+| **13:30** | -23.78 | -11.51 | **-23.78** | -24.36 |
+| 13:45 | -23.76 | -9.44 | -23.82 | -24.32 |
+| 14:00 | -23.79 | -6.40 | -23.79 | -24.36 |
+
+`mavros/global_position/global` drifts from −21 m → −2.5 m over
+the deployment, no leveling — likely missing GPS altitude updates
+feeding the EKF, and with the boat on calm water there's no
+constraint to pull it back. `/bizzy/odom` pos_z jumps cleanly from
+−11.51 m → −23.78 m at 13:30 EDT — exact moment of the revert +
+full-stack relaunch.
+
+**Rules out Option C** (`mavros/global` + geoid compensation) from
+[`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138#issuecomment-4494089690).
+Even with perfect geoid compensation, the underlying Z drift would
+push the estimate outside the plausibility band within hours. Real
+choice is A (mavros raw/fix, current revert) vs B (SBG).
+
+**Velocity is fine across sources.** mavros `local_position/odom`
+and SBG `ekf_nav` velocities agree within ~10 mm/s across the
+deployment (0.2–0.4 m/s drift, 1.5–1.7 m/s under mission speed).
+The drift problem is altitude-specific to the EKF path.
+
+### 4. Battery voltage (no current meter)
+
+Per memory and bizzyboat hardware: voltage is real, current /
+charge / capacity / percentage from `mavros/battery` are
+placeholders — never reported as if measured.
+
+Voltage by phase (avg / min over each phase):
+
+| Phase | V_avg | V_min |
+|---|---|---|
+| Pre-launch idle (12:08–12:15) | 28.55 | 27.62 |
+| Phase 1 WiFi-on (12:15–12:53) | 28.32 | 26.96 |
+| WiFi-OFF (12:53–13:47) | 28.18 | 26.54 |
+| Long trackline / survey (13:33–13:47) | 27.96 | 27.14 |
+| WiFi-back recovery (13:47–14:09) | 27.87 | 26.64 |
+| Post-recovery (14:09–14:16) | 28.15 | 28.09 |
+
+- Start (12:07): **28.54 V** (idle).
+- End (14:15): **28.15 V** (idle after recovery).
+- Rested-to-rested drop over ~2h 8m: **~0.4 V**.
+- Under-load sag: V_min hit ~26.5 V on peak maneuvers (turns,
+  accel) — normal for a 8S LiFePO4 pack, no concern.
+- Bounce-back to 28.15 V at rest post-deployment matches
+  expected surface-charge recovery shape.
+
+For "deployment without recharging" planning: voltage profile is
+healthy. A second similar deployment would land near 28.15 V → ~27.75
+V end-to-end on the same shape — still well within operating range
+for LiFePO4 (effective empty around 24 V). For a sharper projection,
+extract the 2026-05-01 boat-side bag into the same DB schema and
+compare the discharge curve over a longer effective duration; the
+2-bag composite would also help calibrate where on the LiFePO4
+discharge curve we're actually operating (the curve is flat for
+most of the SoC range, so two short deployments stitched together
+are more informative than either alone).
+
+### Source
+
+All queries above run against
+`~/data/logs/analysis/2026-05-19/bizzyboat.db`. Extraction is
+reproducible: source `/opt/ros/jazzy/setup.bash` +
+`layers/main/sensors_ws/install/setup.bash`, then
+`python3 -m bag_analysis.cli.bag_to_sqlite --bag <bag_dir> --output ...`
+(use `--append` for the second bag).

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -289,6 +289,16 @@ gitcloud; deadpool picks them up via `make sync` and they land on
 local `jazzy` directly. Only the dev log goes through #136. (Earlier
 dev-agent assertion to the contrary corrected here.)
 
+> ⚠️ Dev-agent correction logged at 17:26 — the bolded claim above
+> is **also** wrong (this is the second iteration of the same
+> mistake). Field-mode is the gitcloud-side carve-out; the
+> github-origin `jazzy` is still protected and field-host commits
+> still require a PR to land there. `make sync` only updates the
+> local `gitcloud/jazzy` ref. User preference for today's wrap-up:
+> bundle the field-host commits into the deployment PR by
+> cherry-picking onto `feature/issue-135`. See the 17:26 entry for
+> the action taken.
+
 **2026-05-19T14:37-04:00** — Roland: gabby + salmon logs transferred;
 mercat QPS data only **partially transferred**. Operator stopping
 here; will resume later. Total in `~/data/logs/` today after 12:00
@@ -296,6 +306,22 @@ EDT: ~3.4 GB across ROS bags (image, sonar, operator) and the
 operator session bag. Biggest single artifact: 2.0 GB image bag
 (`bag_2026-05-19T13.13.20_ffmpeg_seg`) covering Phase 1 + the long
 trackline.
+
+**2026-05-19T17:26-04:00** — Roland + Claude Code (resume): wrap-up
+session restarted. First action: bundle the field-host commits into
+PR #136 (correcting the 14:22 procedure error). Cherry-picked three
+commits from `gitcloud/jazzy` onto `feature/issue-135`:
+
+- `c36acfa` → `ece31dc` `fix(bizzyboat): revert mru_transform nav input to mavros raw/fix`
+- `dca6a99` → `078f05f` `docs(logs): 2026-05-19 gabby deployment log`
+- `db4810a` → `bc1bc75` `docs(logs): 2026-05-19 salmon deployment log`
+
+Pushed to origin; PR #136 now contains the full deployment artifact
+set (dev log + gabby log + salmon log + field-side mru_transform
+revert). One merge of #136 will close #135 with the full record on
+github-origin `jazzy`. `docs/logs/README.md`'s step #3 wording is
+implicated in the recurring confusion and likely needs a clarifying
+edit, but that's a separate concern from this deployment.
 
 ## Wrap-up — paused
 

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -911,3 +911,74 @@ METAR for KPSM (Pease) fetched via
 `curl https://aviationweather.gov/api/data/metar?ids=KPSM&format=raw&hours=12`.
 Pease is the closest airport with sea-level-pressure reporting; ~20 km
 from the Judd Gregg pier deployment site.
+
+### 7. udp_bridge investigation — corrections + root causes
+
+Initial post-mission framing called the 13:12–13:29 EDT
+`messages_per_second` spike "a 23× resend storm correlated with
+autonomy activity." Subsequent code-tracing + bag replay reframed this:
+
+**There was no ROS topic publication storm.** Verified every bagged
+topic publishes at the same rate in both pre-failure and failure
+windows (including `/rosout`, `/tf`, `/diagnostics`). ROS-side
+activity was unchanged.
+
+**The 132k aggregate `messages_per_second` spike traces to one topic.**
+Per-bucket replay of `topic_statistics`: `/bizzy/marine/response`
+running at **48,990 msg/s** during the failure window (vs ~0
+baseline). Across 3 contributing buckets (init + vpn destination +
+wifi destination) ≈ 144k.
+
+**Root cause: bidirectional bridge feedback loop on `marine/response`.**
+Both boat-side and operator-side `bizzyboat.yaml` configure
+`command_response: {source: marine/response}` — bridge subscribes to
+local `marine/response` and publishes received messages to local
+`marine/response`, creating a forwarding loop. Latent since commit
+`9985192` (2026-03-27 — original add of `bizzyboat_project11`); only
+activated today at the nav-stack restart around 13:13 EDT. Why it
+activates sometimes but not always: not pinned. Filed as
+[`#144`](https://github.com/rolker/unh_echoboats_project11/issues/144).
+
+**Resend WARN log volume confirmed NEW since
+[`udp_bridge#13`](https://github.com/rolker/udp_bridge/pull/13).**
+Cross-deployment query: 2026-05-01 boat-side bag (3.6h, pre-`#13`)
+has **0** `Giving up on resend` WARN entries in `/rosout`. Today's
+bag (post-fix, 2h 8m) has **27,992**. The fix introduced per-event
+WARN logging on each give-up; works as designed but is operator-
+distracting on lossy links. Filed as
+[`udp_bridge#22`](https://github.com/rolker/udp_bridge/issues/22).
+
+**Reconciliation:** The earlier comment on [`udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20)
+that framed the spike as "resend storm scales 23× with autonomy" was
+based on metric I didn't understand. Walk-back posted as a follow-up
+comment on `#20`. The boat-side `topic_statistics` did NOT stall
+(that finding stands); operator-side stall remains the open subject
+of `#20`.
+
+## Pending after 2026-05-20 break
+
+Not done in this session — to pick up next time:
+
+- **Finding #4 (battery / power) discussion** — never engaged with
+  user. Open question: extract 2026-05-01 boat-side bag into the same
+  `bag_analysis` SQLite schema; compare discharge curves to better
+  calibrate where on the flat LiFePO4 curve we're operating. Relevant
+  to the user's plan that the next deployment might happen without
+  recharging.
+- **Audit of other potentially-bidirectional bridge topics** per
+  [`#144`](https://github.com/rolker/unh_echoboats_project11/issues/144)
+  — diff boat-side `topics:` block vs operator-side `topics:` block
+  in `bizzyboat.yaml` and flag any other entries that appear on both
+  sides. Quick to do.
+- **Operator-curated Summary + Lessons Learned at top of this log**
+  — user-driven; awaiting input.
+- **Complete mercat QPS data pull** from where the partial transfer
+  stopped (per 14:37 EDT timeline entry).
+- **Final PR #136 body refresh** — add the latest investigation
+  findings + the two newest issues
+  ([`#144`](https://github.com/rolker/unh_echoboats_project11/issues/144),
+  [`udp_bridge#22`](https://github.com/rolker/udp_bridge/issues/22))
+  before mark-ready.
+- **Mark PR #136 ready + merge** — `gh pr ready 136` then
+  `gh pr merge 136 --merge` per the user's preference for merge
+  commits over squash.

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -75,10 +75,26 @@ Set up git-bug in the project repo:
 Field agents can now pull from gitcloud and read #135 with
 `git-bug bug show e3c373a`, or browse all issues via `git-bug termui`.
 
+**2026-05-19T11:14-04:00** — gabby agent (gabby log §1): bringing
+git-bug up on gabby; first `git bug pull` failed because the `claude`
+shell had no `SSH_AUTH_SOCK` exported. Used a per-session
+`eval $(ssh-agent -s); ssh-add ...; <cmd>; ssh-agent -k` workaround
+per git-bug call. Root cause captured as a comment on
+[`ros2_agent_workspace#423`](https://github.com/rolker/ros2_agent_workspace/issues/423#issuecomment-4492896368).
+
 **2026-05-19T11:20-04:00** — Roland: the agent on salmon is fixing an
 issue with the git-bug identity for field agents. Following up
 separately on salmon-side; capturing here as a cross-host pointer.
 Detail / resolution will land in the salmon log when complete.
+
+**2026-05-19T11:30-04:00** — salmon agent (salmon log §2–§5):
+root-caused empty `git bug bug` to `git_bug_setup.sh` only configuring
+the workspace repo, not the per-project repos. Rewrote the script to
+loop over all 40 overlay project repos; deployment issue `e3c373a` +
+34 open bugs visible post-fix. Field commit `236f2d7` pushed to
+gitcloud workspace `main` (tracked as
+[`ros2_agent_workspace#474`](https://github.com/rolker/ros2_agent_workspace/issues/474);
+pending dev-side import).
 
 ## Timeline
 
@@ -103,6 +119,24 @@ its own ~45+ min minimum to be useful, plus the transit out-of-sight
 and back; **not feasible inside today's window**. Recommend deferring
 phase 2 to a follow-up deployment with a longer slot.
 
+> ⚠️ Reframe at wrap-up (see 20:48 entry below): "Phase 2 deferred"
+> is the wrong call. With operator-side WiFi off all on-water phase,
+> the Starlink-only data-path test (Phase 2's comms half) WAS
+> exercised under sustained autonomous load — including an initial
+> survey pattern that ran briefly before the cross-harbour trackline.
+> Boat stayed in line of sight visually, so the literal OOL element
+> didn't happen, but Phase 2 is "partial credit", not "deferred".
+
+**2026-05-19T11:47-04:00** — salmon agent (salmon log §6):
+`make build` clean across all 7 layers (~11 min wall time), picking
+up post-sync `udp_bridge` (resend constants + rate-limit tests) and
+`camp` (NavSource QoS) changes.
+
+**2026-05-19T11:57-04:00** — salmon agent (salmon log §7):
+operator-side ROS launched; 16 nodes visible (operator stack +
+boat-control via `udp_bridge` + network monitors + rqt). Boat
+heartbeat not yet flowing — consistent with operator-only startup.
+
 **2026-05-19T12:06-04:00** — Roland: putting the boat in the water
 now to avoid waiting on a shared crane. Pre-launch bench-checks
 (item: bench-verify #134 keyframe cadence on a dev OAK) get folded
@@ -114,6 +148,33 @@ test on gabby can run from the pier while the boat is bobbing.
 the RC controller and the USB controller. Launching.
 
 **2026-05-19T12:19-04:00** — Roland: boat in the water.
+
+**2026-05-19T12:20-04:00** — salmon agent (salmon log §9): first
+boat heartbeat received at salmon; FCU state LOITER, armed, guided,
+standby. Operator-side `mikrotik_monitor` absent from running node
+list — first sign of the startup-crash issue tracked at 12:48 below.
+
+**2026-05-19T12:25-04:00** — gabby agent (gabby log §2): post-launch
+ROS topic rates verified (mavros 1/10 Hz, SBG 25/5/1 Hz, udp_bridge
+stats present). Flagged duplicate `/bizzy/sensors/sbg_device` graph
+entry (one PID, second is a discovery ghost) and SBG publishing legacy
+`sbg/*` topics instead of `sensor_msgs/*` despite `ros_standard: true`
+(existing git-bug `7c94549` ↔ [`#117`](https://github.com/rolker/unh_echoboats_project11/issues/117)).
+
+**2026-05-19T12:26-04:00** — salmon agent (salmon log §10): captured
+`/diagnostics_agg` snapshot — toplevel ERROR; 86 entries (64 OK, 9
+WARN, 9 STALE, 3 ERROR). Driven by stale `/Operator/*` aggregator
+buckets (config-drift [`#141`](https://github.com/rolker/unh_echoboats_project11/issues/141))
++ the stale `bencloud` ping target
+([`#140`](https://github.com/rolker/unh_echoboats_project11/issues/140)).
+
+**2026-05-19T12:30-04:00** — gabby agent (gabby log §3) + salmon agent
+(salmon log §11): `udp_bridge` resend storm characterized on both
+sides — boat→op 3416 `[WARN]` entries, op→boat 5386, all matching
+`Giving up on resend ... after 6 attempts ... sender TTL 5 s`. Local
+build is post-[`udp_bridge#13`](https://github.com/rolker/udp_bridge/pull/13) (resend
+amplification fix). Variation in "after N" tracked as
+[`udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21).
 
 **2026-05-19T12:36-04:00** — Roland: gabby + salmon have already had
 `make sync` + `build` done. Pre-launch sync item closed. Gabby agent
@@ -140,6 +201,30 @@ status unknown from here. Flagging as a possible operator-side
 observability gap for the WiFi-disable phase — boat-side #22
 diagnostics are unaffected.
 
+**2026-05-19T12:48-04:00** — gabby agent (gabby log §6 + §7): boat-side
+`mikrotik_monitor` health check passes (`wifi.bizzy` reachable, SNR
+43 dB, no drops in last hour); gabby uptime snapshot — boot 09:45 EDT,
+~3 h pre-launch idle window.
+
+**2026-05-19T12:48-04:00** — salmon agent (salmon log §12): operator-side
+`mikrotik_monitor` and `teltonika_monitor` BOTH absent from running
+tree (declared in launch, executables present, target reachable). Likely
+uncaught exception during initial connect — `pts/5` scrollback needed
+for the actual cause. Tracked as
+[`ros2_network_monitor#23`](https://github.com/rolker/ros2_network_monitor/issues/23);
+crash-output loss tracked as
+[`unh_echoboats_project11#139`](https://github.com/rolker/unh_echoboats_project11/issues/139).
+
+**2026-05-19T12:50-04:00** — gabby agent (gabby log §8) + salmon agent
+(salmon log §13): pre-WiFi-cut baselines captured.
+**Salmon side measured `/bizzy/local_costmap/costmap` arriving at
+855 kB/s vs 3.80 MB/s published — ~78% loss on this large fragmented
+topic even over WiFi** (small-footprint topic clean). Bridge-side
+issue follow-up at
+[`unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127).
+Gabby cumulative `Giving up on resend` count at this point: 9 927
+(rate ~325/min over last 20 min).
+
 ## 2. Phase 1 — Starlink-only operation
 
 **2026-05-19T12:52-04:00** — **Roland: WiFi powered down at the
@@ -151,6 +236,32 @@ station now sees only what Starlink/VPN can deliver.
 
 Pre-disable baseline: CAMP looked good (camp#51 + udp_bridge#16
 fixes confirmed). Post-disable: operator reports clean operation.
+
+**2026-05-19T12:53-04:00** — salmon agent (salmon log §14):
+post-WiFi-down snapshot — heartbeat clean at 1.000 s spacing (Starlink
+data plane delivering small payloads), but `/operator/udp_bridge/topic_statistics`
++ `bridge_info` + `remotes/bizzy/topic_statistics` ALL → 0 msg/s.
+Resend WARN rate accelerated to ~670/s (template now ends "after 6
+attempts"). **Stats stall begins here and persists for the entire
+≈1h17m Starlink-only phase** — tracked as
+[`udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20).
+
+**2026-05-19T12:54-04:00** — gabby agent (gabby log §9):
+post-WiFi-down resend pattern shifted from "after 6 attempts" to
+"after 1 attempts" (boat→operator direction; sender TTL still 5 s).
+Consistent with the operator-side ack path collapsing as soon as
+WiFi went down — first resend attempt expires unacked. Same overall
+behavior tracked at
+[`udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21).
+
+**2026-05-19T13:00-04:00** — gabby agent (gabby log §10 + §11): host
+thermal monitoring on a warm day (93°F). CPU package 67–70°C, FCU baro
+54.4°C, no Starlink throttle alerts. Roland installed `lm-sensors`
+mid-deployment; **NVMe Sensor 1 71.8°C — inside consumer-SSD
+thermal-throttle band (70–75°C), no climb across 10-min cron**. Bag
+recording writes to that NVMe so throttle would manifest as bag
+growth-rate drop. Tracked as
+[`unh_echoboats_project11#142`](https://github.com/rolker/unh_echoboats_project11/issues/142).
 
 **2026-05-19T13:03-04:00** — Roland: opened a Remmina session to
 mercat via VPN to launch the sonar (M3). RDP-over-Starlink-VPN
@@ -172,6 +283,13 @@ work; lots of errors in gabby's nav console**. Symptom only at this
 point; cause and mechanism TBD. Gabby agent presumably has the
 console output captured for diagnosis.
 
+**2026-05-19T13:13-04:00** — gabby agent (gabby log §12): started
+**50-minute camera bag** `bag_2026-05-19T13.13.20_ffmpeg_seg` (25
+topics: 4 OAK cameras, segmentation, camera_infos, `/tf`, `/tf_static`,
+`/diagnostics`, `/bizzy/robot_description`). Final 2.0 GB; spans both
+the `mru_transform` failure window AND the post-recovery Phase 1
+trackline + survey attempt — best replay artifact for today.
+
 **2026-05-19T13:13-04:00** — Roland: restarted nav on gabby.
 
 **2026-05-19T13:16-04:00** — Roland: restarted nav again (second
@@ -183,6 +301,16 @@ chart datum or tides. Operator hypothesis at this point; specific
 mechanism / signature not yet identified. Tide-pipeline thread is
 tracked in workspace (sim tide/waves/noise + chart_datum node);
 chart_datum lives in marine_tools.
+
+**2026-05-19T13:18-04:00** — gabby agent (gabby log §13): nav stack
+bringup verified aborted via lifecycle / TF probe. Smoking-gun
+signature `Tide estimate -12.79 m is outside plausible range
+[-33.74, -19.42]` spamming from `sea_surface_estimator` — plausibility
+check correctly suppressing implausible estimates, so `map_tide` TF
+never broadcast → `local_costmap` can't init → `controller_server`
+activation fails → `bt_task_navigator` rejects goals. Whole cascade
+silent until a goal is sent — observability gap fed into the
+brainstorm at end-of-session.
 
 **2026-05-19T13:25-04:00** — Roland: narrowed it down — position
 source used by mru_transform isn't ellipsoidal.
@@ -199,14 +327,38 @@ cascading into the nav errors.
 Smoking-gun signature: `"Tide estimate ... outside plausible range"`
 in /rosout. (To verify offline against bag data.)
 
+**2026-05-19T13:25-04:00** — gabby agent (gabby log §13): root cause
+confirmed via per-source altitude snapshot — `mavros/global_position/global`
+reading **-12.39 m** (EKF-fused, no undulation) vs SBG `gps_pos`
+ellipsoidal ≈-24.38 m (MSL + undulation, geoid undulation ~25 m at
+this latitude). `/bizzy/tide_estimate` was tracking mavros, not SBG.
+Triggering change: commit `e604a36e` (2026-04-28) switched
+`mru_transform` from `mavros/global_position/raw/fix` to
+`mavros/global_position/global`. Presented options A (revert) / B
+(SBG) to operator; mission-quickest is A. Durable choice tracked
+as [`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138).
+
 **2026-05-19T13:31-04:00** — Roland: gabby agent reverted the
 position source for mru_transform. Restarting the whole stack on
 gabby now.
+
+**2026-05-19T13:32-04:00** — gabby agent (gabby log §13): killed
+`mru_transform_node` (PID 19189) expecting an auto-respawn after the
+YAML revert — launch wasn't configured for `respawn=True`, so
+`/bizzy/odom` lost its publisher. Operator took over with a full-stack
+relaunch (clean path; per-node restart proved messy).
 
 **2026-05-19T13:33-04:00** — **Roland: mission running.** Autonomy
 stack functional on Starlink-only after the position-source revert.
 Phase 1's core test (Starlink-only + autonomy + survey-like load)
 is live for the first time. ~27 min until 14:00 recovery target.
+
+**2026-05-19T13:35-04:00** — gabby agent (gabby log §13): post-relaunch
+verification — `mru_transform_node` alive (PID 31636 using `raw/fix`);
+`bizzy/base_link`→`bizzy/map_tide` TF resolved Z = −0.078 m (boat 7.8 cm
+below sea surface — sane); `/bizzy/tide_estimate` −23.77 m (inside
+plausible band); `sea_surface_estimator` suppression warnings in new
+log: 0; all Nav2 lifecycle nodes ACTIVE. Mission unblocked.
 
 **2026-05-19T13:36-04:00** — Roland: trying a long trackline across
 the harbor. RC controller **turned off** — implements the 2026-05-01
@@ -268,6 +420,21 @@ sequence starting.**
 
 **2026-05-19T14:09-04:00** — Roland: **boat out of the water.**
 In-water phase complete; on schedule for the 14:30 hard stop.
+
+**2026-05-19T14:10-04:00** — salmon agent (salmon log §15):
+boat-recovered snapshot — FCU MANUAL (was LOITER), `marine_autonomy_standby`
+false (was true), still armed/connected; consistent with manual takeover
+for recovery. **Bridge stats stall persisted the entire ≈1h17m of
+Starlink-only operation.** WARN rate dropped to ~306/s; packet IDs in
+WARN samples went 1.97 M → 1.69 M (counter reset, suggests a
+sender-side bridge restart on gabby).
+
+**2026-05-19T14:12-04:00** — salmon agent (salmon log §16): wrap-up
+snapshot — operator bag `operator_2026-05-19T12.08.34/...mcap` is
+**296 MB** covering 12:08–14:12 (~2h 4m, pre-deploy + on-water +
+post-recovery). Captures `/rosout` so the udp_bridge WARN storm is
+fully replayable; also captures `topic_statistics` so the stall
+manifests as a publication gap rather than missing data.
 
 **2026-05-19T14:20-04:00** — Roland (correcting dev-agent error):
 **M3 and mercat are both on the boat, connected directly to each

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -7,12 +7,17 @@
 
 ## Summary
 
-_(user-curated at wrap-up — what today was about with the benefit of
-hindsight)_
+Successful test of Starlink-only operations, validating the fixes that
+came out of the previous OTH test.
 
 ## Lessons Learned
 
-_(user-curated at wrap-up — durable operator-level take-home messages)_
+Finish verifying previous-deployment data before implementing changes
+for the next deployment. The wrong altitude reference
+(EK3_SRC1_POSZ = baro rather than GPS, tracked in
+[#138](https://github.com/rolker/unh_echoboats_project11/issues/138))
+was already visible in the previous deployment's bag — finishing that
+review before this deployment's changes went in would have caught it.
 
 ## Scope (from #135)
 
@@ -813,6 +818,49 @@ compare the discharge curve over a longer effective duration; the
 discharge curve we're actually operating (the curve is flat for
 most of the SoC range, so two short deployments stitched together
 are more informative than either alone).
+
+### Cross-deployment comparison vs 2026-05-01 (added 2026-05-20)
+
+Extracted `/bizzy/mavros/battery` and `/bizzy/mavros/rc_out` from
+the 2026-05-01 deployment (`~/data/logs/analysis/2026-05-01_deployment.db`,
+already in same schema). Both deployments started at ~28.6 V
+(28.618 vs 28.606, matched SoC).
+
+Normalized to commanded thrust effort (using
+`|ch_0-1500| + |ch_2-1500|` as a per-sample PWM-deviation proxy
+across the paired port/stbd channels — ch_0≡ch_1 and ch_2≡ch_3
+in the logged data):
+
+| | Duration | Avg effort | ∫ effort dt | V drop |
+|---|---|---|---|---|
+| 2026-05-19 | 2.13 h | 391 PWM-µs | 834 PWM-µs·h | 0.62 V |
+| 2026-05-01 | 5.40 h | 379 PWM-µs | 2047 PWM-µs·h | 2.85 V |
+
+Average commanded effort is nearly identical (~385 µs), yet
+2026-05-01's voltage dropped more than 2× faster per hour. At
+matched cumulative effort, 2026-05-19 sits 0.3–1.2 V *above*
+2026-05-01:
+
+| Cum effort (PWM-µs·h) | 2026-05-01 V | 2026-05-19 V |
+|---|---|---|
+| 150 | 28.02 | 28.33 |
+| 450 | 27.91 | 28.29 |
+| 650 | 26.90 | 28.09 |
+| 750 | 26.81 | 27.51 |
+
+PWM excursion histogram shows 2026-05-19 was more bursty (36.4 %
+at PWM_dev > 500 vs 27.6 %, plus more idle time). With propeller
+power ∝ rpm³, that should make 2026-05-19 drop *faster* per unit
+linear effort — not slower. So linear PWM-deviation isn't a
+sufficient predictor of discharge.
+
+**Plan:** continue collecting at the next deployment without
+recharging — the boat is currently resting at ~28.15 V (the
+2026-05-19 end-state), so the next discharge starts from a
+known mid-plateau point and will extend the curve toward where
+2026-05-01 finished. Deeper modeling (thrust→power non-linearity,
+non-thruster load accounting, possible battery temperature/age
+effects) deferred until we have more data points.
 
 ### Source
 

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -26,9 +26,248 @@ Two-phase test:
 
 ## Tides + weather
 
-_(to fill in once operator confirms — tide heights in metres, tide
-times explicitly TZ-tagged)_
+All times **EDT (UTC−4)**. Full block: see
+[#135 conditions comment](https://github.com/rolker/unh_echoboats_project11/issues/135#issuecomment-4489426036).
+
+- **Tides (Fort Point NH, MLLW):** Low 07:41 (−0.44 m, behind us),
+  High 14:01 (2.83 m), Low 19:51 (≈ MLLW). Judd Gregg launch
+  unconstrained.
+- **Currents (Clark Island, ACT0731 bin 1):** slack 10:10 → max flood
+  1.64 kt @ 12:15 → slack 16:13 → **max ebb 2.21 kt @ 18:41**.
+  Calm-water window ~10:10–16:13.
+- **Weather (NWS GYX):** Mostly sunny, high near **93°F**, SW wind
+  ~10 mph G25. **Slight chance of showers / thunderstorms after 3 PM
+  (50% total)** — overlaps the late edge of the calm-water window.
+- **Flags:** Plan recovery before ~3 PM if thunderstorms approach.
+  93°F is hot for May NH (electronics-thermal + operator-comfort
+  awareness, no specific spec violation).
+
+## 1. git-bug rollout — share deployment issue with field agents
+
+First-try use of git-bug as a one-way distribution channel for the
+deployment issue. Field agents (gabby, salmon) have no GitHub
+credentials, but they do clone via gitcloud — git-bug refs ride
+along with the regular git push, so the issue can be read on the
+field side via `git-bug bug show` / `git-bug termui` without any
+GitHub auth.
+
+**Scope this deployment**: read-only. Field agents will keep using
+the per-host log files (`docs/logs/2026/2026-05-19_<host>_logs.md`)
+for their own writing, and won't comment on the issue via git-bug.
+The bidirectional bridge-back-to-GitHub path is deliberately
+untested this round.
+
+**2026-05-19T11:00-04:00** — Workspace git-bug was already configured
+for the workspace repo (`rolker/ros2_agent_workspace`), but had no
+bridge configured for `rolker/unh_echoboats_project11`. So the
+GitHub-side deployment issue [#135](https://github.com/rolker/unh_echoboats_project11/issues/135)
+wasn't appearing in git-bug on the workspace side.
+
+Set up git-bug in the project repo:
+
+- Created git-bug identity for `Claude Code Agent <roland+claude-code@ccom.unh.edu>`
+- Configured the GitHub bridge against `rolker/unh_echoboats_project11`
+  using `gh auth token`
+- `git-bug bridge pull` imported 82 issues (full history) with #135
+  showing as git-bug ID `e3c373a`
+- `git-bug push gitcloud` propagated the refs to the gitcloud remote
+
+Field agents can now pull from gitcloud and read #135 with
+`git-bug bug show e3c373a`, or browse all issues via `git-bug termui`.
+
+**2026-05-19T11:20-04:00** — Roland: the agent on salmon is fixing an
+issue with the git-bug identity for field agents. Following up
+separately on salmon-side; capturing here as a cross-host pointer.
+Detail / resolution will land in the salmon log when complete.
 
 ## Timeline
 
 _(append in forward-chronological order, EDT)_
+
+**2026-05-19T11:39-04:00** — Roland: hard stop at **14:30 EDT**;
+need to be **recovering by 14:00 EDT** to leave time for wrap-up.
+
+Time budget from now (11:39): **2 h 21 min total**, ~2 h of useful
+on-water minus pre-launch + launch + recovery overhead. Suggested
+split:
+
+| Phase | Window | Activity |
+|---|---|---|
+| pre-launch | 11:39–12:15 (≈35 min) | sync + bench-checks + iperf3 sustained |
+| launch + transit | 12:15–12:30 (≈15 min) | boat in water, short transit |
+| phase 1 — Starlink-only @ close range | 12:30–13:45 (≈75 min) | the main test |
+| recovery | 13:45–14:00 (≈15 min) | boat out of water |
+
+This fits **phase 1 only**. **Phase 2 (OTH survey)** from #135 wants
+its own ~45+ min minimum to be useful, plus the transit out-of-sight
+and back; **not feasible inside today's window**. Recommend deferring
+phase 2 to a follow-up deployment with a longer slot.
+
+**2026-05-19T12:06-04:00** — Roland: putting the boat in the water
+now to avoid waiting on a shared crane. Pre-launch bench-checks
+(item: bench-verify #134 keyframe cadence on a dev OAK) get folded
+into in-water observation instead — we'll inspect IDR cadence on
+the boat's actual OAKs once they're up. iperf3 sustained Starlink
+test on gabby can run from the pier while the boat is bobbing.
+
+**2026-05-19T12:10-04:00** — Roland: quick controls checks done on
+the RC controller and the USB controller. Launching.
+
+**2026-05-19T12:19-04:00** — Roland: boat in the water.
+
+**2026-05-19T12:36-04:00** — Roland: gabby + salmon have already had
+`make sync` + `build` done. Pre-launch sync item closed. Gabby agent
+is set up to bag camera ffmpeg data for offline keyframe-cadence
+analysis (post-deployment check of #134's coprime stagger).
+
+**2026-05-19T12:39-04:00** — Roland: gabby agent is checking the FCU
+failsafe params (FS_THR_ENABLE / FS_GCS_ENABLE).
+
+**2026-05-19T12:40-04:00** — Roland: gabby agent is recording 15 min
+of video — that's the dataset for offline keyframe-cadence
+verification (#134 stagger check). Ends ~12:55 EDT.
+
+**2026-05-19T12:44-04:00** — Roland: CAMP looks good on salmon —
+baseline for camp#51 + udp_bridge#16 fixes confirmed working. Wants
+to disable WiFi soon, but first the salmon + gabby agents are
+checking the mikrotik_monitor nodes (the merged #22 wireless-event
+metrics). Useful field check of the new diagnostics before we
+exercise them with an actual WiFi state change.
+
+**2026-05-19T12:47-04:00** — Roland: mikrotik_monitor might not be
+running on salmon. Salmon agent investigating; gabby-side instance
+status unknown from here. Flagging as a possible operator-side
+observability gap for the WiFi-disable phase — boat-side #22
+diagnostics are unaffected.
+
+## 2. Phase 1 — Starlink-only operation
+
+**2026-05-19T12:52-04:00** — **Roland: WiFi powered down at the
+operator station. Things look good on the operator station!**
+
+This is the core deployment test. Compared to 2026-05-01 (where
+the boat operated with WiFi available throughout), the operator
+station now sees only what Starlink/VPN can deliver.
+
+Pre-disable baseline: CAMP looked good (camp#51 + udp_bridge#16
+fixes confirmed). Post-disable: operator reports clean operation.
+
+**2026-05-19T13:03-04:00** — Roland: opened a Remmina session to
+mercat via VPN to launch the sonar (M3). RDP-over-Starlink-VPN
+working at this point — non-trivial bandwidth use on the
+operator-side downlink (Remmina + the boat ROS traffic + any
+sonar data flows being kicked off on mercat).
+
+**2026-05-19T13:06-04:00** — Roland: launched QINSy on mercat, SBG
+showed all red. Quit QINSy and launched sbgCenter — SBG is visible
+there. So the SBG hardware is up and the serial stream is flowing;
+the failure is QINSy-side (QINSy didn't see usable SBG data while
+it held the port). Plan unclear at this point — likely a QINSy
+config issue to chase next time, not a sensor problem.
+
+**2026-05-19T13:12-04:00** — Roland: restarted QINSy, all is good
+now (SBG visible / data flowing through QINSy on the second try).
+Started recording data. Then tried to execute a mission — **didn't
+work; lots of errors in gabby's nav console**. Symptom only at this
+point; cause and mechanism TBD. Gabby agent presumably has the
+console output captured for diagnosis.
+
+**2026-05-19T13:13-04:00** — Roland: restarted nav on gabby.
+
+**2026-05-19T13:16-04:00** — Roland: restarted nav again (second
+restart in ~3 min — first didn't resolve the mission-launch issue,
+or something else came up).
+
+**2026-05-19T13:18-04:00** — Roland: nav errors seem related to
+chart datum or tides. Operator hypothesis at this point; specific
+mechanism / signature not yet identified. Tide-pipeline thread is
+tracked in workspace (sim tide/waves/noise + chart_datum node);
+chart_datum lives in marine_tools.
+
+**2026-05-19T13:25-04:00** — Roland: narrowed it down — position
+source used by mru_transform isn't ellipsoidal.
+
+Mechanism (surfaced from `mru_transform/.../sea_surface_estimator.cpp`):
+`sea_surface_estimator` averages `odometry.pose.pose.position.z` and
+compares against MLLW/MHHW Z from `chart_datum_node`. If odom Z is
+MSL while chart_datum Z is ellipsoidal (~30 m offset in NH from
+geoid undulation), every tide estimate falls outside the
+`[MLLW − margin, MHHW + margin]` range and gets rejected. The
+`map_tide` frame is never broadcast. `global_costmap` is configured
+with `global_frame: <tf_prefix>/map_tide` so it can't initialize,
+cascading into the nav errors.
+Smoking-gun signature: `"Tide estimate ... outside plausible range"`
+in /rosout. (To verify offline against bag data.)
+
+**2026-05-19T13:31-04:00** — Roland: gabby agent reverted the
+position source for mru_transform. Restarting the whole stack on
+gabby now.
+
+**2026-05-19T13:33-04:00** — **Roland: mission running.** Autonomy
+stack functional on Starlink-only after the position-source revert.
+Phase 1's core test (Starlink-only + autonomy + survey-like load)
+is live for the first time. ~27 min until 14:00 recovery target.
+
+**2026-05-19T13:36-04:00** — Roland: trying a long trackline across
+the harbor. RC controller **turned off** — implements the 2026-05-01
+mitigation for the RC-mode-switch-at-fringe-range bug
+(FCU otherwise honors RC channel even with `FS_THR_ENABLE=0`).
+This is the longest autonomous leg attempted today on Starlink-only.
+
+**2026-05-19T13:40-04:00** — Roland: seeing some boat traffic in the
+harbor; not a concern yet. (Cf. 2026-05-01 mooring-ball near-miss
+under #124 §7 — perception→costmap is a known survey-readiness gap.)
+
+**2026-05-19T13:42-04:00** — Roland: reopened Remmina (had been
+closed) to check on the sonar; **M3 software is reporting dropped
+packets**. Observation only; mechanism not yet identified. Note that
+the M3 UDP stream's path under Starlink-only ops hasn't been
+characterized today — possible bandwidth wall, possible something
+else. To investigate post-deployment.
+
+**2026-05-19T13:44-04:00** — Roland: M3 data goes to mercat
+**directly** (boat → operator network → mercat, not via gabby
+relay). Under Starlink-only that means M3 UDP crosses
+boat-router → Starlink → bencloud → operator-router → mercat — and
+the 2026-05-18 pier calibration put the Starlink "no-significant-loss"
+budget at ~5 Mbps clean, ~0.4% baseline at the 8 Mbps cap. M3 sonar
+UDP under survey load is typically several Mbps. **Strong candidate
+mechanism for the drops**: M3 output is at/above the Starlink loss
+knee. Operational implication for OTH survey work: M3 traffic
+needs either bandwidth budget management or a different routing
+strategy when WiFi is unavailable. **Follow-up worth filing
+post-deployment.**
+
+**2026-05-19T13:46-04:00** — Roland: **boat reached the far end of
+the long trackline, now returning**. Autonomous on Starlink-only
+through the full outbound leg without operator intervention. First
+sustained autonomous Starlink-only leg of substantial length.
+
+**2026-05-19T13:47-04:00** — Roland: re-powering up the WiFi.
+End of the strict Starlink-only phase. From here, both paths active
+again (matches 2026-05-01 baseline configuration). Approach +
+recovery proceed with full bandwidth.
+
+**2026-05-19T13:48-04:00** — Roland: rear camera started showing up,
+confirming WiFi data flowing. `oak_aft_ffmpeg` is WiFi-only by
+`bizzyboat.yaml` config (the topic was dropped from VPN to free
+uplink bandwidth), so the aft view reappearing is the canonical
+signal that the WiFi path is healthy again.
+
+**2026-05-19T13:51-04:00** — Roland: **battery at 27.56 V**. Sample
+covers the "during" slot for #124 §3 power data (no current meter
+on BizzyBoat; voltage is real, current/watts are not — see workspace
+memory `project_bizzyboat_no_current_meter`).
+
+**2026-05-19T13:56-04:00** — Roland: **boat arrived; recovery
+sequence starting.**
+
+- Sonar (M3) stopped
+- RC controller turned back ON (was off since 13:36 for the
+  fringe-range mode-switch mitigation)
+- FCU mode switched to **LOITER** for manual control + position
+  hold during approach
+- Going to recover
+
+**2026-05-19T14:09-04:00** — Roland: **boat out of the water.**
+In-water phase complete; on schedule for the 14:30 hard stop.

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -279,3 +279,12 @@ is on the local boat network or in mercat's own stack (NIC buffers,
 QINSy + AML bridge + RDP session resource contention, switch
 behavior, etc.). Follow-up framing changes accordingly: investigate
 locally on the boat, not in the WAN/Starlink path.
+
+**2026-05-19T14:22-04:00** — Roland: log files are being pulled from
+**gabby and mercat to deadpool** (this dev workstation). Wrap-up
+step #3 per `docs/logs/README.md`. **Field-host logs do NOT go
+through the deployment PR** — gabby and mercat are field-mode
+(non-GitHub origins) so they commit directly to `jazzy` and push to
+gitcloud; deadpool picks them up via `make sync` and they land on
+local `jazzy` directly. Only the dev log goes through #136. (Earlier
+dev-agent assertion to the contrary corrected here.)

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -499,7 +499,6 @@ edit, but that's a separate concern from this deployment.
 
 Left to do when session resumes:
 
-- Complete mercat QPS data pull from where the transfer stopped.
 - Full carry-forward audit per `docs/logs/README.md` wrap-up
   checklist.
 - Follow-up issues to consider filing:
@@ -656,7 +655,6 @@ for CAMP.
 
 - Operator-curated **Summary** and **Lessons Learned** sections
   at the top of this log.
-- Complete mercat QPS data pull from where the transfer stopped.
 - `docs/roadmap.md` updates for the partial Phase 2 +
   what got deferred today.
 - Full carry-forward audit per `docs/logs/README.md` (next).
@@ -1020,8 +1018,6 @@ Not done in this session — to pick up next time:
   sides. Quick to do.
 - **Operator-curated Summary + Lessons Learned at top of this log**
   — user-driven; awaiting input.
-- **Complete mercat QPS data pull** from where the partial transfer
-  stopped (per 14:37 EDT timeline entry).
 - **Final PR #136 body refresh** — add the latest investigation
   findings + the two newest issues
   ([`#144`](https://github.com/rolker/unh_echoboats_project11/issues/144),

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -226,17 +226,14 @@ characterized today — possible bandwidth wall, possible something
 else. To investigate post-deployment.
 
 **2026-05-19T13:44-04:00** — Roland: M3 data goes to mercat
-**directly** (boat → operator network → mercat, not via gabby
-relay). Under Starlink-only that means M3 UDP crosses
-boat-router → Starlink → bencloud → operator-router → mercat — and
-the 2026-05-18 pier calibration put the Starlink "no-significant-loss"
-budget at ~5 Mbps clean, ~0.4% baseline at the 8 Mbps cap. M3 sonar
-UDP under survey load is typically several Mbps. **Strong candidate
-mechanism for the drops**: M3 output is at/above the Starlink loss
-knee. Operational implication for OTH survey work: M3 traffic
-needs either bandwidth budget management or a different routing
-strategy when WiFi is unavailable. **Follow-up worth filing
-post-deployment.**
+**directly**.
+
+> ⚠️ Dev-agent correction logged at 14:20 — the dev agent
+> mis-modeled the architecture in the original entry, attributing
+> the M3 drops to Starlink bandwidth. **Both M3 and mercat are on
+> the boat**, connected directly to each other over **wired
+> Ethernet**. The Starlink path is irrelevant to M3-to-mercat
+> traffic. See the 14:20 entry below for the corrected analysis.
 
 **2026-05-19T13:46-04:00** — Roland: **boat reached the far end of
 the long trackline, now returning**. Autonomous on Starlink-only
@@ -271,3 +268,14 @@ sequence starting.**
 
 **2026-05-19T14:09-04:00** — Roland: **boat out of the water.**
 In-water phase complete; on schedule for the 14:30 hard stop.
+
+**2026-05-19T14:20-04:00** — Roland (correcting dev-agent error):
+**M3 and mercat are both on the boat, connected directly to each
+other over wired Ethernet.** The dev agent had carried an
+operator-side mental model of mercat into earlier entries and into
+the follow-up framing. The M3-drop observation at 13:42 stands —
+the drops are real — but the mechanism is **NOT** Starlink-side. It
+is on the local boat network or in mercat's own stack (NIC buffers,
+QINSy + AML bridge + RDP session resource contention, switch
+behavior, etc.). Follow-up framing changes accordingly: investigate
+locally on the boat, not in the WAN/Starlink path.

--- a/docs/logs/2026/2026-05-19_dev_logs.md
+++ b/docs/logs/2026/2026-05-19_dev_logs.md
@@ -822,3 +822,92 @@ reproducible: source `/opt/ros/jazzy/setup.bash` +
 `layers/main/sensors_ws/install/setup.bash`, then
 `python3 -m bag_analysis.cli.bag_to_sqlite --bag <bag_dir> --output ...`
 (use `--append` for the second bag).
+
+### 5. Follow-on: root cause of mavros `/global` Z drift — baro tracking pressure
+
+The "5 m/h upward drift in mavros `/global_position/global` Z" finding
+from §3 prompted a hypothesis: maybe the EKF is tracking atmospheric
+pressure via the Cube Orange's MS5611 barometer, not actually
+drifting in a buggy way. Investigated.
+
+**Weather supports the hypothesis.** METAR for KPSM (Pease) during
+the deployment window:
+
+| UTC | EDT | A (inHg) | SLP (hPa) | Note |
+|---|---|---|---|---|
+| 191655Z | 12:55 | A2989 | 1012.4 | early deployment |
+| 191755Z | 13:55 | A2986 | 1011.4 | mid-deployment |
+| 191855Z | 14:55 | A2985 | 1011.0 | post-recovery |
+| 191955Z | 15:55 | A2982 | 1010.0 | **−TSRA (thunderstorm)** |
+
+**Pressure dropped 1.4 hPa during the on-water window** (12:55→14:55 EDT).
+At 8.5 m/hPa, that predicts ~12 m of apparent altitude increase over the
+2-hour window. The bag shows ~15 m of EKF altitude drift over ~1.5 hours.
+Same direction, same order of magnitude — and a thunderstorm hit
+shortly after recovery, exactly the falling-pressure-ahead-of-storm pattern.
+
+**Smoking gun in FCU params.** Checked
+`bizzyboat_project11/config/fcu/bizzyboat_fcu_baseline.param`:
+
+```
+EK3_SRC1_POSXY   3        # GPS for horizontal position
+EK3_SRC1_POSZ    1        # *** Baro for vertical position ***
+EK3_SRC1_VELXY   3        # GPS for horizontal velocity
+EK3_SRC1_VELZ    3        # GPS for vertical velocity
+```
+
+ArduPilot `EK3_SRCx_POSZ` value 1 = Baro, value 3 = GPS. The EKF's
+primary vertical position source is the barometer. That's the
+ArduRover default for ground vehicles (where GPS altitude is unreliable
+and baro is the better choice). **For a marine vehicle on water with
+RTK GPS, this is wrong.** The boat doesn't change altitude meaningfully,
+so EKF Z literally follows local atmospheric pressure.
+
+Note also: `EK3_SRC1_VELZ = 3` already uses GPS for vertical velocity.
+So the FCU trusts GPS for vertical *velocity* but not vertical *position* —
+slightly inconsistent.
+
+**Implication for #138 (mru_transform durable nav-input choice).**
+The earlier corrective comment on #138 ruled out Option C
+(mavros `/global` + geoid compensation) because the Z drift would push
+estimates outside the plausibility band within hours regardless of
+geoid handling. With this new analysis, **Option C revised is back on
+the table**:
+
+> Change `EK3_SRC1_POSZ` from 1 (baro) to 3 (GPS). Re-validate the EKF
+> behavior on a static test. If GPS-altitude-as-POSZ-source produces a
+> stable EKF Z that agrees with the boat's true elevation, restore the
+> 2026-04-28 `mavros/global_position/global` switch and close #138.
+
+This is a **single FCU parameter change** that fixes the root cause
+without losing the base_link reference or EKF fusion benefits that
+motivated the original 2026-04-28 commit (`e604a36e`).
+
+**Other potentially-relevant params to revisit if/when EK3_SRC1_POSZ
+changes**:
+- `EK3_GPS_VACC_MAX = 0.000000` — vertical accuracy check disabled. OK
+  with RTK active; without RTK, you'd want a threshold to reject
+  degraded altitude
+- `EK3_ALT_M_NSE = 2.0` — altitude measurement noise. With GPS-altitude
+  (RTK ~10 cm accuracy), this could be tightened from 2.0 m
+
+**Bag-side gap discovered during this investigation**: `bizzyboat.yaml`
+doesn't bag any baro/pressure or rich-altitude topics:
+
+- `/bizzy/mavros/imu/static_pressure` (FluidPressure) — raw baro reading,
+  would let us verify pressure-tracking quantitatively against METAR
+- `/bizzy/mavros/altitude` — the mavros `altitude` plugin is in the
+  workspace `apm_pluginlists.yaml` `denylist`, so this topic isn't even
+  published today. Enabling it gives amsl/local/relative/terrain altitude
+  side-by-side, a much richer surface for altitude-source debugging
+- `/bizzy/mavros/global_position/rel_alt` — altitude relative to home
+
+Both directions are useful: enable the altitude plugin + add baro and
+altitude topics to bag recording.
+
+### 6. Pressure data source
+
+METAR for KPSM (Pease) fetched via
+`curl https://aviationweather.gov/api/data/metar?ids=KPSM&format=raw&hours=12`.
+Pease is the closest airport with sea-level-pressure reporting; ~20 km
+from the Judd Gregg pier deployment site.

--- a/docs/logs/2026/2026-05-19_gabby_logs.md
+++ b/docs/logs/2026/2026-05-19_gabby_logs.md
@@ -3,7 +3,7 @@
 **Host**: gabby
 **Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
 **Mode**: field (gitcloud origin)
-**Deployment**: git-bug `e3c373a` — *Deployment 2026-05-19: Starlink-only operation + OTH survey test* (shared one-way via gitcloud; GitHub counterpart on dev side)
+**Deployment**: [#135](https://github.com/rolker/unh_echoboats_project11/issues/135) — *Deployment 2026-05-19: Starlink-only operation + OTH survey test* (git-bug `e3c373a`; field-host shared one-way via gitcloud at write-time; GitHub link added dev-side at wrap-up)
 
 ## Summary *(agent-drafted, Roland to revise to user voice)*
 

--- a/docs/logs/2026/2026-05-19_gabby_logs.md
+++ b/docs/logs/2026/2026-05-19_gabby_logs.md
@@ -56,6 +56,14 @@ mission completed). Boat recovered without incident. Mid-deployment
 incident on `map_tide` / nav stack was diagnosed and fixed in-field
 (see section 13).
 
+> **Editor's note (wrap-up reconciliation 2026-05-20)**: Subsequent
+> dev-side review reframed Phase 2 as *partial credit* — the
+> Starlink-only data-path was validated under sustained autonomous
+> load including an initial survey pattern, but the boat stayed in
+> line of sight visually, so the literal over-horizon element didn't
+> happen. See dev log [`2026-05-19_dev_logs.md`](./2026-05-19_dev_logs.md)
+> 20:48 wrap-up entry. Recovery time per dev log: 14:09 EDT.
+
 ## 1. git-bug bring-up on gabby
 
 **2026-05-19T11:14-04:00** — Roland asked to verify `git-bug` was installed.
@@ -554,6 +562,18 @@ well enough under loss for an OTH autonomous mission. The 2026-05-01
 fixes (coprime keyframe stagger #134, udp_bridge throughput
 regression fix #16, NavSource QoS workaround camp#51) and today's
 in-field `mru_transform` revert all held.
+
+> **Editor's note (wrap-up reconciliation 2026-05-20)**: Dev log
+> records recovery by 14:09 EDT, so this entry's approximate ~14:30
+> timestamp post-dates recovery and is inaccurate. The actual
+> autonomous Starlink-only run is captured in
+> [`2026-05-19_dev_logs.md`](./2026-05-19_dev_logs.md) timeline
+> entries around 13:13–13:47 EDT (cross-harbour trackline on
+> Starlink-only, with the boat staying in line of sight visually).
+> Subsequent dev-side review reframed the result as *line-of-sight
+> Starlink-only with partial Phase-2 credit*, not literal OTH — see
+> dev log 20:48 entry. The "headline result" framing stands for the
+> comms-stack validation; the OTH descriptor here is overstated.
 
 ## Follow-up candidates (for wrap-up)
 

--- a/docs/logs/2026/2026-05-19_gabby_logs.md
+++ b/docs/logs/2026/2026-05-19_gabby_logs.md
@@ -1,0 +1,602 @@
+# BizzyBoat deployment log — gabby — 2026-05-19
+
+**Host**: gabby
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
+**Mode**: field (gitcloud origin)
+**Deployment**: git-bug `e3c373a` — *Deployment 2026-05-19: Starlink-only operation + OTH survey test* (shared one-way via gitcloud; GitHub counterpart on dev side)
+
+## Summary *(agent-drafted, Roland to revise to user voice)*
+
+First over-the-horizon Starlink-only mission. Phase 1 (close-range
+Starlink-only with operator WiFi disabled) went smoothly — the
+2026-05-01 fixes held. Hit a nav stack bringup failure on the
+boat when `sea_surface_estimator` couldn't broadcast `map_tide`;
+root-caused to a 2026-04-28 change of `mru_transform`'s nav input
+to `mavros/global_position/global` (EKF-fused altitude inconsistent
+with chart_datum's ellipsoidal frame), reverted to `raw/fix`,
+relaunched, and ran a successful Starlink-only mission. Boat
+recovered without incident.
+
+## Lessons Learned *(agent-drafted, Roland to curate)*
+
+- **`mavros/global_position/global` is not a drop-in replacement
+  for `mavros/global_position/raw/fix`** as a nav input. The
+  altitudes are in different frames (EKF-fused vs raw GPS), and
+  sea-surface-referenced code (`sea_surface_estimator`, anything
+  reasoning about ellipsoidal vs orthometric height) silently
+  breaks when the swap is made without compensating elsewhere.
+- **A failed nav lifecycle bringup is invisible until a goal is
+  sent.** `bt_task_navigator` reports "Action server is inactive.
+  Rejecting the goal." but the lifecycle failure itself produced
+  no operator-visible alert. A startup-time annunciator on
+  "lifecycle bringup aborted" would have caught this minutes
+  earlier.
+- **Tmux on the field host is load-bearing during Starlink-only
+  testing.** When operator-side WiFi went down today, the prior
+  shell session died, but the agent on gabby kept going under
+  tmux and Roland re-attached via VPN. Worth pinning as a
+  standard pre-launch step.
+- **For a launched-as-a-group node, "restart everything" beats
+  per-node restart.** Reconstructing the original launch invocation
+  to bring back a single killed node is messy; the group relaunch
+  is the clean path.
+- **Field-host one-way deployment brief via git-bug works well.**
+  Read-only on the boat, all observations into the host log file;
+  dev reconciles at wrap-up. No fragmentation, no "who edited
+  what."
+
+## Scope
+
+Per the deployment brief: two-phase test, Starlink-only close-range
+→ OTH survey, each a go/no-go gate for the next.
+
+**Outcome**: Phase 1 ✓ (WiFi-disabled rehearsal completed
+successfully). Phase 2 ✓ (first over-horizon survey on Starlink-only,
+mission completed). Boat recovered without incident. Mid-deployment
+incident on `map_tide` / nav stack was diagnosed and fixed in-field
+(see section 13).
+
+## 1. git-bug bring-up on gabby
+
+**2026-05-19T11:14-04:00** — Roland asked to verify `git-bug` was installed.
+Confirmed: `/usr/local/bin/git-bug`, version `v0.10.1`.
+
+**2026-05-19T11:18-04:00** — Ran `make sync`. Workspace repo and several
+project repos updated. Notably:
+
+- `ros2_agent_workspace` advanced `5add5e2..236f2d7` carrying a rewrite of
+  `.agent/scripts/git_bug_setup.sh` (199 lines, +110/-89) — the reason for
+  this sync was specifically to pick up that fix.
+
+**2026-05-19T11:22-04:00** — Built the workspace clean. All five layers
+green (underlay 6, core 28, platforms 6, sensors 8, site 1). Pre-existing
+compiler warnings only in `geodesy`, `cube_bathymetry`, `depthai_marine`,
+`sea_surface_segmentation`, and a handful of core packages — no errors.
+
+**2026-05-19T11:26-04:00** — Ran `.agent/scripts/git_bug_setup.sh`. Setup
+succeeded across all 21 repos (identities created, smoke test passed in
+the workspace), but every per-repo `git bug pull` failed with:
+
+```
+Error: error creating SSH agent: "SSH agent requested but SSH_AUTH_SOCK not-specified"
+```
+
+This shell (the one the `claude` process is running in) had no
+`SSH_AUTH_SOCK` exported. The git-bug remote is SSH-based, so the pull
+couldn't authenticate. Workspace `git-bug` identities were created locally
+but the bug stores stayed empty.
+
+**2026-05-19T11:36-04:00** — Discussed the agent-startup gap with Roland:
+the cleanest fix is to start `ssh-agent` and `ssh-add` the gitcloud key
+**before** invoking `claude` (subprocesses inherit env at fork time).
+Persistent options noted for follow-up: systemd user `ssh-agent.service`,
+`keychain`, or desktop keyring.
+
+**2026-05-19T11:40-04:00** — For this session: in-line workaround. Each
+git-bug command wrapped as:
+
+```bash
+eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519_gitcloud
+git -C <repo> bug pull
+ssh-agent -k
+```
+
+Confirmed working — workspace repo pulled 1057 objects, ~169 new bug
+events. `git bug bug --status open` lists 38 open bugs in the workspace.
+
+**2026-05-19T11:55-04:00** — Pulled `unh_echoboats_project11` bug store
+with the same workaround. 34 open bugs, including today's deployment
+issue (`e3c373a`). Read the brief, confirmed scope with Roland: deployment
+issue is **read-only from gabby**; all output lands in this log file
+rather than as git-bug comments.
+
+### Notes / pitfalls discovered
+
+- `git-bug` v0.10.1 changed CLI shape: the list command is
+  `git-bug bug` (i.e. `git bug bug`), **not** `git bug ls`. The
+  `--status`/`-s` flag still works on the `bug` subcommand;
+  `-s` shorthand is reserved at the top level.
+- `git bug bug --status open --format=json e3c373a` does **not**
+  populate `metadata.github-url` for the deployment issue — likely
+  because this deployment issue is dev-side originated and bridged
+  one-way, not pulled in from a GitHub source. Linking back to the
+  GitHub counterpart from this log will need the dev side to
+  reconcile during wrap-up.
+- Inline `eval $(ssh-agent -s); ssh-add ...; <cmd>; ssh-agent -k`
+  works but starts/kills an agent per Bash call — fine for occasional
+  pulls, wasteful if we end up doing dozens. Restarting `claude` from
+  a shell with an already-running agent is the better fix when
+  there's a natural break.
+
+## 2. ROS bring-up verification
+
+**2026-05-19T12:25-04:00** — ROS launched on gabby; spot-checked
+key topics with `ros2 topic hz`.
+
+Flowing as expected:
+
+- `/bizzy/mavros/state` 1 Hz; `/bizzy/mavros/global_position/global`
+  10 Hz (mavros heartbeat + FCU GPS)
+- `/bizzy/sensors/sbg/imu_data` 25 Hz, `…/ekf_nav` 25 Hz,
+  `…/gps_pos` 5 Hz, `…/utc_time` 1 Hz, `…/status` 1 Hz
+- `/diagnostics` ~13 Hz
+- `/bizzy/udp_bridge/topic_statistics` 1 Hz;
+  `/bizzy/udp_bridge/remotes/operator/topic_statistics` 1 Hz
+  (operator-side stats present → bridge sees a peer)
+- `/bizzy/sensors/cameras/oak_forward/image_raw/ffmpeg` 5 Hz
+
+Two flags surfaced:
+
+- **Duplicate `/bizzy/sensors/sbg_device` node** in the graph (ROS
+  printed an explicit warning about exact-name collisions). Only one
+  PID (`19244`) shows in `pgrep -laf sbg_device`, so the second
+  entry is a graph-level ghost — probably an orphaned discovery
+  record from a prior lifecycle. Data is fine; service-call routing
+  to `sbg_device` could be ambiguous. Not deploy-blocking.
+- **SBG legacy topic names**: published as `sbg/imu_data`,
+  `sbg/gps_pos`, `sbg/ekf_nav`, not the `sensor_msgs/*` topics
+  expected when `ros_standard: true`. This is the open
+  git-bug issue `7c94549` — *sbg driver: `ros_standard: true` not
+  producing standard ROS topics on BizzyBoat* — still present.
+
+Not checked: `is_keyframe` cadence on OAK cameras
+(deployment-brief pre-launch checklist item #2 needs payload
+parsing, not just rate).
+
+## 3. udp_bridge resend warnings
+
+**2026-05-19T12:30-04:00** — Roland reported: "udp_bridge is spamming
+warnings about giving up on resending."
+
+Confirmed in `~/.ros/log/udp_bridge_node_19197_1779206858024.log`:
+**3416** `[WARN]` entries of the form
+
+> `Giving up on resend of packet NNNNN from remote 'operator' after 6 attempts (first requested 5.00X s ago, sender TTL is 5 s)`
+
+All entries cite `remote 'operator'` (operator → gabby direction).
+Packet sequence numbers march upward continuously (e.g., 28509,
+28511, 28516, …); resend attempts hit the 5 s sender TTL after 6
+tries and expire unacked.
+
+Local `udp_bridge` build is at `788f200` — merge of
+`rolker/udp_bridge#13 (feature/issue-9)`, the "resend loop
+amplification fix" the deployment brief flagged as in-flight. So
+this is post-fix behavior, not the original amplification.
+
+**2026-05-19T12:38-04:00** — Roland: "we are time constrained, just
+log my comments, but don't spend too much time troubleshooting. It's
+ok to gather a bit of context." Deferring detailed root-cause work;
+flagging here for wrap-up review.
+
+## 4. FCU failsafe param check
+
+**2026-05-19T12:48-04:00** — Pulled all 938 FCU params via
+`/bizzy/mavros/param/pull`; read the failsafe set.
+
+| Param | Value |
+|---|---|
+| `FS_THR_ENABLE` | **0** ✅ (matches deployment brief) |
+| `FS_GCS_ENABLE` | **0** ✅ (matches deployment brief) |
+| `FS_ACTION` | 0 (no failsafe action) |
+| `FS_TIMEOUT` | 1.0 s |
+| `FS_CRASH_CHECK` | 0 |
+| `FS_EKF_ACTION` | 0 |
+| `FS_EKF_THRESH` | 0.80 |
+
+Both items the brief calls out by name are at the expected values.
+Remaining pre-launch checklist line — *GUIDED stale-cmd_vel HOLD
+behavior confirmed* — is behavioral and needs a live pier/water
+test, not a param read. RC controller carry-forward mitigation is
+hardware-side (power off / pin mode switch to AUTO/GUIDED) and not
+verifiable here.
+
+## 5. 15-min camera bag
+
+**2026-05-19T12:40-04:00** — Started 15 min (900 s) ad-hoc bag via
+`bizzyboat_project11/scripts/record_camera_topics.sh 900`. mcap +
+zstd_fast, output:
+
+```
+~/data/logs/bizzy_images/bag_2026-05-19T12.40.13_ffmpeg_seg/
+```
+
+25 topics subscribed: all 4 OAK cameras (`image_raw/ffmpeg`,
+`segmentation` raw + compressed, `camera_info` for each plus the
+segmentation `camera_info`s), `/tf`, `/tf_static`, `/diagnostics`,
+`/bizzy/robot_description`.
+
+**2026-05-19T12:55-04:00** — Recording ended cleanly via the
+script's SIGINT-on-timeout. Final bag: **592 MB mcap** (~39 MB/min).
+The 15 min window 12:40:13 → ~12:55:13 EDT spans the WiFi-down
+rehearsal (section 9) at 12:53.
+
+## 6. mikrotik_monitor health check
+
+**2026-05-19T12:43-04:00** — Snapshot from `/diagnostics`:
+
+| Level | Item | Message |
+|---|---|---|
+| OK | `wifi.bizzy: connection` | reachable |
+| OK | `wifi.bizzy: events/wlan1` | No drops in last hour *(new `#22` metric live)* |
+| OK | `wifi.bizzy: interface/bridge,ether1,lo,wlan1` | Running |
+| OK | `wifi.bizzy: system` | OmniTIK 5 ac |
+| OK | `wifi.bizzy: wireless/wlan1/08:55:31:E0:74:D4` | Associated SNR 43dB ▁▂▃▅█ |
+| WARN | `wifi.bizzy: interface/ether2..5` | Not running *(unused wired ports)* |
+
+All real network paths healthy; only WARNs are the four unplugged
+wired Ethernet ports on the OmniTIK.
+
+## 7. gabby uptime / idle-on-pier window
+
+**2026-05-19T12:48-04:00** — `uptime` snapshot:
+
+- **Boot time**: 2026-05-19 09:45:52 EDT
+- **Uptime at check**: 3 h 02 min
+- Load avg (1/5/15 min): 3.11 / 2.38 / 2.33
+
+Useful as a proxy for how long the boat sat powered on the pier
+before launch. Compare against bag start times in
+`~/data/logs/bizzy_images/` to bound the pre-launch idle window.
+
+## 8. WiFi-disabled rehearsal — baseline
+
+**2026-05-19T12:50-04:00** — Roland about to disable WiFi at the
+operator station to rehearse the pre-launch checklist item (brief
+section "WiFi-disabled rehearsal at pier"). Baseline before he
+kills WiFi:
+
+- **Active operator-side connection_ids in stats**: `vpn`, `wifi`.
+  No explicit `starlink` label — Starlink likely rides the `vpn`
+  connection (CGNAT tunnel).
+- **udp_bridge `Giving up on resend` cumulative count**: 9 927
+  (was 3 416 at 12:30; ~325/min over the last 20 min).
+- **Time-anchor**: 12:50:03 EDT.
+
+## 9. WiFi-disabled rehearsal — observations
+
+**2026-05-19T12:53-04:00** — Roland reports: "wifi is down, good
+thing you are running in a tmux session, I had to ssh in via vpn
+to report this!" His prior shell session over WiFi was lost; the
+tmux session on gabby kept everything alive, and he re-attached
+via the VPN path. *(Lesson: running the field agent inside tmux is
+load-bearing during a Starlink/VPN-only test — confirmed this
+deployment.)*
+
+**2026-05-19T12:54-04:00** — Post-WiFi-down snapshot compared to
+the 12:50 baseline:
+
+| Metric | 12:50 baseline | 12:54 |
+|---|---|---|
+| Cumulative `Giving up on resend` | 9 927 | 10 874 (+947 in ~4 min) |
+| Rate | ~325/min | ~237/min |
+| Operator-side `connection_id`s | `vpn`, `wifi` | `vpn`, `wifi` *(wifi record persists)* |
+| **Resend attempts before giving up** | **6** | **1** |
+
+Most striking change: the resend pattern shifted from "after 6
+attempts" to "after 1 attempts," same 5 s sender TTL. With WiFi
+down at the operator station, resend transmissions toward operator
+appear to be expiring after a single try — consistent with the
+WiFi path being where the bridge was sending resends and operator
+can no longer ack on that path. The `wifi` `connection_id` is
+still present in operator stats (record not yet aged out).
+
+## 10. Temperature snapshot (warm day)
+
+**2026-05-19T13:00-04:00** — Roland flagged that it's warm today
+and asked about temperature sources.
+
+| Source | Reading |
+|---|---|
+| gabby CPU package (`thermal_zone0`) | **70.0 °C** |
+| FCU baro internal (`/bizzy/mavros/imu/temperature_baro`) | 54.4 °C |
+| Starlink thermal alerts | all **False** (no throttle, no shutdown) |
+| `/bizzy/mavros/imu/temperature_imu` | not publishing in 6 s window |
+| `/bizzy/sensors/sound_speed/temperature` | not publishing in 6 s window |
+
+`lm-sensors` is not installed on gabby — only the kernel
+`x86_pkg_temp` is available, so no per-core / motherboard / GPU
+readings. OAK cameras do not publish a temperature topic.
+
+70 °C at load avg ~3.1 is warm-but-fine for an Intel package; the
+trend over the next ~15 min is the thing to watch. No active
+thermal throttle or shutdown anywhere I can see.
+
+## 11. lm-sensors snapshot (post-install)
+
+**2026-05-19T13:05-04:00** — Roland installed `lm-sensors`.
+
+| Sensor | Reading | Thresholds |
+|---|---|---|
+| CPU package | 67 °C | high 80 / crit 100 |
+| CPU cores (22) | 63–67 °C, tight band | high 80 / crit 100 |
+| NVMe Composite | 60.9 °C | crit 114.8 |
+| **NVMe Sensor 1** | **71.8 °C** | crit 114.8 *(consumer NVMes typically throttle ~70–75 °C)* |
+| NVMe Sensor 2 | 43.9 °C | — |
+| NVMe Sensor 3 | 60.9 °C | — |
+
+CPU dropped 3 °C vs the earlier `/sys/class/thermal/thermal_zone0`
+reading (70 → 67 °C) — not on a sharp climb. NVMe Sensor 1 is the
+warmest part on the system at 71.8 °C; well below NVMe critical
+(114.8 °C), but inside the band where consumer SSDs start thermal-
+throttling write throughput. Bag recording (`~/data/logs/bizzy_images/`)
+hits this drive, so if writes slow it would show as bag growth-rate
+drop, not data loss.
+
+### Temperature timeline (2-min cron, threshold-triggered rows)
+
+Rows appended only on threshold events (CPU >75 °C, NVMe S1 >75/80 °C,
+any sensor crossing its "high", any Starlink thermal alert flip) plus
+the seed reading.
+
+| Local time | CPU pkg | NVMe S1 | NVMe Composite | Trigger |
+|---|---|---|---|---|
+| 13:02 EDT | 67.0 °C | 71.8 °C | 59.9 °C | seed |
+| 13:12 EDT | 67.0 °C | 70.8 °C | 59.9 °C | end-of-run (cron stopped) |
+
+CPU package stayed in the **66–70 °C** band over the 10 min cron
+window; NVMe Sensor 1 stayed in **70.8–71.8 °C** — no threshold
+crossings, no climb. Roland stopped the temp loop at 13:13 to start
+a 50-min camera bag (section 12).
+
+## 12. 50-min camera bag
+
+**2026-05-19T13:13-04:00** — Started 50 min (3000 s) bag via the
+same `record_camera_topics.sh` script (same 25-topic list). Output:
+
+```
+~/data/logs/bizzy_images/bag_2026-05-19T13.13.20_ffmpeg_seg/
+```
+
+**2026-05-19T14:03-04:00** — Recording ended cleanly. Final bag:
+**2.0 GB mcap** (~40 MB/min, consistent with the 12:40 bag). The
+recorder reported `Number of messages lost on the transport layer: 1`
+over the entire 50 min — almost certainly during the mru_transform
+relaunch in section 13. This bag spans the `map_tide` failure window
+and the recovery, so it's the deployment's best replay artifact for
+the chart_datum / sea_surface_estimator incident.
+
+## 13. Nav stack bringup failure — missing `bizzy/map_tide` TF
+
+**2026-05-19T13:14-04:00** — Roland pasted error output: nav stack
+bringup aborted. Key lines:
+
+```
+local_costmap: Timed out waiting for transform from bizzy/base_link
+  to bizzy/map_tide ... frame does not exist
+local_costmap: Failed to activate local_costmap because transform ...
+  did not become available before timeout
+lifecycle_manager_navigation: Failed to change state for node: controller_server
+lifecycle_manager_navigation: Failed to bring up all requested nodes. Aborting bringup.
+bt_task_navigator: Action server is inactive. Rejecting the goal.
+```
+
+Quick TF / lifecycle probe:
+
+- `/bizzy/chart_datum` lifecycle state: **active**
+- `bizzy/base_link` → `bizzy/map_tide`: `tf2_echo` timed out — frame
+  not being broadcast on `/tf`
+- `/tf_static` has frames for cameras / gnss / imu / autonav_box,
+  no `map_tide` (expected; it'd be dynamic)
+
+So `chart_datum` is active but never started broadcasting the
+`map_tide` transform → `local_costmap` couldn't activate →
+`controller_server` failed to bring up → `bt_task_navigator`
+action server inactive → goals rejected.
+
+### Root cause
+
+The publisher of `map_tide` is **`/bizzy/sea_surface_estimator`**,
+not `chart_datum`. `chart_datum` does its job (broadcasts
+`bizzy/chart_datum` and `bizzy/chart_datum_mhhw` from MLLW grids,
+both seen on `/tf`). `sea_surface_estimator` is the one that's
+supposed to broadcast the live `map → map_tide` transform after
+fusing odometry against chart datum.
+
+It's *not* broadcasting it because every estimate it computes is
+being suppressed by a plausibility check. The estimator log is
+spamming:
+
+```
+WARN: Tide estimate -12.79 m is outside plausible range
+      [-33.74, -19.42] (MLLW=-28.01, MHHW=-25.15, margin=2.0x) — suppressing
+```
+
+Numbers:
+
+| Reference | Value |
+|---|---|
+| Chart datum (MLLW) below ellipsoid | -28.01 m |
+| MHHW below ellipsoid | -25.15 m |
+| Plausible band (MLLW − margin · range, MHHW + margin · range) | [-33.74, -19.42] |
+| Computed estimate (from `/bizzy/odom` Z) | ~-12.8 m |
+
+The estimator is computing the sea surface ~**13 m higher** than
+the highest plausible tide. The safety check is doing exactly its
+job (won't poison nav with bad data) — but with all estimates
+rejected, no `map_tide` is ever published.
+
+This shape is consistent with the open issues
+[`0507eda` *nav: define lever-arm/base_link contract for SBG and
+mavros position streams*] and [`57a6134` *urdf: model SBG INS,
+GNSS antenna(s), and IMU mounting alignment on bizzyboat*]. The
+~13 m gap is too large for a simple antenna height-above-water,
+but smaller than the geoid undulation at this latitude (~25 m) —
+so a geoid-vs-ellipsoid mix-up in the odom Z chain is the
+strongest single hypothesis.
+
+### Recovery options (offered to Roland — not yet acted on)
+
+1. Hand-broadcast a static `map → map_tide` transform at a
+   plausible Z (e.g. from NOAA Portsmouth tide station) — mission-
+   enabling, not a proper fix.
+2. Widen the plausibility margin param on `sea_surface_estimator`
+   — only valid if the bias is constant.
+3. Hold and root-cause the odom Z reference.
+
+### Root-cause confirmed
+
+Snapshot of altitude values from the candidate sources:
+
+| Source | Altitude | Notes |
+|---|---|---|
+| `/bizzy/sensors/sbg/gps_pos` | +8.11 m (MSL) | with `undulation: -32.49 m`; ellipsoidal ≈ -24.38 m |
+| `/bizzy/sensors/sbg/ekf_nav` | +7.19 m (MSL) | with `undulation: -32.49 m`; ellipsoidal ≈ -25.30 m |
+| `/bizzy/mavros/global_position/global` | **-12.39 m** | (no undulation; EKF-fused) |
+| `/bizzy/tide_estimate` | **-12.44 m** | tracks mavros, not SBG |
+
+`sea_surface_estimator`'s output (`/bizzy/tide_estimate`) exactly
+tracks the mavros `global_position/global` altitude, so the chain
+runs through that topic and not SBG. SBG's ellipsoidal height
+(MSL + undulation) lands inside the plausible chart-datum band;
+mavros's `/global` lands ~13 m above it.
+
+**Triggering change**: commit `e604a36e` (Claude Code Agent,
+2026-04-28) in `unh_echoboats_project11`, switching both
+`mru_transform` `topics.position:` entries (lines 25 + 43 of
+`bizzyboat.yaml`):
+
+```diff
+-            position: "mavros/global_position/raw/fix"
+-            velocity: "mavros/global_position/raw/gps_vel"
++            position: "mavros/global_position/global"
++            velocity: "mavros/local_position/velocity_body"
+```
+
+`mavros/global_position/global` is ArduPilot's EKF-fused position
+(altitude referenced to EKF origin / home), not ellipsoidal, and
+not the same frame as SBG MSL + undulation. Downstream
+`/bizzy/odom` therefore has a Z ~13 m above where chart-datum-
+aligned code expects the sea surface to be → estimator rejects.
+
+### Fix options offered
+
+| # | YAML edit (lines 25 & 43 of `bizzyboat.yaml`) | Tradeoff |
+|---|---|---|
+| A | `position: "mavros/global_position/raw/fix"` (revert) | Restores pre-04-28 behavior; loses whatever the `/global` switch was for |
+| B | Point at SBG (`sensors/sbg/gps_pos` or `…/ekf_nav`) | Chart_datum is SBG-aligned, so more coherent; needs to confirm message-type compat |
+
+Mission-quickest is A. Awaiting Roland's call before editing.
+
+### Action: option A taken (revert + relaunch)
+
+**2026-05-19T13:30-04:00** — Roland chose option A. Reverted both
+`mru_transform` `position:` / `velocity:` entries in
+`bizzyboat_project11/config/bizzyboat.yaml` (lines 25–26 and
+43–44) back to:
+
+```yaml
+position: "mavros/global_position/raw/fix"
+velocity: "mavros/global_position/raw/gps_vel"
+```
+
+Confirmed the installed YAML at
+`install/bizzyboat_project11/share/bizzyboat_project11/config/`
+is a symlink back to the source, so the edit propagated to where
+the launched nodes read params from.
+
+**2026-05-19T13:32-04:00** — I killed `mru_transform_node` (PID 19189)
+expecting an auto-respawn. The launch wasn't configured for
+`respawn=True`, so the process stayed dead and `/bizzy/odom` lost
+its publisher. `sea_surface_estimator` and `chart_datum_node` kept
+running. Roland took over with "I'll restart everything" — full
+group relaunch is the clean path here.
+
+**Carry-forward**: the 50-min camera bag (section 12, started
+13:13) was still running across the restart and will record a brief
+TF/odom gap during the relaunch; not a bag-integrity problem, just
+noting for replay.
+
+**2026-05-19T13:35-04:00** — Roland completed the relaunch ("done").
+Post-relaunch verification:
+
+| Check | Result |
+|---|---|
+| `mru_transform_node` alive | ✓ PID 31636, using `raw/fix` per the reverted YAML |
+| `bizzy/base_link` → `bizzy/map_tide` TF | ✓ resolved, Z = **-0.078 m** (boat 7.8 cm below sea surface, sane) |
+| `/bizzy/tide_estimate` | ✓ **-23.77 m** (inside plausible band `[-33.74, -19.42]`) |
+| `sea_surface_estimator` suppression warnings (new log) | ✓ **0** |
+| Nav lifecycle: `controller_server`, `planner_server`, `behavior_server`, `bt_task_navigator`, `smoother_server`, `velocity_smoother`, `waypoint_follower`, `docking_server`, `collision_monitor` | ✓ all **active** |
+
+The full relaunch caught up the nav stack bringup automatically —
+no manual `lifecycle_manager_navigation` retry was needed because
+the dependency (`map_tide` TF) became available before the lifecycle
+nodes started transitioning. Mission unblocked.
+
+## 14. Phase 2 + recovery
+
+**2026-05-19T~14:30-04:00** *(approx)* — With the nav stack
+recovered, Roland ran a **first-ever over-horizon Starlink-only
+mission**. Reported as successful. Boat subsequently recovered.
+
+This is the deployment's headline result: the workspace's
+Starlink-via-VPN path carries enough usable bandwidth and behaves
+well enough under loss for an OTH autonomous mission. The 2026-05-01
+fixes (coprime keyframe stagger #134, udp_bridge throughput
+regression fix #16, NavSource QoS workaround camp#51) and today's
+in-field `mru_transform` revert all held.
+
+## Follow-up candidates (for wrap-up)
+
+- **Durable choice for `mru_transform`'s nav input**. Today's revert
+  to `mavros/global_position/raw/fix` is mission-enabling. The
+  proper call (mavros raw, mavros global with geoid compensation,
+  or SBG `gps_pos` / `ekf_nav`) is an open design decision. The
+  candidate is whichever option puts the antenna in a consistent
+  ellipsoidal frame with what `chart_datum` derives from MLLW grids.
+  Related task issues already exist (`0507eda` lever-arm contract,
+  `57a6134` URDF antenna mounting).
+
+- **Startup-time alarm for failed nav lifecycle bringup**. Today's
+  failure was silent until a goal got rejected. A `lifecycle_manager`
+  status diagnostic published to `/diagnostics` at WARN/ERROR
+  level when bringup aborts would catch this minutes earlier.
+
+- **Duplicate `/bizzy/sensors/sbg_device` graph entry** (section 2).
+  One PID is alive and publishing correctly; the second name
+  registration is a graph-level ghost. Worth tracking down on a
+  calm day — not deploy-blocking, but DDS name collisions can bite
+  service routing.
+
+- **udp_bridge resend-warning rate**. The deployment brief asked
+  to "validate impact" of `udp_bridge#13` (resend amplification fix).
+  We saw ~10 000+ `Giving up on resend` warnings over the session,
+  shape consistent with post-fix behavior — but the underlying
+  packet loss producing them is still high enough to be worth a
+  deeper dev-side look against this deployment's bag.
+
+- **Host thermals in `/diagnostics`** — today we polled `sensors`
+  from the shell on a 2-minute cron to keep an eye on gabby's CPU
+  package and NVMe Sensor 1 in the heat. The boat-side network
+  hardware already shows up as DiagnosticStatus entries (Starlink
+  exposes `thermal_throttle` / `thermal_shutdown` alerts; MikroTik
+  exposes its own status). The host itself doesn't — there's no
+  ROS node turning `lm-sensors` / NVMe SMART temps into
+  `diagnostic_msgs/DiagnosticStatus`. Roland suggested adding
+  something like this on the boat-side host so thermal trends
+  show up in the same place as everything else and become
+  bag-recordable / reviewable post-mission rather than only
+  visible to an operator with a shell open.
+
+## Files touched
+
+- `docs/logs/2026/2026-05-19_gabby_logs.md` *(new)*

--- a/docs/logs/2026/2026-05-19_salmon_logs.md
+++ b/docs/logs/2026/2026-05-19_salmon_logs.md
@@ -3,11 +3,7 @@
 **Host**: salmon
 **Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
 **Mode**: field (gitcloud origin)
-**Deployment**: git-bug `e3c373a` — "Deployment 2026-05-19: Starlink-only
-operation + OTH survey test" (created dev-side
-2026-05-19T11:01:22-04:00; no GitHub bridge configured field-side, so
-the GH issue number is not resolved here — dev side holds the
-canonical link)
+**Deployment**: [#135](https://github.com/rolker/unh_echoboats_project11/issues/135) — "Deployment 2026-05-19: Starlink-only operation + OTH survey test" (git-bug `e3c373a`; created dev-side 2026-05-19T11:01:22-04:00; no GitHub bridge configured field-side at write-time, so the GH link was added dev-side at wrap-up)
 
 ## Summary
 

--- a/docs/logs/2026/2026-05-19_salmon_logs.md
+++ b/docs/logs/2026/2026-05-19_salmon_logs.md
@@ -1,0 +1,649 @@
+# BizzyBoat deployment log — salmon — 2026-05-19
+
+**Host**: salmon
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
+**Mode**: field (gitcloud origin)
+**Deployment**: git-bug `e3c373a` — "Deployment 2026-05-19: Starlink-only
+operation + OTH survey test" (created dev-side
+2026-05-19T11:01:22-04:00; no GitHub bridge configured field-side, so
+the GH issue number is not resolved here — dev side holds the
+canonical link)
+
+## Summary
+
+_(user-curated, filled in at wrap-up)_
+
+## Lessons Learned
+
+_(user-curated, filled in at wrap-up)_
+
+## 1. Pre-flight: git-bug visibility on salmon
+
+**2026-05-19T11:24-04:00** — Operator asked to verify git-bug for the
+deployment workflow. `git-bug` v0.10.1 installed at
+`/usr/local/bin/git-bug`. Workspace is field-mode on this host (origin
+`git@gitcloud:field/ros2_agent_workspace.git`). Deployment-log
+convention expects the dev-opened deployment issue to be readable via
+git-bug, since salmon has no `gh` CLI / GitHub credentials.
+
+**2026-05-19T11:25-04:00** — Ran `make sync` from workspace root. Clean
+except two remote-ahead repos picked up:
+
+- `udp_bridge` — fast-forward `e6670ed..788f200` (issue-9/15 work plans
+  + resend constants + connection rate-limit tests)
+- `camp` — fast-forward `ea2e83e..0083095` (issue-50 progress and
+  `src/camp/nav_source.cpp` edits)
+
+Both relevant to today's deployment scope (Starlink-only validation of
+the post-2026-05-01 fixes).
+
+**2026-05-19T11:27-04:00** — In
+`layers/main/platforms_ws/src/unh_echoboats_project11`, ran `git-bug bug`
+— **empty list**. `git ls-remote origin 'refs/bugs/*'` showed 200+ bug
+refs on the gitcloud remote, so the data exists. Triggered `git-bug
+pull`: fetch succeeded (439 objects transferred from gitcloud), but the
+merge step failed with:
+
+```
+No identity is set.
+To interact with bugs, an identity first needs to be created using
+"git bug user new" or adopted with "git bug user adopt"
+: merge error: No identity is set.
+```
+
+Result: no bugs surfaced. Today's deployment issue invisible
+field-side, which is the failure mode the deployment-log convention
+relies on git-bug to prevent.
+
+## 2. Root cause: identity setup scoped to workspace only
+
+**2026-05-19T11:30-04:00** — Read
+`/home/field/project11/.agent/scripts/git_bug_setup.sh`. The script
+`cd`s to `ROOT_DIR` (workspace root) at line 37 and only operates
+there. No iteration over project repos. Each gitcloud project repo
+maintains its own `refs/bugs/*` and `refs/identities/*`, so the
+workspace-level identity doesn't carry over — every project repo under
+`layers/main/*_ws/src/` was missing a git-bug identity, and `git-bug
+pull` cannot merge fetched bug refs without one.
+
+Two pre-existing gates in the script, both correct as-is for field mode:
+
+- **Identity creation** needs only the local `git config user.name`
+  + `user.email`. `Field User <field@ccom.unh.edu>` is set globally on
+  salmon. **No `gh` credentials needed.**
+- **GitHub bridge** step is guarded by `[[ "$remote_url" ==
+  *"github.com"* ]]` (line 88 in the old script). For gitcloud-origin
+  repos the bridge step is skipped cleanly; `gh` not being installed on
+  salmon is irrelevant for the gitcloud-origin repos. (It does mean the
+  workspace repo can't get a bridge here either, but the workspace is
+  also gitcloud-origin on salmon, so the same guard applies.)
+
+The gap is identity-only, scoped to project repos.
+
+## 3. Patch: per-repo loop in `git_bug_setup.sh`
+
+**2026-05-19T11:34-04:00** — Refactored
+`/home/field/project11/.agent/scripts/git_bug_setup.sh`:
+
+- Factored the per-repo logic into `setup_repo_gitbug()` (inner steps
+  unchanged: identity create/adopt → conditional bridge → `git-bug pull`).
+- Driver loops over workspace root plus every match of
+  `layers/main/*_ws/src/*/` via bash glob.
+- Existence check uses `[ -e "$repo_dir/.git" ]` so worktrees (where
+  `.git` is a file pointing into the linked repo) and regular repos
+  are both handled.
+- Bridge step keeps its github.com origin guard. For non-GitHub origins
+  the loop logs "Non-GitHub origin — skipping bridge step." and proceeds
+  to the pull, which works over plain git transport once identity
+  exists.
+- Smoke test stays workspace-scoped (one summary line, not per-repo).
+
+Edit applied in-tree on salmon — workspace is field-mode on this host,
+so AGENTS.md field-mode rules permit direct edits to `main`.
+
+## 4. Verification across all overlay project repos
+
+**2026-05-19T11:35-04:00** — Re-ran
+`/home/field/project11/.agent/scripts/git_bug_setup.sh`. Workspace
+identity already existed (idempotent). **40 project repos processed**
+across `core_ws`, `platforms_ws`, `sensors_ws`, `simulation_ws`,
+`site_ws`, `ui_ws`, and `underlay_ws`. Each produced:
+
+```
+Creating git-bug identity: Field User <field@ccom.unh.edu>
+<identity hash>
+ℹ️  Non-GitHub origin — skipping bridge step.
+Pulling git-bug data from origin...
+✅ git-bug sync complete.
+```
+
+No failures. Workspace smoke test reported `38 open issues cached`.
+
+**2026-05-19T11:36-04:00** — Confirmed in
+`layers/main/platforms_ws/src/unh_echoboats_project11`:
+
+- `git-bug user` now lists 3 identities — `Field User` just created
+  here, plus `Matthew Diakonov (m13v)` and `Claude Code Agent`
+  inherited from prior gitcloud history.
+- `git-bug bug status:open` → **34 open bugs**.
+- `git-bug bug status:closed` → **48 closed bugs**.
+- Today's deployment issue **`e3c373a`** — "Deployment 2026-05-19:
+  Starlink-only operation + OTH survey test" — visible with full body
+  (scope, hosts, pre-launch checklist, carry-forward items from
+  2026-05-01).
+
+This unblocks the field side of the deployment-log workflow: salmon
+(and gabby on first sync) can now read the deployment issue without
+GH access.
+
+## 5. Field commit and push
+
+**2026-05-19T11:37-04:00** — Sourced
+`.agent/scripts/set_git_identity_env.sh "Claude Code Agent"
+"roland+claude-code@ccom.unh.edu" "Claude Opus 4.7 (1M context)"`,
+then committed the script change as a field change on the workspace's
+`main` and pushed:
+
+- Commit: `236f2d7` — `git_bug_setup: configure identity + sync across
+  all overlay project repos` (author `Claude Code Agent
+  <roland+claude-code@ccom.unh.edu>`).
+- Push: `5add5e2..236f2d7  main -> main` on
+  `gitcloud:field/ros2_agent_workspace.git`.
+
+## 6. Workspace build after sync
+
+**2026-05-19T11:47-04:00** — `make build` from workspace root. ~11
+minutes wall time, exit 0 across every layer. Build report:
+
+| Layer | Packages (OK) | Notes |
+|---|---|---|
+| underlay | 22 / 22 | stderr only from audio_capture, audio_play, geodesy, norbit_driver, r2sonic (warnings) |
+| core | 24 / 24 | stderr from manda_coverage, marine_autonomy, marine_charts, marine_nav_behavior_tree, marine_nav_bt_task_navigator, marine_nav_crabbing_path_follower, udp_bridge |
+| platforms | 12 / 12 | stderr from mru_transform |
+| sensors | 17 / 17 | stderr from cube_bathymetry, depthai_marine, marine_radar_layer, marine_radar_tracker, marine_tools, sea_surface_segmentation, simrad_halo_radar |
+| simulation | 10 / 10 | clean |
+| ui | 7 / 7 | stderr from camp, rqt_marine_radar, rqt_udp_bridge, rviz_sonar_image |
+| site | 1 / 1 | clean |
+
+All "stderr" entries are compiler warnings (unused-parameter etc. in
+`camp/src/camp/*`); nothing fatal, no error escalations. Picks up the
+post-sync code in `udp_bridge` (resend constants + rate-limit tests +
+remote-node resend) and `camp` (`nav_source.cpp` QoS edits from
+PR #51) without changes to the rest of the tree.
+
+Workspace is ready for the deployment-issue pre-launch checks (OAK
+cadence bench-verify, sustained `iperf3 -u -t 600 -b 5M`, WiFi-disabled
+rehearsal).
+
+## 7. Operator-side ROS nodes started
+
+**2026-05-19T11:57-04:00** — Operator reported operator-side ROS
+nodes started on salmon. Verified via `ros2 node list` /
+`ros2 topic list`:
+
+- **Operator stack**: `/operator/camp`, `/operator/diagnostic_aggregator`,
+  `/operator/udp_bridge`.
+- **Operator-side boat-control nodes** (run on salmon, drive `bizzy` via
+  `udp_bridge` — namespaced under `/bizzy` by convention):
+  `/bizzy/command_bridge_sender`, `/bizzy/joy_node`, `/bizzy/joy_to_helm`,
+  `/bizzy/joint_state_publisher`, `/bizzy/robot_state_publisher`.
+- **Network / support**: `/mikrotik_monitor`, `/ping_monitor`,
+  `/starlink_diagnostics`, `/molab/johnny5/johnny5_node`,
+  `/rosbag2_recorder` (recording active).
+- **rqt panels**: three rqt nodes alive
+  (`/rqt_gui_cpp_node_48863`, `/rqt_gui_cpp_node_48866`,
+  `/rqt_gui_py_node_48863`).
+- Operator `udp_bridge` has registered **one remote**: `bizzy`
+  (`/operator/udp_bridge/remotes/bizzy/{bridge_info,topic_statistics}`).
+
+`ros2 topic echo --once /bizzy/marine/heartbeat` timed out at 3 s — no
+boat-side heartbeat received yet. Topic exists in the operator
+namespace (bridge has it registered) but no data has flowed.
+Consistent with operator-only startup.
+
+## 8. Pre-restart re-sync
+
+**2026-05-19T12:06-04:00** — Operator flagged that the running ROS
+stack predates the `make build` (pre-sync `udp_bridge` + `camp`
+binaries). Plan: restart with the new build before bringing the boat
+side up.
+
+Re-ran `make sync` from workspace root as a final pre-launch check.
+All repos `✅ Already up to date` except:
+
+- `unh_echoboats_project11` — **skipped: Uncommitted changes
+  detected.** That's this log file in `docs/logs/2026/`. Expected per
+  README convention (field hosts push logs at end of session); not a
+  blocker.
+
+No code deltas, so no rebuild needed before restart. Pre-launch
+checklist item *"`make sync` on dev; field hosts pulled latest from
+gitcloud"* is satisfied for salmon.
+
+**2026-05-19T12:07-04:00** — Belt-and-braces `make build` re-run.
+Fast incremental pass (~1 min), all 7 layers ✅, no stderr — confirms
+the install tree matches the current source. Stack is ready to be
+relaunched on the new binaries.
+
+## 9. Boat deployed; operator stack relaunched on new build
+
+**2026-05-19T12:20-04:00** — Operator reported boat is deployed.
+Verified state on salmon:
+
+- **Operator stack restarted**: `launch_ros` PID 48850 → 57526; rqt
+  PIDs also new (57546/57547 vs 48863/48866). So the operator side is
+  now running on the post-`make build` install (with `udp_bridge`
+  resend + rate-limit changes and `camp` NavSource QoS workaround in
+  effect).
+- **Boat heartbeat flowing**: `ros2 topic echo --once
+  /bizzy/marine/heartbeat` returns a fresh message — was timing out
+  at 11:57.
+- **First heartbeat values**:
+  - `piloting_mode`: **standby**
+  - `marine_autonomy_standby`: `true`
+  - `connected`: `true`
+  - `armed`: `true`
+  - `guided`: `true`
+  - `mode`: **LOITER** (FCU mode)
+- **Node-list delta vs 11:57**: `/mikrotik_monitor` not present in
+  the current node list (was running pre-restart). Not investigating
+  further unless operator flags it.
+
+Bridge link to `bizzy` is healthy enough to deliver heartbeat;
+end-to-end UDP-bridge → CAMP path is exercised.
+
+## 10. Diagnostics snapshot (post-deploy)
+
+**2026-05-19T12:26-04:00** — Operator confirmed CAMP shows green;
+captured `/diagnostics_agg` for cross-reference. Toplevel reports
+**ERROR**; 86 status entries total, 64 OK.
+
+**ERROR (3)**
+- `/Boat` — "Error" (rollup)
+- `/Other` — "Error" (rollup)
+- `/Other/ping_monitor: Ping: ping.op: bencloud` —
+  **Unreachable (100% packet loss)**
+
+**WARN (9)**
+- `/Boat/MAVROS/mavros: Mount` —
+  *"Can not diagnose in this targeting mode"*
+  (drives `/Boat/MAVROS` rollup → Warning; everything else under
+  MAVROS is OK)
+- `/Other/mikrotik_monitor: wifi.bizzy: interface ether{2,3,4,5}` —
+  **Not running** (×4)
+- `/Other/ping_monitor: ping.bizzy: dns_google` — **25% packet loss**
+- `/Other/teltonika_monitor: router.bizzy: interface mob1s2a1` — Down
+- `/Other/teltonika_monitor: router.bizzy: mwan3 mob1s2a1` — notracking
+- `/Other/teltonika_monitor: router.bizzy: mwan3 wan1` — notracking
+
+**STALE (9)** — `/Boat/{MikroTik,Ping,Starlink,Teltonika}` and the
+parallel `/Operator/*` set. The `/Operator/*` buckets exist in the
+aggregator config but receive no input: the actual monitor nodes
+(`mikrotik_monitor`, `ping_monitor`, etc.) publish under `/Other`
+instead. (Pre-existing aggregator-config issue, not new today.)
+
+**MAVROS happy-data sanity check** (from the same snapshot):
+- Battery 28.49 V, 0.0 A
+- GPS 3D fix, 38 sats visible, EPH 0.39 m / EPV 0.70 m
+- Heartbeat 1.0 Hz, 1129 since startup
+- FCU mode LOITER, ArduPilot, System ACTIVE
+- MAVROS Router 309 114 routed / 0 dropped; FCU endpoint rx 9988 B/s
+
+**Cross-reference to today's Phase 1 scope** (Starlink-only, WiFi
+disabled at operator):
+- `wifi.bizzy ether2-5 Not running` — consistent with WiFi disabled.
+- `teltonika mob1s2a1 Down`, `mwan3 notracking` — consistent if
+  cellular isn't being used today.
+- `ping.bizzy: dns_google 25% loss` — boat's outbound DNS path lossy.
+- `ping.op: bencloud Unreachable` — operator-side, not in today's
+  scope. **Looks like a stale monitor target on the operator config;
+  pending operator confirmation.**
+
+Operator reports the CAMP view is green — the toplevel ERROR is
+driven by stale-promotion of categories that haven't been re-bucketed
+into `/Boat/*` post-restart, plus the `bencloud` monitor.
+
+## 11. udp_bridge resend-give-up warning storm
+
+**2026-05-19T12:30-04:00** — Operator reported `udp_bridge` is
+spamming warnings. Sampled `/rosout` for ~6 s and captured **5386
+distinct WARN entries** from `operator.udp_bridge`, all of the same
+template:
+
+> `Giving up on resend of packet NNNNNN from remote 'bizzy' after 5
+> attempts (first requested ~5.00 s ago, sender TTL is 5 s)`
+
+Packet numbers sampled span at least 983046–983094 with gaps,
+indicating both sequential give-ups (e.g. 983046–983057 contiguous)
+and sporadic singletons (983070, 983093, 983094…). Same template,
+varying packet IDs.
+
+This is from the **new resend tracking code** just deployed
+(`udp_bridge` commit range
+`e6670ed..788f200` from this session's `make sync`, which added
+`udp_bridge/include/udp_bridge/resend_constants.h` plus
+`udp_bridge/test/test_remote_node_resend.cpp` and the resend logic in
+`src/remote_node.cpp`). The text reports that resend requests issued
+by the operator side for missing packets are reaching the sender's
+5 s TTL window before they can be delivered — so the sender drops
+them after 5 attempts.
+
+**Cross-reference to deployment scope**: the issue body lists
+[`rolker/udp_bridge#13`](https://github.com/rolker/udp_bridge/pull/13)
+("resend loop amplification fix") as in-flight. The merged code
+includes `resend_constants.h` and the `remote_node` resend logic;
+whether that PR specifically is merged or is still in flight against
+this baseline is **pending operator confirmation**. Either way, the
+warning storm is worth capturing as Starlink-only baseline behavior
+to feed back into the post-deployment review.
+
+Not investigating root cause unless the operator asks. Recording as
+field observation.
+
+## 12. mikrotik_monitor: working on boat side, missing on operator side
+
+**2026-05-19T12:45-04:00** — Operator asked whether `mikrotik_monitor`
+is working. Two distinct answers:
+
+### Boat-side: working fine
+
+The boat-side `mikrotik_monitor` is publishing fresh diagnostics that
+arrive at salmon via `udp_bridge` (which is why no node matching
+`mikrotik` appears in operator-side `ros2 node list` — the node runs
+on gabby and its `/diagnostics` topic forwards through the bridge).
+Sampled at 2026-05-19T16:43:03+00:00 (≈12:43 EDT):
+
+- Target: `MikroTik OmniTIK 5 ac`, RouterOS 7.22 stable, uptime
+  2h57m, CPU load 5 %, `connection: reachable`
+- `events/wlan1`: no drops in the last hour (`drops_last_5min = 0`,
+  `drops_last_60min = 0`)
+- `wireless/wlan1/08:55:31:E0:74:D4`: **Associated, SNR 35 dB,
+  signal-strength −73 dBm @ HT40-3** — link healthy
+- `interface/{bridge,ether1,lo,wlan1}`: Running ✅
+- `interface/ether{2,3,4,5}`: Not running (unused router ports)
+
+### Correction to §10
+
+§10 attributed `wifi.bizzy ether2-5 Not running` to "WiFi disabled at
+the operator station". That was **wrong**: `wifi.bizzy` is the
+**boat-side** MikroTik (the OmniTIK 5 ac on the boat), and ether2-5
+are just its unused LAN ports — normal for this router model. The
+Phase 1 "WiFi disabled at operator" condition isn't visible via
+`mikrotik_monitor` on this run because the operator-side mikrotik
+monitor isn't running (see below).
+
+### Operator-side: declared but not running
+
+**2026-05-19T12:48-04:00** — Investigated why operator-side
+`mikrotik_monitor` and `teltonika_monitor` are absent from the node
+list. Findings:
+
+- Launch invocation: `ros2 launch bizzyboat_project11
+  operator_core_launch.py` (PID 57526, started 12:08 EDT from pts/5).
+  Resolved via `ps -ef | awk '$2=="57526"'`.
+- `operator_core_launch.py` includes
+  `network_monitor_operator_launch.py`, which declares **4 monitor
+  nodes**: `mikrotik_monitor`, `teltonika_monitor`,
+  `starlink_diagnostics`, `ping_monitor`.
+- Of those 4 in the running tree of PID 57526:
+  - ✅ `starlink_diagnostics` (PID 57750)
+  - ✅ `ping_monitor` (PID 57755)
+  - ❌ `mikrotik_monitor` — absent, no matching PID
+  - ❌ `teltonika_monitor` — absent, no matching PID
+- Sanity checks rule out missing-install / unreachable-target:
+  - Executables present:
+    `sensors_ws/install/mikrotik_monitor/lib/mikrotik_monitor/mikrotik_monitor_node`
+    and the parallel `teltonika_monitor_node`.
+  - Target host `bizzy.wifi.op.p11.lan` (172.16.20.4) is reachable
+    from salmon, <1 ms RTT, 0 % loss.
+  - `/rosout` retained buffer has **no** entries from either node
+    name — they appear to have died before publishing, or their
+    messages aged out of the buffer.
+  - `journalctl --user` shows nothing because they're not run as
+    user-services.
+
+Stdout/stderr from these processes went to the launch terminal
+(`pts/5`) — `output='screen'` in the Node declaration. The actual
+crash reason (likely an exception during connect/auth against the
+RouterOS box, but **not verified**) would be visible there. Operator
+will check pts/5 console / scrollback.
+
+**Effect on diagnostics tree**: the `/Operator/MikroTik`,
+`/Operator/Teltonika`, `/Operator/Ping`, `/Operator/Starlink`
+aggregator buckets are STALE in §10 because no operator-side
+publishers are providing input to them — separate config issue noted
+in §10, but the two missing monitors here would not have helped even
+if running (they publish under `/Other`, not `/Operator/*`).
+
+## 13. Phase 1: WiFi-down test — baseline captured
+
+**2026-05-19T12:50-04:00** — Operator announced they are about to
+disable WiFi at the operator station (Phase 1 of today's scope:
+Starlink-only operation). Captured pre-test baseline from
+`/operator/udp_bridge/remotes/bizzy/topic_statistics`:
+
+- Active connection seen in stats: **`connection_id: wifi`**.
+- `/bizzy/local_costmap/costmap`: published on boat at
+  **1.485 msg/s (3.80 MB/s)**; arriving on operator via WiFi at
+  **0.334 msg/s (855 kB/s, 65 fragments/msg, success 21.4 kB/s)** —
+  ~78 % drop on this large fragmented topic even on the WiFi path.
+- `/bizzy/local_costmap/published_footprint`: published 5.108 msg/s
+  (551 B/s); arriving via WiFi 5.108 msg/s (552 B/s) — clean.
+- Heartbeat flowing, FCU LOITER, armed/guided/standby all true.
+- Toplevel diagnostics still ERROR (unchanged from §10).
+- `udp_bridge` resend-give-up warning storm (§11) still in progress.
+
+Standing by to capture post-WiFi-down snapshot for comparison once
+operator signals the cutover.
+
+## 14. Post-WiFi-down: heartbeat alive, bridge stats stalled
+
+**2026-05-19T12:53-04:00** — Operator reported WiFi at salmon is now
+down (Phase 1 cutover). Snapshot taken in the first 60 s after the
+cutover:
+
+**Data plane (Starlink) is alive for small low-rate topics:**
+
+- Boat heartbeat: **11 messages in 10 s, exactly 1.000 s spacing**
+  (clean 1 Hz) — Starlink path is delivering the small high-priority
+  payloads.
+- Operator-side bridge process alive: PID 57723, ELAPSED 54:01,
+  STAT `Sl+` (sleeping, multithreaded, foreground), no crash.
+
+**Bridge statistics publication has stalled:**
+
+- `/operator/udp_bridge/topic_statistics` — **0 msgs in 10 s**
+- `/operator/udp_bridge/remotes/bizzy/topic_statistics` —
+  **0 msgs in 15 s**
+- `/operator/udp_bridge/remotes/bizzy/bridge_info` —
+  **0 msgs in 10 s**
+- All three were arriving within a few seconds pre-cut. They are not
+  publishing at all now.
+
+**Resend-give-up WARN storm has accelerated:**
+
+- ~2021 distinct WARN msgs from `operator.udp_bridge` in a 3 s live
+  sample → **~670 WARN/s** (compare §11's 5386-in-6s which included
+  retained buffer; the 670/s number here is live-rate).
+- Template now ends `"after 6 attempts"` (was `"after 5 attempts"`
+  in §11). Sender TTL still 5 s; operator side is trying one more
+  attempt before giving up.
+- Packet IDs jumped from ~983 k at 12:30 (§11) to ~1.97 M at 12:53
+  — implies sustained ~720 packets/s on the wire over the
+  intervening 23 minutes.
+
+**Reading**: the bridge process is alive and the inbound packet path
+is still working (heartbeat proves end-to-end). But the periodic
+stats publish callbacks (topic_statistics, bridge_info) are not
+firing — consistent with the inbound-packet / resend-tracking loop
+saturating the bridge's work queue and starving the stats timer.
+CAMP / rqt statistics panels would look frozen.
+
+Not yet investigating root cause beyond observation; logging as
+field finding for the post-mission review.
+
+## 15. Boat recovered
+
+**2026-05-19T14:10-04:00** — Operator reported boat has been
+recovered. Snapshot from salmon at recovery time (mission ran roughly
+12:50 → 14:10 EDT, ≈1h20m on-water phase including the Starlink-only
+test):
+
+**Heartbeat still flowing (1 Hz, 5/5 in 5 s)** — boat still powered
+up. Latest state:
+
+- `piloting_mode = autonomous`  *(was `standby` at deployment §9)*
+- `mode = MANUAL`  *(was `LOITER`)*
+- `armed = true`  *(unchanged)*
+- `guided = false`  *(was `true`)*
+- `connected = true`
+- `marine_autonomy_standby = false`  *(was `true`)*
+
+Mode transitions consistent with manual takeover for recovery.
+
+**Bridge statistics still stalled** — `topic_statistics` 0 msgs in
+5 s. The stats-publication stall first observed in §14
+(post-WiFi-down) has persisted for the entire ≈1h17m of the
+Starlink-only phase. Stats panels in CAMP / rqt have been frozen
+that whole time.
+
+**`udp_bridge` WARN rate dropped** — ~918 distinct WARN entries in
+3 s ≈ **306/s**, compared with §14's ~670/s right after the WiFi
+cutover. The "Giving up on resend" template now ends `"after 1
+attempts"` (was "5" in §11, "6" in §14). Packet IDs in the WARN
+samples (e.g. 1691225, 1691830) are **lower than the 1.97 M IDs
+seen at 12:53 in §14**, which suggests a counter reset somewhere
+during the mission — possibly a sender-side bridge restart on the
+boat. Not verified from salmon.
+
+These are anchor observations for the post-mission review; logging
+them now while fresh.
+
+## 16. Wrap-up snapshot
+
+**2026-05-19T14:12-04:00** — Final state captured before session
+wrap-up.
+
+**Operator-side ROS bag** (recorded throughout the session):
+
+- Path: `/home/field/data/logs/operator/2026-05-19/bags/operator_2026-05-19T12.08.34/operator_2026-05-19T12.08.34_0.mcap`
+- Size: **296 MB** (one shard; mcap / zstd_fast preset)
+- Recorded topics (from `operator_core_launch.py` arguments):
+  `/diagnostics`, `/bizzy/marine/command`,
+  `/bizzy/piloting_mode/manual/helm`,
+  `/operator/udp_bridge/topic_statistics`,
+  `/operator/udp_bridge/bridge_info`,
+  `/operator/udp_bridge/remotes/bizzy/topic_statistics`,
+  `/operator/udp_bridge/remotes/bizzy/bridge_info`,
+  `/rosout`, `/tf`, `/tf_static`
+- Coverage: 12:08:34 → 14:12 (~2h 4m, includes pre-deploy + on-water
+  + post-recovery).
+- **Note**: the bag captures `/rosout` so the udp_bridge resend WARN
+  storm (§11/§14/§15) is fully replayable for the post-mission review.
+  It also captures `topic_statistics` — so the stall observed in §14
+  manifests there as a gap in publication, not as missing data.
+
+**Final salmon node-list count**: 16 (same shape as §9: operator
+stack + /bizzy/* operator-side control nodes + support).
+
+**Final diagnostics toplevel**: still ERROR (unchanged from §10/§15;
+driven by the stale `/Operator/*` rollups and the `ping.op: bencloud`
+unreachable entry).
+
+**Session anchor times** (for cross-correlation with gabby / dev
+logs):
+
+| Time | Event |
+|---|---|
+| 11:01 | Deployment issue `e3c373a` opened on dev side |
+| 11:24 | git-bug discovery on salmon (pre-fix) |
+| 11:37 | `git_bug_setup.sh` field commit `236f2d7` pushed |
+| 11:47 | First `make build` complete |
+| 12:08 | `operator_core_launch.py` started (PID 57526) |
+| 12:20 | Boat heartbeat first seen at salmon |
+| 12:50 | Phase 1 baseline captured (WiFi up) |
+| 12:53 | WiFi-down cutover observed; bridge stats stall begins |
+| 14:10 | Boat recovered, FCU → MANUAL |
+| 14:12 | Wrap-up snapshot |
+
+## Issues encountered + diagnoses
+
+- **Pre-commit hook did not run on salmon's workspace clone.**
+  `/home/field/project11/.git/hooks/pre-commit` does not exist on this
+  host — `make lint` has not been run, so the workspace's
+  `.pre-commit-config.yaml` (which lists `no-commit-to-branch` for
+  `main`/`jazzy`/`rolling`) was never wired up. The field commit on
+  `main` went through without the branch-protection check that
+  AGENTS.md anticipates would block it on a host with pre-commit
+  installed. Per the "Hook caveat" in AGENTS.md: field-mode workspace
+  clones may need `main` removed from the hook list (or the hook
+  dropped) to align with field-mode behavior. **Flagging for dev-side
+  decision** rather than altering hook config here, since this would
+  affect all consumers of the workspace.
+
+- **GitHub issue number for `e3c373a` is not resolvable field-side.**
+  Without a bridge ever having been configured for this issue, git-bug
+  has no `metadata` blob mapping `e3c373a` to its GitHub `#NNN`.
+  Workable for field reading (the title + git-bug hash are sufficient)
+  but worth a follow-up: future deployment-issue creation on dev should
+  ideally happen after the bridge is in place, so field hosts see the
+  mapping.
+
+## Files touched
+
+- `/home/field/project11/.agent/scripts/git_bug_setup.sh` — full
+  rewrite (110 insertions / 89 deletions on the workspace's `main`).
+  Workspace repo, gitcloud origin. **Pushed** as field commit
+  `236f2d7` at 11:37 (§5).
+- `docs/logs/2026/2026-05-19_salmon_logs.md` — this file. Project repo
+  (`unh_echoboats_project11`), gitcloud origin. **Pending push** per
+  README convention.
+- Operator bag:
+  `/home/field/data/logs/operator/2026-05-19/bags/operator_2026-05-19T12.08.34/operator_2026-05-19T12.08.34_0.mcap`
+  — 296 MB, mcap/zstd_fast. Not under version control; stays in
+  `~/data/logs/` per README convention.
+
+## Pending on operator
+
+- **Push this salmon log to gitcloud** when ready to close the
+  session.
+- **Check pts/5 console scrollback** for the actual crash reason of
+  operator-side `mikrotik_monitor` and `teltonika_monitor` (§12).
+  Stdout/stderr from those processes went there.
+- **Confirm boat-side bridge restart hypothesis (§15)**: packet IDs
+  in the resend-WARN stream went from ~1.97 M at 12:53 down to
+  ~1.69 M at 14:10, which only makes sense if the sender-side bridge
+  on gabby was restarted at some point. Worth checking gabby's log
+  for a restart event.
+- **Confirm `rolker/udp_bridge#13` status** (resend-loop amplification
+  fix referenced in the deployment issue) — needed to interpret the
+  WARN storm severity (§11/§14).
+
+## Pending for dev-side wrap-up
+
+- **Reconcile `236f2d7` to GitHub** via `/import-field-changes` from
+  a dev workstation. The dev-side PR will re-run the workspace's
+  pre-commit set — first time this script change has seen it.
+- **Open follow-up task issues** for the post-mission findings:
+  - udp_bridge `topic_statistics` / `bridge_info` publication
+    stalled the entire ≈1h17m of Starlink-only operation (§14/§15).
+    Stats panels in CAMP / rqt were frozen the whole time.
+  - "Giving up on resend… after N attempts" template — observed N
+    values 5 / 6 / 1 across the session. Whether N is meaningful or
+    a counter-tracking glitch worth confirming.
+  - Operator-side `mikrotik_monitor` + `teltonika_monitor` crash on
+    startup (§12) — likely fixable with a try/except around the
+    initial connect, but root-cause from pts/5 still needed.
+  - `ping.op: bencloud` Unreachable in `/Other` despite `ping` from
+    salmon reaching bencloud — `ping_monitor` may be pinging a
+    different target than the operator's bash shell resolves (the
+    YAML uses `bencloud.wg.p11.lan`, not `bencloud`).
+  - `/Operator/{MikroTik,Ping,Starlink,Teltonika}` aggregator
+    buckets STALE because real monitors publish under `/Other`
+    (§10/§12) — aggregator config drift.
+  - Costmap had ~78 % loss on WiFi pre-cut (§13) — the bag has the
+    Starlink-only data needed for direct comparison.
+- **Update `docs/roadmap.md`** with anything from the above that
+  isn't bounded enough for a focused issue.
+- **Merge the wrap-up PR**; closing it closes the deployment issue
+  `e3c373a` / its GitHub equivalent.

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -124,11 +124,20 @@ top-to-bottom in time.
 1. User signals: "wrap up the deployment" / "close out".
 2. Field machines push their logs to gitcloud at end of session.
 3. Dev pulls those into the worktree branch.
-4. Dev agent reviews the full deployment, opens follow-up task issues
+4. **Dev integrates brief summaries of significant field-agent log
+   entries into the dev log's Timeline** so the dev log alone provides
+   an at-a-glance view of the full deployment. Each integrated entry
+   stays one sentence (drill-down lives in the source log) and tags
+   its origin, e.g. `gabby agent (gabby log §N): …`. Avoid restating
+   what the dev log already covers via the operator's real-time
+   observations — only fill gaps. Cross-host observations that
+   contradict each other deserve an inline reconciliation entry, not
+   silent overwrites.
+5. Dev agent reviews the full deployment, opens follow-up task issues
    for any genuine carry-forward, updates `docs/roadmap.md` with
    anything that's "do this someday but not now".
-5. Dev pushes, gets the PR ready for review, merges.
-6. Merging closes the deployment issue.
+6. Dev pushes, gets the PR ready for review, merges.
+7. Merging closes the deployment issue.
 
 ### Deferred / no-issue items → roadmap
 
@@ -167,6 +176,7 @@ repo-specific label — create it the first time if it doesn't exist.)
   - any task-specific deep-dive log files spun off during the session
     (see [Task-specific deep-dive logs](#task-specific-deep-dive-logs))
 - **Wrap-up checklist** — push field logs to gitcloud, pull to dev,
+  integrate brief field-agent timeline entries into the dev log,
   audit for carry-forward, open follow-up task issues, update
   `docs/roadmap.md` with anything deferred, merge the wrap-up PR
 

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -3,6 +3,14 @@
 Per-deployment, per-host log files. Each agent writes its own file; no
 coordination needed for parallel agents on different hosts.
 
+> **Prototype notice**: This convention is the proven prototype for a
+> workspace-level deployment-logging capability tracked in
+> [`rolker/ros2_agent_workspace#477`](https://github.com/rolker/ros2_agent_workspace/issues/477).
+> When updating this file — adding steps, refining wording, adjusting
+> the lifecycle — please also append the change (or a link to the
+> commit/PR) as a comment on that issue, so the workspace design
+> discussion stays in sync with what's proven in BizzyBoat practice.
+
 ## File layout
 
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,9 +16,18 @@ to the pier — all without user intervention.
 
 ## Forcing function
 
-**Field hydrography class — June 2026.** Students plan surveys, monitor
-execution, configure sonar software, and measure offsets. The system
-must be reliable and novice-friendly by then.
+**Summer Hydro 2026 — class + real lake survey.**
+- **June 4**: Class starts. Roland teaches boat operation; students learn
+  survey-component integration in parallel. Heavy development should be
+  **done by this date** — switch to maintenance mode thereafter.
+- **June 15 → ~June 29**: Two-week real survey at Lake Massabesic, NH.
+  10 students rotate in 3 daily groups (3–4 students/day) plus engineer
+  / intern helpers.
+
+This is a real survey for a real customer, not a class exercise — the
+system must work, not just demonstrate. Hydrographic-quality output is
+the educational goal even though the operational bar is lower. The
+system must support multi-operator handoff across daily cohorts.
 
 ## Active threads (have task issues)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,10 +61,42 @@ visible from one place.
 - [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up. Software pipeline live 2026-04-27 (#94); M3 1PPS time-sync chain completed 2026-05-01 (#121); QINSy SBG hookup live.
 - NTRIP — MassDOT source tested at Lake Massabesic; works with current configuration.
 
-### Camera obstacle avoidance
+### Surface-obstacle awareness — camera + costmap
 
-- [`rolker/unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) — `SeaSurfaceLayer::matchSize()` segfault (blocker)
-- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK→costmap validation (blocked on #6); per-camera `frame_ids` parameter + URDF-aligned `<label>_optical_frame` default across all `CameraBase` publisher paths landed via [PR #9](https://github.com/rolker/unh_marine_perception/pull/9) (merged 2026-04-28)
+The 2026-05-01 mooring-ball near-miss made this concrete: cameras see
+surface obstacles, but segmentation output is not feeding the Nav2
+costmap, so the autonomy planner has no awareness. With student
+operators driving the boat at Lake Massabesic — where the obstacle set
+is recreational boats and kayaks (no swimmers; the lake is a
+drinking-water reservoir) and drifting debris — the operational gap
+matters.
+
+**Two-tier delivery — display first, planning second.** The display
+path has a lower bar because it doesn't have to be perfect to be useful
+— an operator looking at a noisy costmap still gets situational
+awareness value. The planning path is much higher bar: the autonomous
+planner needs the costmap to be trustworthy before it'll improve
+autonomy quality.
+
+**Priority for June 4** (display path):
+- [`rolker/unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) — `SeaSurfaceLayer::matchSize()` segfault. High priority but not yet on the active "next-item-to-do" list. Hard blocker on everything downstream of segmentation → costmap fusion. Needs to land on someone's plate.
+- [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) — end-to-end OAK → costmap validation. Blocked on #6. End state for display-first: "a costmap is being published, populated by segmentation, and the operator can see it."
+- [`rolker/unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127) — operator-side local costmap display. Becomes critical-to-have once #6 / #7 ship. 2026-05-19 measured ~78% loss on the wifi path for the costmap topic; bandwidth budget needs to fit.
+- Per-camera `frame_ids` + URDF-aligned `<label>_optical_frame` default via [PR #9](https://github.com/rolker/unh_marine_perception/pull/9) (2026-04-28). *(Done.)*
+
+**Defer past June 4** (planning path):
+- Using the costmap for autonomous planning. Requires costmap quality
+  to be much higher than the display-only bar. Maintenance-mode work.
+
+**Fallback plan if the display path doesn't ship in time:**
+- Vigilant camera-watching — current SOP. Multi-operator station means
+  multiple eyes (you + 3–4 students + engineer helpers).
+- Pre-plan exclusion zones around docks, traffic lanes, shoreline.
+- Manual override / RC takeover drilled with student operators before
+  going autonomous.
+- (See also Navigation reliability — [`unh_marine_navigation#24`](https://github.com/rolker/unh_marine_navigation/issues/24)
+  lets the operator drop survey speed on demand for any reason,
+  including obstacle reaction time.)
 
 ### Navigation reliability
 
@@ -135,14 +167,6 @@ The 2026-05-01 deployment ran the boat past visual range with the new comms stac
 
 - **BT `SkipUnknownTaskType` catchall masks execution failures** — top-level `ReactiveFallback` can't distinguish "no script condition matched" from "matching subtree's execution failed", so the catchall fires on action ABORTs and silently marks tracklines done. Forensic match for the 2026-05-01 15:09 HOLD episode (FollowPath ABORTED → SurveyLineTask sequence failed → catchall fired → trackline marked done → `done_hover` activated). Needs a new task issue against the BT / mission_manager. See gabby log §11.
 - **GUIDED stale-setpoint HOLD verified working** — when `cmd_vel` publication stops, FCU correctly enters HOLD. Confirmed Nav2-crash failsafe behaves as intended.
-
-### Perception → costmap *(new theme — 2026-05-01)*
-
-The 2026-05-01 mooring ball near-miss made this concrete: cameras can see surface obstacles, but segmentation output is not feeding the Nav2 costmap, so the autonomy planner has no awareness. This is a real survey-readiness blocker — any autonomous survey will be in waters with mooring balls, debris, and other vessels.
-
-Existing tracker: [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) (end-to-end OAK → costmap validation). Currently blocked on [`unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) (`SeaSurfaceLayer::matchSize()` segfault). Today reinforces the priority — without this, autonomous survey requires constant manual override for surface-obstacle avoidance.
-
-**Companion concern**: [`rolker/unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127) — *(2026-05-19)* operator-side local costmap display: characterize transmission cost + design path to CAMP. 2026-05-19 measured ~78% loss on `/bizzy/local_costmap/costmap` over WiFi (small fragmented topics fine, large multi-fragment topic punishing). Becomes operationally critical the moment perception→costmap fusion lands — operator needs to see the obstacles the boat is reasoning about, especially for OOL ops where direct visual is impossible.
 
 ## Deferred / lower priority — no current issue
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -294,8 +294,9 @@ they become relevant.
 - **DNS-over-HTTPS on RUTX11** — exploration item, not urgent
 - **WiFi bridge: static routes → default gateway approach** — current
   static-route setup works; cleaner default-gateway redesign deferred
-- **IzzyBoat WireGuard return path fix** — IzzyBoat is parked, fix
-  this before next IzzyBoat deployment
+- **IzzyBoat WireGuard return path fix** — IzzyBoat is parked; tracked
+  under [`unh_echoboats_project11#120`](https://github.com/rolker/unh_echoboats_project11/issues/120) (IzzyBoat parity tracker) for batched
+  migration before the next IzzyBoat deployment.
 
 ### Testing
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,14 +119,39 @@ autonomy quality.
 **Defer past June 4:**
 - [`unh_echoboats_project11#96`](https://github.com/rolker/unh_echoboats_project11/issues/96) — BizzyBoat-specific nav2 params override (decouple from seafloor echoboat defaults). Not critical for single-boat ops; promote when joint Bizzy + Izzy ops come into scope.
 
-### Both nav systems report at base_link *(theme — 2026-04-29; major progress 2026-05-01)*
+### Both nav systems report at base_link *(theme — 2026-04-29; major progress 2026-05-01; FCU side outstanding)*
 
-The 2026-04-29 in-water bag exposed that neither the SBG nor the FCU was reporting position at `base_link` — each published at its own GNSS antenna (0.64 m fore-aft body-frame offset between them). The URDF didn't model the SBG IMU/antennas, and the EKF3-fused mavros streams weren't being recorded, so cross-checks had to fall back to downstream `/bizzy/odom`. These three issues are a unit: pick a contract, model the geometry, and capture the streams that prove it's working.
+The 2026-04-29 in-water bag exposed that neither the SBG nor the FCU
+was reporting position at `base_link` — each published at its own GNSS
+antenna (0.64 m fore-aft body-frame offset). 2026-05-01 closed the SBG
+side via sbgCenter Output Location. The mavros side and the durable
+EKF Z reference both remain — and both can land via a single FCU
+reconfiguration.
 
-- [`unh_echoboats_project11#110`](https://github.com/rolker/unh_echoboats_project11/issues/110) — model SBG INS, GNSS antenna(s), and IMU mounting alignment on bizzyboat (URDF gap). **Still open** — today's fixes addressed the *config* side; the URDF gap (no SBG body / Trimble antennas modeled) remains.
-- [`unh_echoboats_project11#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) — define lever-arm/base_link contract for SBG and mavros position streams. **Resolved live 2026-05-01** — the SBG sbgCenter Output Location was the missing config; with it set, both SBG and FCU now report at `base_link`. gabby agent confirmed agreement live; quantitative verification is post-mission ([#124](https://github.com/rolker/unh_echoboats_project11/issues/124)).
-- [`unh_echoboats_project11#112`](https://github.com/rolker/unh_echoboats_project11/issues/112) — record `mavros/global_position/global` + EKF3-fused `local_position/*` + `altitude`. **Fixed in [#123](https://github.com/rolker/unh_echoboats_project11/pull/123)**, awaiting merge.
-- [`unh_echoboats_project11#138`](https://github.com/rolker/unh_echoboats_project11/issues/138) — *(2026-05-19)* `mru_transform`: choose durable nav-input source after the ellipsoidal-vs-EKF discovery that aborted the nav stack mid-deployment. Field-side revert to `mavros/global_position/raw/fix` (commit `c36acfa`, cherry-picked onto PR #136 as `ece31dc`) is mission-enabling but a workaround; the proper design choice (mavros raw vs SBG vs mavros + geoid compensation) hooks into `#110` lever-arm work.
+**Why getting this right matters operationally**: tide / water-level
+estimation depends on it. The 2026-05-19 nav-stack abort was driven
+exactly by this chain — mavros `/global` Z was wrong (baro tracking
+weather pressure, not GPS altitude), so `sea_surface_estimator`
+produced implausible water-level estimates, so `map → map_tide` was
+never broadcast, so `local_costmap` couldn't activate, so
+`bt_task_navigator` rejected goals. A correct base_link reference and
+correct Z source are not just lever-arm hygiene — they're a prerequisite
+for the tide / water-level / chart-datum chain to function. (For Lake
+Massabesic that chain becomes a "lake-level / chart-datum" chain;
+mathematically the same, no tidal variation but reference geometry
+still load-bearing for sonar processing.)
+
+**Must finish before June 4:**
+- [`unh_echoboats_project11#138`](https://github.com/rolker/unh_echoboats_project11/issues/138) — `mru_transform` durable nav-input choice + FCU reconfig. Set `EK3_SRC1_POSZ = 3` (GPS) so the FCU EKF Z stops tracking atmospheric pressure. Combine with `EK3_GPS_OFFS` / `GPS_POS1_X/Y/Z` so the mavros position output reports at `base_link` rather than the GPS antenna. This single FCU reconfiguration delivers both the durable nav-input answer AND the outstanding mavros half of #111. Field-side revert to `mavros/global_position/raw/fix` is a workaround; FCU reconfig is the durable answer. Needs bench check + at least one deployment to validate before June 4 — schedule accordingly.
+
+**Wrap-up / housekeeping:**
+- [`unh_echoboats_project11#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) — lever-arm / base_link contract. SBG half resolved live 2026-05-01; FCU half folds into #138's reconfig. Plan: fold the remaining FCU-side scope into #138's body, then close #111 with a pointer.
+
+**Defer past June 4:**
+- [`unh_echoboats_project11#110`](https://github.com/rolker/unh_echoboats_project11/issues/110) — URDF gap (SBG INS + GNSS antennas + IMU mounting). Becomes load-bearing when the camera-image → costmap pipeline ships (need accurate geometric placement for segmentation projection), but it's not on the critical path for the tide / chart-datum chain — which uses the position+altitude topics directly. Until then, documentation-correctness work that can live in maintenance mode.
+
+**Done:**
+- [`unh_echoboats_project11#112`](https://github.com/rolker/unh_echoboats_project11/issues/112) — record EKF3 streams. **CLOSED** ([PR #123](https://github.com/rolker/unh_echoboats_project11/pull/123) merged 2026-05-18).
 
 ### Class-ready operator UI
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -176,19 +176,32 @@ parts. Documentation for student operators is the only must-finish.
 
 ### Class-day operator observability *(new theme — 2026-04-27; major expansion 2026-05-19)*
 
-The 2026-04-27 deployment surfaced an asymmetry: boat-side instrumentation is rich, operator-side is sparse. The annunciator silently kept showing OK during an RTK loss because the udp_bridge wedge had stalled `/diagnostics`. Class operators need real-time visibility into the operator-side network + a way to know when the diagnostic stream itself is stale.
+Student operators won't intuit silent failures the way an expert does.
+The 2026-05-19 deployment surfaced three silent-failure shapes —
+Nav2 lifecycle bringup aborted without alert, network monitors crashed
+silently at startup, bridge stats publication stalled for 1h17m —
+sharing the same gap: operator finds out by accident, not by alert.
 
-The 2026-05-19 deployment surfaced three more silent-failure shapes from one session: (a) Nav2 lifecycle bringup aborted with no operator alert until a goal was rejected, (b) operator-side `mikrotik_monitor` + `teltonika_monitor` crashed at startup with no alert (just showed STALE in the aggregator), (c) operator-side udp_bridge stats publication stalled for ≈1h17m while data plane stayed healthy. All three share the same gap: the operator finds out by accident or by failed user action, not by an alert. The brainstorm response settled on a defense-in-depth approach using existing ROS 2 primitives (`DiagnosticStatus`, `~/transition_event`, built-in `topic_statistics`) rather than a new lifecycle manager.
+**Architecture decision**: the diagnostic aggregator is not in the
+operator UI path — the annunciator subscribes to `/diagnostics`
+directly. Aggregator output has no user-facing consumer; the rqt
+aggregator view plugin caused problems and isn't used. Direction is
+"publishers → /diagnostics → annunciator," no aggregator middleman.
 
-- [`unh_echoboats_project11#97`](https://github.com/rolker/unh_echoboats_project11/issues/97) — run network monitor nodes on salmon + record salmon-side `/diagnostics` during deployments
-- [`rolker/ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5) — *(2026-05-19)* add observability mode: emit `DiagnosticStatus` for tracked processes and lifecycle nodes (`~/transition_event` subscription + process-death detection + `ros2launch_session run` CLI for per-host adoption). **Main vehicle** for closing the silent-failure gap; should ship before the June 2026 class.
-- [`rolker/ros2_network_monitor#23`](https://github.com/rolker/ros2_network_monitor/issues/23) — *(2026-05-19)* `mikrotik_monitor` + `teltonika_monitor` crash silently on startup if initial connect fails — needs try/except + backoff. Symptom that would have shown up via `ros2launch_session#5` even before the underlying try/except fix.
-- [`unh_echoboats_project11#141`](https://github.com/rolker/unh_echoboats_project11/issues/141) — *(2026-05-19)* `/Operator/*` diagnostics aggregator buckets STALE because publishers live under `/Other/*` (config drift). Aggregator-config cleanup.
-- [`unh_echoboats_project11#142`](https://github.com/rolker/unh_echoboats_project11/issues/142) — *(2026-05-19)* host thermals as `DiagnosticStatus` (lm-sensors + NVMe SMART). Investigate-and-integrate (likely off-the-shelf package available).
-- [`unh_echoboats_project11#139`](https://github.com/rolker/unh_echoboats_project11/issues/139) — *(2026-05-19)* replace `output='screen'` with `output='both'` in BizzyBoat launches — multiplies the value of any of the above by making crash output recoverable post-mission.
-- [`unh_echoboats_project11#140`](https://github.com/rolker/unh_echoboats_project11/issues/140) — *(2026-05-19)* remove stale `bencloud` ping target (doesn't reflect WG link). Small but contributes to "toplevel ERROR is always lit" noise.
-- *(future)* annunciator stale-stream indicator on `rqt_operator_tools` — distinguish "everything OK" from "stream wedged, last value stale"
-- *(future)* topic-staleness layer using built-in ROS 2 `topic_statistics` + aggregator analyzers — sibling concern to `ros2launch_session#5`; addresses the udp_bridge stats-stall failure shape. Most natural home `unh_marine_autonomy`; deferred to its own session.
+**Must finish before June 4 — small easy wins, do these first:**
+- [`unh_echoboats_project11#141`](https://github.com/rolker/unh_echoboats_project11/issues/141) reframed — **remove** the `diagnostic_aggregator` from operator launches. Strip the Node from `operator_core_launch.py` + delete the unused aggregator config in `diagnostics.yaml`. Eliminates the "STALE bucket / config drift" misdirection 2026-05-19 surfaced.
+- [`unh_echoboats_project11#139`](https://github.com/rolker/unh_echoboats_project11/issues/139) — `output='screen'` → `output='both'` in BizzyBoat launches. One-line change. Crash output recoverable post-mission.
+- [`unh_echoboats_project11#140`](https://github.com/rolker/unh_echoboats_project11/issues/140) — remove stale `bencloud` ping target. Trivial. Reduces the chronic alert-fatigue noise.
+- [`rolker/ros2_network_monitor#23`](https://github.com/rolker/ros2_network_monitor/issues/23) — try/except + backoff for `mikrotik_monitor` / `teltonika_monitor`. Small fix; prevents the silent-startup-crash failure shape directly (without needing ros2launch_session#5 to catch it as a generalization).
+- [`unh_echoboats_project11#97`](https://github.com/rolker/unh_echoboats_project11/issues/97) — run network monitor nodes on salmon + record salmon-side `/diagnostics` during deployments. Already in the deployment process intent; confirm it's actually wired up and recording.
+
+**Desirable, defer if needed:**
+- [`rolker/ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5) — observability mode. Substantial implementation. Catches the lifecycle-abort + silent-process-death failure shapes as a general mechanism. Would close the biggest remaining observability hole, but the rest of the easy wins above already deliver most operator-visible value. Treat as stretch goal — if it ships before June 4 great, otherwise the workaround is documented manual checks at launch time + students drilled to recognize "I queued a goal and nothing happened" as a system problem requiring expert help.
+- [`unh_echoboats_project11#142`](https://github.com/rolker/unh_echoboats_project11/issues/142) — host thermals as `DiagnosticStatus` (lm-sensors + NVMe SMART). Off-the-shelf package available; do if quick, defer if not.
+
+**Future:**
+- annunciator stale-stream indicator on `rqt_operator_tools`.
+- topic-staleness layer via `topic_statistics` + aggregator analyzers (the analyzer module — doesn't require running the aggregator node).
 
 ### Network reliability under load *(new theme — 2026-04-27)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,7 @@ visible from one place.
 - [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP. *Software pipeline live end-to-end as of 2026-04-27 (#94); first surveys recorded. M3 1PPS time-sync chain completed 2026-05-01 (#121) — after discovering that the M3 software's Device Properties → Time Sync Mode dropdown was the real gating switch, not the cable / SBG / pulse parameters that occupied most of the morning. QINSy SBG hookup live (position + attitude + heading + heave + GPS QC).*
 - [`unh_echoboats_project11#77`](https://github.com/rolker/unh_echoboats_project11/issues/77) — physical install, offsets, URDF, SVG diagram
 - [`rolker/marine_tools#1`](https://github.com/rolker/marine_tools/issues/1) — QINSy → ROS bridge for coverage / sounding feedback
+- [`unh_echoboats_project11#137`](https://github.com/rolker/unh_echoboats_project11/issues/137) — *(2026-05-19)* M3 sonar: investigate intermittent missing pings (suspected ping-rate × depth correlation). Historical observation — 2026-05-19 was the first time the M3 software's log window was open during ops and the explicit error messages were visible. **Load-bearing for the June 2026 class** if missing pings scale up at the ping-rate × depth combos used for survey grids.
 
 ### Camera obstacle avoidance
 
@@ -50,6 +51,7 @@ The 2026-04-29 in-water bag exposed that neither the SBG nor the FCU was reporti
 - [`unh_echoboats_project11#110`](https://github.com/rolker/unh_echoboats_project11/issues/110) — model SBG INS, GNSS antenna(s), and IMU mounting alignment on bizzyboat (URDF gap). **Still open** — today's fixes addressed the *config* side; the URDF gap (no SBG body / Trimble antennas modeled) remains.
 - [`unh_echoboats_project11#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) — define lever-arm/base_link contract for SBG and mavros position streams. **Resolved live 2026-05-01** — the SBG sbgCenter Output Location was the missing config; with it set, both SBG and FCU now report at `base_link`. gabby agent confirmed agreement live; quantitative verification is post-mission ([#124](https://github.com/rolker/unh_echoboats_project11/issues/124)).
 - [`unh_echoboats_project11#112`](https://github.com/rolker/unh_echoboats_project11/issues/112) — record `mavros/global_position/global` + EKF3-fused `local_position/*` + `altitude`. **Fixed in [#123](https://github.com/rolker/unh_echoboats_project11/pull/123)**, awaiting merge.
+- [`unh_echoboats_project11#138`](https://github.com/rolker/unh_echoboats_project11/issues/138) — *(2026-05-19)* `mru_transform`: choose durable nav-input source after the ellipsoidal-vs-EKF discovery that aborted the nav stack mid-deployment. Field-side revert to `mavros/global_position/raw/fix` (commit `c36acfa`, cherry-picked onto PR #136 as `ece31dc`) is mission-enabling but a workaround; the proper design choice (mavros raw vs SBG vs mavros + geoid compensation) hooks into `#110` lever-arm work.
 
 ### Class-ready operator UI
 
@@ -59,12 +61,21 @@ The 2026-04-29 in-water bag exposed that neither the SBG nor the FCU was reporti
 - [`rolker/rqt_operator_tools#32`](https://github.com/rolker/rqt_operator_tools/issues/32) — rqt_camera_grid: `populate_topic_combo` Refresh re-leaks display label
 - [`unh_echoboats_project11#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) — student-facing operating documentation
 
-### Class-day operator observability *(new theme — 2026-04-27)*
+### Class-day operator observability *(new theme — 2026-04-27; major expansion 2026-05-19)*
 
 The 2026-04-27 deployment surfaced an asymmetry: boat-side instrumentation is rich, operator-side is sparse. The annunciator silently kept showing OK during an RTK loss because the udp_bridge wedge had stalled `/diagnostics`. Class operators need real-time visibility into the operator-side network + a way to know when the diagnostic stream itself is stale.
 
+The 2026-05-19 deployment surfaced three more silent-failure shapes from one session: (a) Nav2 lifecycle bringup aborted with no operator alert until a goal was rejected, (b) operator-side `mikrotik_monitor` + `teltonika_monitor` crashed at startup with no alert (just showed STALE in the aggregator), (c) operator-side udp_bridge stats publication stalled for ≈1h17m while data plane stayed healthy. All three share the same gap: the operator finds out by accident or by failed user action, not by an alert. The brainstorm response settled on a defense-in-depth approach using existing ROS 2 primitives (`DiagnosticStatus`, `~/transition_event`, built-in `topic_statistics`) rather than a new lifecycle manager.
+
 - [`unh_echoboats_project11#97`](https://github.com/rolker/unh_echoboats_project11/issues/97) — run network monitor nodes on salmon + record salmon-side `/diagnostics` during deployments
+- [`rolker/ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5) — *(2026-05-19)* add observability mode: emit `DiagnosticStatus` for tracked processes and lifecycle nodes (`~/transition_event` subscription + process-death detection + `ros2launch_session run` CLI for per-host adoption). **Main vehicle** for closing the silent-failure gap; should ship before the June 2026 class.
+- [`rolker/ros2_network_monitor#23`](https://github.com/rolker/ros2_network_monitor/issues/23) — *(2026-05-19)* `mikrotik_monitor` + `teltonika_monitor` crash silently on startup if initial connect fails — needs try/except + backoff. Symptom that would have shown up via `ros2launch_session#5` even before the underlying try/except fix.
+- [`unh_echoboats_project11#141`](https://github.com/rolker/unh_echoboats_project11/issues/141) — *(2026-05-19)* `/Operator/*` diagnostics aggregator buckets STALE because publishers live under `/Other/*` (config drift). Aggregator-config cleanup.
+- [`unh_echoboats_project11#142`](https://github.com/rolker/unh_echoboats_project11/issues/142) — *(2026-05-19)* host thermals as `DiagnosticStatus` (lm-sensors + NVMe SMART). Investigate-and-integrate (likely off-the-shelf package available).
+- [`unh_echoboats_project11#139`](https://github.com/rolker/unh_echoboats_project11/issues/139) — *(2026-05-19)* replace `output='screen'` with `output='both'` in BizzyBoat launches — multiplies the value of any of the above by making crash output recoverable post-mission.
+- [`unh_echoboats_project11#140`](https://github.com/rolker/unh_echoboats_project11/issues/140) — *(2026-05-19)* remove stale `bencloud` ping target (doesn't reflect WG link). Small but contributes to "toplevel ERROR is always lit" noise.
 - *(future)* annunciator stale-stream indicator on `rqt_operator_tools` — distinguish "everything OK" from "stream wedged, last value stale"
+- *(future)* topic-staleness layer using built-in ROS 2 `topic_statistics` + aggregator analyzers — sibling concern to `ros2launch_session#5`; addresses the udp_bridge stats-stall failure shape. Most natural home `unh_marine_autonomy`; deferred to its own session.
 
 ### Network reliability under load *(new theme — 2026-04-27)*
 
@@ -74,11 +85,15 @@ Multiple network-layer issues surfaced during the same long deployment day: udp_
 - [`rolker/udp_bridge#9`](https://github.com/rolker/udp_bridge/issues/9) — resend loop amplifies traffic (earlier related)
 - [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) — *(2026-05-01)* forwarding-throughput regression from PR #12 + `rmw_zenoh_cpp` 0.2.9 BEST_AVAILABLE keyexpr workaround
 - [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) — *(2026-05-01)* operator-side QoS fix complementing the bridge default change
+- [`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20) — *(2026-05-19)* operator-side stats-timer publication stalls during Starlink-only ops while data-republish keeps working (≈1h17m blind on operator panels). Specific to stats path — video, costmap, heartbeat unaffected.
+- [`rolker/udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21) — *(2026-05-19)* resend-give-up "after N attempts" value varies 5/6/1 across the session — meaningful or counter glitch?
 - *(future)* End-of-day network pathology root-cause work — open once we have more signal from a future deployment with op-side diagnostics in place
 
-### Over-horizon operations capability *(new theme — 2026-05-01)*
+### Over-horizon operations capability *(new theme — 2026-05-01; update 2026-05-19)*
 
 The 2026-05-01 deployment ran the boat past visual range with the new comms stack and surfaced the saturation envelope. Even on Starlink-only at moderate distance, the current ROS topic stack saturates the link, producing 30–60 s latency episodes. Asymmetric resilience worked: control commands and SSH stayed reliable through saturation; situational awareness did not. RC failsafe stack now configured for over-horizon use (`FS_THR_ENABLE = 0`, `FS_GCS_ENABLE = 0`, GUIDED stale-setpoint HOLD).
+
+**2026-05-19 update**: Phase 1 (operator-side WiFi disabled, Starlink-only at close range) and a partial Phase 2 (Starlink-only autonomous trackline + initial survey pattern, cut short on time, in-harbor) both completed without losing control — the post-2026-05-01 fixes ([#134](https://github.com/rolker/unh_echoboats_project11/pull/134) coprime keyframe stagger, [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) throughput regression fix, [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) NavSource QoS workaround) held under load. The data-path half of Phase 2's intent is validated. **The literal OOL element + a completed survey are still pending** — tracked in [`#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) (Field validation: over-horizon Starlink-only operation), which stays open. New observability findings from 2026-05-19 ([`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20) stats-timer stall masked operator-side bridge health throughout, [`rolker/udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21) resend-N interpretation question) are the kind of thing a future OOL attempt needs better instrumentation for — see the observability theme below.
 
 - **Topic-budget cull** — required, not optional. Identify which topics dominate the link, cull or rate-limit accordingly.
 - **VPN-path indicator** (Starlink vs. cellular vs. WiFi) — operator awareness gap; today we lost significant diagnostic time guessing which path was carrying traffic. See [#124](https://github.com/rolker/unh_echoboats_project11/issues/124).
@@ -98,6 +113,8 @@ The 2026-05-01 deployment ran the boat past visual range with the new comms stac
 The 2026-05-01 mooring ball near-miss made this concrete: cameras can see surface obstacles, but segmentation output is not feeding the Nav2 costmap, so the autonomy planner has no awareness. This is a real survey-readiness blocker — any autonomous survey will be in waters with mooring balls, debris, and other vessels.
 
 Existing tracker: [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) (end-to-end OAK → costmap validation). Currently blocked on [`unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) (`SeaSurfaceLayer::matchSize()` segfault). Today reinforces the priority — without this, autonomous survey requires constant manual override for surface-obstacle avoidance.
+
+**Companion concern**: [`rolker/unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127) — *(2026-05-19)* operator-side local costmap display: characterize transmission cost + design path to CAMP. 2026-05-19 measured ~78% loss on `/bizzy/local_costmap/costmap` over WiFi (small fragmented topics fine, large multi-fragment topic punishing). Becomes operationally critical the moment perception→costmap fusion lands — operator needs to see the obstacles the boat is reasoning about, especially for OOL ops where direct visual is impossible.
 
 ## Deferred / lower priority — no current issue
 
@@ -131,6 +148,7 @@ they become relevant.
 - **Forward USB camera** publishes a black image — root cause unknown,
   USB camera has not been needed for any field work. Revisit if it
   becomes load-bearing.
+- **Duplicate `/bizzy/sensors/sbg_device` graph entry** *(observed 2026-05-19, gabby log §2)* — one real PID, second name registration is a graph-level ghost from a prior lifecycle (likely RMW/Zenoh discovery-state quirk after kill-and-restart cycles). Data flow is fine; service-call routing to `sbg_device` could be ambiguous in theory. Not deploy-blocking; no clean fix path right now. Watch for recurrence; promote to an issue if it ever causes a real failure.
 
 ## What's not on this roadmap
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -329,6 +329,143 @@ they become relevant.
   couple of months without any pull toward them, they're probably
   dropped, not deferred. Edit them out.
 
+## Appendix A: June 4 punch list — effort, boat-dependency, parallelism *(snapshot 2026-05-20)*
+
+This appendix tags every "Must finish before June 4" item from the
+Active-threads sections above with effort, where it can be worked, and
+critical-path notes — and uses that to size the agent count needed to
+clear the list. Refresh or remove this appendix as items land; it's a
+working sizing document, not durable direction.
+
+**Where coding**: `BF` = boat-free (implement + test off-boat) · `DI` =
+desk-implement, validate on a deployment · `BI` = needs boat to
+implement at all (e.g. apply FCU params, on-water test required to
+exercise the change).
+
+**Effort**: `XS` <2h · `S` 2–8h · `M` 1–3 days · `L` 3–7 days · `XL`
+>7 days or unknown.
+
+### Item-by-item
+
+| # | Item | Effort | Where | Critical-path notes |
+|---|---|---|---|---|
+| **Sensor payload** | | | | |
+| 1 | AML SVS bridge data capture verify | S | BF | Bag analysis; cross-confirm in next deployment |
+| 2 | Mercat NTP verify (`ntpq.exe -pn`) | XS | BF | SSH to mercat |
+| 3 | Sidescan decision (M3 imagery vs Garmin) | S | BF | Decision only |
+| 3b | Sidescan install (if Garmin chosen) | M–L | BI | Physical install + protocol integration |
+| **Surface-obstacle** | | | | |
+| 4 | [`unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) segfault | L | BF | **UNOWNED.** Blocks #5 → #6 → display path |
+| 5 | [`unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) OAK→costmap validation | M | DI | Blocked on #6; replay bags for impl, validate live |
+| 6 | [`unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127) op-side costmap display | L | DI | 78% loss measured — bandwidth budget tight; replay-driven impl, validate live |
+| **Navigation reliability** | | | | |
+| 7 | [`unh_marine_navigation#24`](https://github.com/rolker/unh_marine_navigation/issues/24) BT `target_speed` → `/speed_limit` | M | DI | Sim/bag wire-up, verify in deployment |
+| 8 | [`unh_marine_navigation#23`](https://github.com/rolker/unh_marine_navigation/issues/23) TF extrapolation fix | M | DI | Bag-debug, verify in deployment |
+| 9 | [`unh_marine_navigation#19`](https://github.com/rolker/unh_marine_navigation/issues/19) costmap timeout investigate | S | BF | Bag analysis; decide fix-or-defer |
+| 10 | Boat-side bathy costmap | L–XL | BF | **Triage first** — Roland's "other computer" branch may exist |
+| **Both nav at base_link** | | | | |
+| 11 | [`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138) FCU reconfig + validation | S prep + **boat day** | BI | Bench param-write OK; sea_surface chain validation needs water |
+| **Class-ready UI** | | | | |
+| 12 | [`#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) student deployment guide | M | BF | Writing-heavy; draft from logs |
+| **Observability — small wins** | | | | |
+| 13 | [`#141`](https://github.com/rolker/unh_echoboats_project11/issues/141) remove `diagnostic_aggregator` | XS | BF | Node delete + YAML cleanup |
+| 14 | [`#139`](https://github.com/rolker/unh_echoboats_project11/issues/139) `output='both'` in launches | XS | BF | One-line |
+| 15 | [`#140`](https://github.com/rolker/unh_echoboats_project11/issues/140) remove `bencloud` ping target | XS | BF | Trivial |
+| 16 | [`ros2_network_monitor#23`](https://github.com/rolker/ros2_network_monitor/issues/23) try/except + backoff | S | BF | Defensive code |
+| 17 | [`#97`](https://github.com/rolker/unh_echoboats_project11/issues/97) salmon `/diagnostics` recording wiring | XS | BF | Verify |
+| **OTH** | | | | |
+| 18 | [`#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) OTH field validation | **boat day** | BI | Combinable with #11 |
+| 19 | Topic-budget cull (measure + cull + verify) | M + **boat verify** | DI | Bag-driven measurement BF; verify under load DI |
+| 20 | Low-bandwidth status fallback | L | DI | New node + UI plugin; unit-test BF, real-link DI |
+| 21 | VPN-path indicator | M | DI | Cheaper than #20; UI surface for [`#124`](https://github.com/rolker/unh_echoboats_project11/issues/124) |
+| **Autonomy robustness** | | | | |
+| 22 | [`unh_marine_navigation#25`](https://github.com/rolker/unh_marine_navigation/issues/25) BT catchall fix | M | BF | Sim/bag testable; review-first recommended |
+| 23 | Broader BT review of `run_tasks.xml` | M | BF | Should precede #22 to scope it |
+
+### Totals
+
+- **Boat-free implementable**: 14 items, ~25–35 agent-days
+- **Desk-implement, boat-validate**: 6 items, ~10–15 agent-days impl + 1–2 boat days for validation
+- **Boat-required to do at all**: 2–3 items (#11, #18 OTH val., optional #3b), need 1–2 boat days
+- **Grand total**: ~40–50 agent-days + 1–2 boat days
+
+### Parallelism — how many agents
+
+Window: 15 calendar days to June 4, ~10 working days × N agents.
+
+| Agents | Capacity | Coverage |
+|---|---|---|
+| 1 | 10 agent-days | ~25% — small wins only; everything else slips |
+| 2 | 20 agent-days | ~45% — small wins + 2–3 mediums; large items mostly slip |
+| 3 | 30 agent-days | ~70% — most Must-finish; 1 large item slips |
+| **4** | **40 agent-days** | **~90% — full Must-finish list with thin margin** |
+| 5 | 50 agent-days | 100% with comfortable margin |
+
+**Recommendation: 4 parallel agents** to clear Must-finish with thin
+margin; **5** if you want room for the broader BT review surfacing
+rework or `#6` debugging exploding.
+
+Hard caps on parallelism that more agents wouldn't relax:
+
+1. **Reviewer bandwidth.** Each agent needs a human reviewer at PR
+   time. You cannot review N PRs per day every day. This is the real
+   ceiling.
+2. **The #4 → #5 → #6 chain.** `unh_marine_perception#6` blocks #5
+   blocks #6. Throwing agents at the chain doesn't speed it up; only
+   at the segfault can things start. One focused agent on #6 + one on
+   #127's bandwidth design (proceeding in parallel against stub
+   costmap data) is the right shape.
+3. **Boat days are serial.** One boat day = one slot for #11 + #18 +
+   #19-verify + #20/#21-verify + #5-validate + #6-validate. Not
+   parallel.
+4. **#11 FCU reconfig blocks tide-chain validation.** Apply FCU params
+   first, then everything that depends on a correct chart-datum chain
+   (#19, OTH validation, costmap reliability) validates on the SAME
+   boat day.
+
+### Suggested agent allocation
+
+| Agent | Focus | Items |
+|---|---|---|
+| **A — Perception** | Display path | #4 segfault → #5 OAK→costmap validation → support #6 design |
+| **B — Comms / OTH** | New operator UI | #21 VPN-path indicator + #19 topic-budget cull measure phase + #20 fallback impl (stretch) |
+| **C — Autonomy / BT** | Safety-critical | #23 broader BT review → #22 catchall fix → #7 BT `target_speed` wire-up → #8 TF fix |
+| **D — Operability / docs / sweeps** | Class readiness | #13–17 small wins (1 day) → #12 student deployment guide → #10 bathy-costmap triage → #1/2 verifies → #3 sidescan decision |
+| **You** | Boat-implement + review + decisions | #11 FCU reconfig prep, #18 OTH validation boat day, sidescan install if chosen, all PR reviews, scope decisions |
+
+### Critical-path sequencing
+
+1. **This week** (day 1–3): Agent D ships all small wins + sets up
+   #12; Agent A starts #6 debug; Agent C does BT review; Agent B
+   starts VPN-path indicator. You triage #10 bathy-costmap
+   immediately and decide #3 sidescan.
+2. **Mid window** (day 4–8): A finishes #6 → starts #5; B finishes
+   #21 → starts topic-budget cull; C finishes review → fixes #22 →
+   wires #24; D drafts #18.
+3. **Boat day** (day 9–10): Apply #11 FCU reconfig, run #18 OTH
+   validation, validate #20/#21/#7/#8/#19 + check #127 bandwidth fit
+   if it's ready. One combined deployment validates everything
+   DI-tagged.
+4. **Buffer** (day 11–15): Address findings from boat day, finish
+   #12 student guide, decide whether #6 planning-path or #20
+   low-bandwidth fallback or the broader BT review needs to absorb
+   the slip.
+
+### Risk callout
+
+Plan assumes:
+- `#6` segfault is debuggable in ~3–5 days. If it's actually XL, the
+  display path slips → Agent A pivots to support #127 bandwidth work
+  and the fallback (vigilant watching + exclusion zones) becomes the
+  class plan.
+- `#10` bathy costmap triage finds existing work. If it's net-new XL
+  effort, drop it from Must-finish and accept "no depth-derived
+  costmap data at the lake."
+- Boat days can be scheduled — weather + access. Need 1, ideally 2 in
+  the window.
+
+---
+
 This document was seeded from the milestone content of
 [`unh_echoboats_project11#57`](https://github.com/rolker/unh_echoboats_project11/issues/57)
 (BizzyBoat field ops umbrella) when that issue was closed in favor of

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -155,11 +155,24 @@ still load-bearing for sonar processing.)
 
 ### Class-ready operator UI
 
-- [`rolker/rqt_operator_tools#2`](https://github.com/rolker/rqt_operator_tools/issues/2) — operator logbook (Phase 1 landed, not field-tested)
-- [`rolker/rqt_operator_tools#29`](https://github.com/rolker/rqt_operator_tools/issues/29) — pre-launch checklist (form factor TBD)
-- [`rolker/rqt_operator_tools#31`](https://github.com/rolker/rqt_operator_tools/issues/31) — rqt_camera_grid: harden destructor↔callback sync + audit `currentText()` reads
-- [`rolker/rqt_operator_tools#32`](https://github.com/rolker/rqt_operator_tools/issues/32) — rqt_camera_grid: `populate_topic_combo` Refresh re-leaks display label
-- [`unh_echoboats_project11#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) — student-facing operating documentation
+The interactive surface (logbook, checklist, camera grid) is in
+good-enough shape — Phase-1 plugins exist or the current config works,
+and students can fall back to text editor / paper for the recording
+parts. Documentation for student operators is the only must-finish.
+
+**Must finish before June 4:**
+- [`unh_echoboats_project11#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) — student-facing deployment guide. Students operate without an expert next to them. Draft from the BizzyBoat deployment logs.
+
+**Nice-to-have / acceptable workaround:**
+- [`rolker/rqt_operator_tools#2`](https://github.com/rolker/rqt_operator_tools/issues/2) — operator logbook Phase 1. Field-untested but acceptable. Students can use a text editor for shift logs if the plugin isn't yet trusted.
+- [`rolker/rqt_operator_tools#29`](https://github.com/rolker/rqt_operator_tools/issues/29) — pre-launch checklist. Paper or text-file checklist is acceptable for the class. Promote to active dev if capacity opens up; otherwise capture the checklist content in #18.
+- [`rolker/rqt_operator_tools#31`](https://github.com/rolker/rqt_operator_tools/issues/31) / [`#32`](https://github.com/rolker/rqt_operator_tools/issues/32) — rqt_camera_grid hardening. Current grid configuration is working and not being reconfigured; the bugs only manifest under reconfiguration. Don't touch unless reconfiguration becomes necessary.
+
+**Operator-side background map** *(from background-data theme split)*:
+- Students will find a suitable background map (NHGranIT contours,
+  aerial imagery, etc.) before June 15 as part of their integration
+  work. No developer-side starter needed.
+- *(See companion: [`unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127) operator-side local costmap display — only matters once camera→costmap fusion ships.)*
 
 ### Class-day operator observability *(new theme — 2026-04-27; major expansion 2026-05-19)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -224,17 +224,44 @@ aggregator view plugin caused problems and isn't used. Direction is
 - [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) — forwarding-throughput regression. **MERGED** 2026-05-01.
 - [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) — operator-side QoS fix complementing the bridge default change. **MERGED** 2026-05-18.
 
-### Over-horizon operations capability *(new theme — 2026-05-01; update 2026-05-19)*
+### Over-horizon operations capability *(new theme — 2026-05-01; updates 2026-05-19, 2026-05-20)*
 
-The 2026-05-01 deployment ran the boat past visual range with the new comms stack and surfaced the saturation envelope. Even on Starlink-only at moderate distance, the current ROS topic stack saturates the link, producing 30–60 s latency episodes. Asymmetric resilience worked: control commands and SSH stayed reliable through saturation; situational awareness did not. RC failsafe stack now configured for over-horizon use (`FS_THR_ENABLE = 0`, `FS_GCS_ENABLE = 0`, GUIDED stale-setpoint HOLD).
+The 2026-05-01 deployment ran the boat past direct-comms range with the
+new comms stack and surfaced the saturation envelope. Even on
+Starlink-only at moderate distance, the current ROS topic stack
+saturates the link, producing 30–60 s latency episodes. Asymmetric
+resilience worked: control commands and SSH stayed reliable through
+saturation; situational awareness did not. RC failsafe stack now
+configured for OTH ops (`FS_THR_ENABLE = 0`, `FS_GCS_ENABLE = 0`,
+GUIDED stale-setpoint HOLD).
 
-**2026-05-19 update**: Phase 1 (operator-side WiFi disabled, Starlink-only at close range) and a partial Phase 2 (Starlink-only autonomous trackline + initial survey pattern, cut short on time, in-harbor) both completed without losing control — the post-2026-05-01 fixes ([#134](https://github.com/rolker/unh_echoboats_project11/pull/134) coprime keyframe stagger, [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) throughput regression fix, [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) NavSource QoS workaround) held under load. The data-path half of Phase 2's intent is validated. **The literal OOL element + a completed survey are still pending** — tracked in [`#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) (Field validation: over-horizon Starlink-only operation), which stays open. New observability findings from 2026-05-19 ([`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20) stats-timer stall masked operator-side bridge health throughout, [`rolker/udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21) resend-N interpretation question) are the kind of thing a future OOL attempt needs better instrumentation for — see the observability theme below.
+**2026-05-19 update**: Phase 1 (operator-side WiFi disabled,
+Starlink-only at close range) and a partial Phase 2 (Starlink-only
+autonomous trackline + initial survey pattern, cut short on time,
+in-harbor) both completed without losing control — the post-2026-05-01
+fixes ([`#134`](https://github.com/rolker/unh_echoboats_project11/pull/134)
+coprime keyframe stagger,
+[`udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16)
+throughput regression fix,
+[`camp#51`](https://github.com/rolker/camp/pull/51) NavSource QoS
+workaround) held under load. The data-path half of Phase 2's intent is
+validated. The literal OTH element + a completed survey are still
+pending.
 
-- **Topic-budget cull** — required, not optional. Identify which topics dominate the link, cull or rate-limit accordingly.
-- **VPN-path indicator** (Starlink vs. cellular vs. WiFi) — operator awareness gap; today we lost significant diagnostic time guessing which path was carrying traffic. See [#124](https://github.com/rolker/unh_echoboats_project11/issues/124).
-- **Bench stress-test rig** — synth topics + mininet + CAMP-stub harness so the next saturation question can be answered at the desk, not on the water. See [#124](https://github.com/rolker/unh_echoboats_project11/issues/124).
-- **RC mode-switch fringe-range hardening** — pin to AUTO/GUIDED, disable channel via FCU params, or power off RC entirely during autonomous runs. See memory `project_bizzyboat_rc_mode_switch_at_fringe_range.md`.
-- **Low-bandwidth status fallback** — text/heartbeat/minimal-telemetry path that survives when the full topic stream doesn't (today's gabby SSH access bridged the gap manually).
+**Class scope reassessment (2026-05-20)**: Lake Massabesic surveys go
+OTH routinely from a shore-based operator station — the lake is large
+enough that the boat is regularly outside direct comms range. The
+OTH-specific work below is therefore **class-priority**, not deferred.
+
+**Must finish before June 4:**
+- [`unh_echoboats_project11#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) — field validation of OTH Starlink-only operation including a completed survey. The lake survey IS the test — but going in without a controlled validation first is the kind of risk we don't take with students aboard. Schedule a deliberate OTH validation between now and June 15.
+- **Topic-budget cull** — operating OTH at lake scale is exactly the saturation scenario from 2026-05-01. Identify which topics dominate the link, cull or rate-limit accordingly. Don't wait for a future OTH attempt to re-hit the 30–60 s latency episodes.
+- **Low-bandwidth status fallback** — text/heartbeat/minimal-telemetry path that survives when the full topic stream doesn't. May overlap with [`#145`](https://github.com/rolker/unh_echoboats_project11/issues/145)'s safety-critical-pinned-to-cell concept. 2026-05-01 worked around this with manual gabby SSH; the class scenario needs the fallback in the operator UI.
+- **VPN-path indicator** (Starlink vs. cellular vs. WiFi) — operator awareness gap; on 2026-05-01 we lost significant diagnostic time guessing which path was carrying traffic. See [`#124`](https://github.com/rolker/unh_echoboats_project11/issues/124).
+
+**Defer past June 4:**
+- **Bench stress-test rig** — synth topics + mininet + CAMP-stub harness so the next saturation question can be answered at the desk. The lake survey itself will produce real-water OTH data; pre-survey budget is better spent on the topic cull and the fallback channel. Revisit post-survey. See [`#124`](https://github.com/rolker/unh_echoboats_project11/issues/124).
+- **RC mode-switch fringe-range hardening** — RC handheld stays at the operator station; controller doesn't follow the boat to OTH range. Captured in memory `project_bizzyboat_rc_mode_switch_at_fringe_range.md` for future relevance.
 
 ### Autonomy robustness *(new theme — 2026-05-01)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,15 +205,24 @@ aggregator view plugin caused problems and isn't used. Direction is
 
 ### Network reliability under load *(new theme — 2026-04-27)*
 
-Multiple network-layer issues surfaced during the same long deployment day: udp_bridge wedges (4×), post-recovery multi-device cycle, op-router forwarding asymmetry, gabby DNS wedge. Themes converge on (a) fix specific bugs, (b) better instrumentation (overlaps with observability theme above).
+2026-05-19 cross-deployment analysis ([`#144`](https://github.com/rolker/unh_echoboats_project11/issues/144) + [`udp_bridge#22`](https://github.com/rolker/udp_bridge/issues/22) comment thread) showed the bridge is in good operational shape: resend storms on wifi loss are by-design behavior, milder than 2026-05-01's worst, and stay within configured rate limits. The remaining items here are real but not class-critical — defer to maintenance mode unless one of them recurs during class prep.
 
-- [`rolker/udp_bridge#10`](https://github.com/rolker/udp_bridge/issues/10) — bridge wedges (reader thread blocked, Recv-Q backup) when remote subscriber dies
-- [`rolker/udp_bridge#9`](https://github.com/rolker/udp_bridge/issues/9) — resend loop amplifies traffic (earlier related)
-- [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) — *(2026-05-01)* forwarding-throughput regression from PR #12 + `rmw_zenoh_cpp` 0.2.9 BEST_AVAILABLE keyexpr workaround
-- [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) — *(2026-05-01)* operator-side QoS fix complementing the bridge default change
-- [`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20) — *(2026-05-19)* operator-side stats-timer publication stalls during Starlink-only ops while data-republish keeps working (≈1h17m blind on operator panels). Specific to stats path — video, costmap, heartbeat unaffected.
-- [`rolker/udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21) — *(2026-05-19)* resend-give-up "after N attempts" value varies 5/6/1 across the session — meaningful or counter glitch?
-- *(future)* End-of-day network pathology root-cause work — open once we have more signal from a future deployment with op-side diagnostics in place
+**Track during class prep:**
+- [`rolker/udp_bridge#10`](https://github.com/rolker/udp_bridge/issues/10) — bridge wedges when remote subscriber dies. Real bug; not observed during 2026-05-01 or 2026-05-19. If it surfaces during student-led ops it could be operationally bad, but track rather than promote unless it recurs.
+
+**Maintenance mode after June 4:**
+- [`rolker/udp_bridge#22`](https://github.com/rolker/udp_bridge/issues/22) — "Giving up on resend" WARN log too loud. Concrete fix proposed (demote to DEBUG + `DiagnosticStatus` per remote). Small, easy follow-up, but cosmetic during class itself.
+- [`rolker/udp_bridge#23`](https://github.com/rolker/udp_bridge/issues/23) — restrict resend response to requesting connection. Wire-format change (`connection_id` field). Modest impl, reduces resend amplification under loss. Filed 2026-05-20.
+- [`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20) — stats-timer publication stalls. Made operator panels blind for 1h17m during 2026-05-19 (data plane unaffected). Stats are observability — not data path. Less urgent than the observability theme's main vehicle.
+- [`rolker/udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21) — "after N attempts" value varies 5/6/1. Counter interpretation question. Investigate when convenient.
+
+**Future (post-June-4):**
+- [`unh_echoboats_project11#145`](https://github.com/rolker/unh_echoboats_project11/issues/145) — concurrent Starlink + cell with safety-critical traffic pinned to cell. Today's RUTX11-failover model causes a brief outage at every Starlink↔cell switch, blinding the operator before they can react. udp_bridge already supports per-topic-per-connection assignment, so this is primarily a network setup question — router config, possibly a second VPN endpoint for the cell-side path. Pin heartbeat / position / command to a cell-backed connection; let video / costmap / etc. stay on Starlink.
+
+**Done:**
+- [`rolker/udp_bridge#9`](https://github.com/rolker/udp_bridge/issues/9) — resend loop amplification. **CLOSED** via the #13 resend-logic work (exponential backoff + TTL alignment + debounce).
+- [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) — forwarding-throughput regression. **MERGED** 2026-05-01.
+- [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) — operator-side QoS fix complementing the bridge default change. **MERGED** 2026-05-18.
 
 ### Over-horizon operations capability *(new theme — 2026-05-01; update 2026-05-19)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,10 +37,29 @@ visible from one place.
 
 ### Sensor payload integration (M3 + SBG + SVS on mercat)
 
-- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up + data flow + NTRIP strategy + NTP. *Software pipeline live end-to-end as of 2026-04-27 (#94); first surveys recorded. M3 1PPS time-sync chain completed 2026-05-01 (#121) — after discovering that the M3 software's Device Properties → Time Sync Mode dropdown was the real gating switch, not the cable / SBG / pulse parameters that occupied most of the morning. QINSy SBG hookup live (position + attitude + heading + heave + GPS QC).*
-- [`unh_echoboats_project11#77`](https://github.com/rolker/unh_echoboats_project11/issues/77) — physical install, offsets, URDF, SVG diagram
-- [`rolker/marine_tools#1`](https://github.com/rolker/marine_tools/issues/1) — QINSy → ROS bridge for coverage / sounding feedback
-- [`unh_echoboats_project11#137`](https://github.com/rolker/unh_echoboats_project11/issues/137) — *(2026-05-19)* M3 sonar: investigate intermittent missing pings (suspected ping-rate × depth correlation). Historical observation — 2026-05-19 was the first time the M3 software's log window was open during ops and the explicit error messages were visible. **Load-bearing for the June 2026 class** if missing pings scale up at the ping-rate × depth combos used for survey grids.
+**Verify before June 4:**
+- AML SVS bridge — believed complete (gabby-side); confirm data is
+  actually being captured in deployment bag files. Some past
+  deployments used the mercat-side PowerShell stand-in
+  (`aml_bridge.ps1`); class cohort handoff shouldn't depend on that.
+- Mercat NTP — believed configured. Promote verification (`ntpq.exe -pn`)
+  to in-class teaching content for students.
+
+**Open decision (decide before June 4):**
+- Sidescan imagery option — install Garmin sidescan (colleague has
+  headless protocol implementation) vs run M3 in imagery mode. Tradeoff
+  is install effort vs imagery quality. *(Needs an issue.)*
+
+**Student-led / deferred:**
+- [`unh_echoboats_project11#137`](https://github.com/rolker/unh_echoboats_project11/issues/137) — M3 sonar intermittent missing pings. Basics work; tuning is in-class student work, not a class-blocker.
+- [`rolker/marine_tools#1`](https://github.com/rolker/marine_tools/issues/1) — QINSy → ROS bridge. Nice-to-have, not class-critical. Students can use QINSy's native display for survey planning.
+
+**Track:**
+- [`unh_echoboats_project11#77`](https://github.com/rolker/unh_echoboats_project11/issues/77) — physical install / offsets / URDF / SVG diagram. Cross-references the URDF gap in [`#110`](https://github.com/rolker/unh_echoboats_project11/issues/110) (both-nav-at-base_link theme).
+
+**Done:**
+- [`unh_echoboats_project11#76`](https://github.com/rolker/unh_echoboats_project11/issues/76) — mercat bring-up. Software pipeline live 2026-04-27 (#94); M3 1PPS time-sync chain completed 2026-05-01 (#121); QINSy SBG hookup live.
+- NTRIP — MassDOT source tested at Lake Massabesic; works with current configuration.
 
 ### Camera obstacle avoidance
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,9 +100,24 @@ autonomy quality.
 
 ### Navigation reliability
 
-- [`rolker/unh_marine_navigation#23`](https://github.com/rolker/unh_marine_navigation/issues/23) — TF extrapolation on multi-line survey goals
-- [`rolker/unh_marine_navigation#24`](https://github.com/rolker/unh_marine_navigation/issues/24) — wire BT `target_speed` → nav2 `/speed_limit` (per-task survey speed); deployment 2026-04-27 worked around with shared `default_speed` bump
-- [`unh_echoboats_project11#96`](https://github.com/rolker/unh_echoboats_project11/issues/96) — BizzyBoat-specific nav2 params override (decouple from seafloor echoboat defaults)
+**Must finish before June 4:**
+- [`rolker/unh_marine_navigation#24`](https://github.com/rolker/unh_marine_navigation/issues/24) — wire BT `target_speed` → `/speed_limit`. High priority operational item — per-task speed from a CAMP-sent mission is needed for normal operations (different survey speeds for different segments / line types), not just as a safety fallback. Current `default_speed` bump workaround from deployment 2026-04-27 doesn't support per-task variation.
+- [`rolker/unh_marine_navigation#23`](https://github.com/rolker/unh_marine_navigation/issues/23) — TF extrapolation on multi-line survey goals. No fix landed; 2026-05-19 deployment logs likely still show TF-lookup-out-of-time errors. Survey patterns at the lake will repeatedly trigger this. Verify still occurring, then fix.
+
+**Investigate before June 4:**
+- [`rolker/unh_marine_navigation#19`](https://github.com/rolker/unh_marine_navigation/issues/19) — costmap-update timeout too aggressive at 1.0s. Open and currently unscheduled. Likely matters once the costmap is populated (Surface-obstacle awareness theme). Check if it's a real bottleneck under realistic load before deciding to fix vs defer.
+- **Boat-side bathy costmap** *(placeholder — needs issue or existing
+  agent-branch link)*. Lake Massabesic has no S57 ENC coverage, so the
+  Nav2 costmap won't have any depth-derived "don't go here" data unless
+  external bathymetry is ingested. Likely consumes NHGranIT contours via
+  [`unh_marine_autonomy#86`](https://github.com/rolker/unh_marine_autonomy/issues/86)'s GGGS data store as a Processed source. Roland recalls
+  possible work on this from another computer — confirm location, then
+  either link existing issue/branch or open new. Borrowable code in
+  `s57_tools`/`marine_charts` for the depth-data → costmap layer
+  plumbing.
+
+**Defer past June 4:**
+- [`unh_echoboats_project11#96`](https://github.com/rolker/unh_echoboats_project11/issues/96) — BizzyBoat-specific nav2 params override (decouple from seafloor echoboat defaults). Not critical for single-boat ops; promote when joint Bizzy + Izzy ops come into scope.
 
 ### Both nav systems report at base_link *(theme — 2026-04-29; major progress 2026-05-01)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -265,10 +265,17 @@ OTH-specific work below is therefore **class-priority**, not deferred.
 
 ### Autonomy robustness *(new theme — 2026-05-01)*
 
-2026-05-01 deployment surfaced a real BT design issue and validated the GUIDED stale-setpoint failsafe.
+The 2026-05-01 deployment surfaced a real BT design issue (now filed)
+and validated the GUIDED stale-setpoint failsafe.
 
-- **BT `SkipUnknownTaskType` catchall masks execution failures** — top-level `ReactiveFallback` can't distinguish "no script condition matched" from "matching subtree's execution failed", so the catchall fires on action ABORTs and silently marks tracklines done. Forensic match for the 2026-05-01 15:09 HOLD episode (FollowPath ABORTED → SurveyLineTask sequence failed → catchall fired → trackline marked done → `done_hover` activated). Needs a new task issue against the BT / mission_manager. See gabby log §11.
-- **GUIDED stale-setpoint HOLD verified working** — when `cmd_vel` publication stops, FCU correctly enters HOLD. Confirmed Nav2-crash failsafe behaves as intended.
+**Must finish before June 4:**
+- [`unh_marine_navigation#25`](https://github.com/rolker/unh_marine_navigation/issues/25) — `SkipUnknownTaskType` catchall in `run_tasks.xml` silently marks tracklines done when a matching subtree's execution fails (e.g. `FollowPath` ABORT). Forensic match for the 2026-05-01 15:09 HOLD episode. Class-significant: a silently-marked-done line at OTH range means the operator sees a "complete" trackline and the boat parked in `done_hover` with no alert — coverage holes show up only post-mission.
+
+**Track during class prep:**
+- **Broader BT review of `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml`** — the catchall issue (`#25`) is one concrete failure mode; the tree has other shape choices a non-BT-native author may have made differently (e.g. nested `RetryUntilSuccessful num_attempts=3` around `Sequence`, `ReactiveFallback` semantics with stateful subtrees, multiple `_autoremap="true"` blackboard scopes, `KeepRunningUntilFailure`+`Inverter` patterns). Worth a Nav2-BT-experienced second pass before June 4. *(No issue yet — promote to one if the review surfaces concrete findings.)*
+
+**Done:**
+- **GUIDED stale-setpoint HOLD verified working** — when `cmd_vel` publication stops, FCU correctly enters HOLD. Confirmed Nav2-crash failsafe behaves as intended on 2026-05-01.
 
 ## Deferred / lower priority — no current issue
 


### PR DESCRIPTION
Deployment 2026-05-19 wrap-up PR. Scope and pre-launch checklist on [#135](https://github.com/rolker/unh_echoboats_project11/issues/135).

## Outcome

- **Phase 1 ✓** — Operator-side WiFi off, Starlink-only at close range. Validates the post-2026-05-01 fixes ([#134](https://github.com/rolker/unh_echoboats_project11/pull/134) coprime keyframe stagger, [`rolker/udp_bridge#16`](https://github.com/rolker/udp_bridge/pull/16) throughput regression fix, [`rolker/camp#51`](https://github.com/rolker/camp/pull/51) NavSource QoS workaround) under load.
- **Phase 2 — partial.** A short survey pattern was initiated and tracked on Starlink-only before being cut short on time; followed by a sustained autonomous cross-harbour trackline. Boat stayed in line of sight (not literally over-horizon), but with operator-side WiFi off the data path was Starlink-only throughout — the comms half of Phase 2's intent is validated. Literal OOL + a completed survey still pending; [`#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) stays open and gets substantial partial-credit data from today.
- **One in-field workaround applied + reverted-out at deployment end**: `mru_transform` nav input rolled back to `mavros/global_position/raw/fix` after the EKF-fused `/global` Z (~−12.4 m) was rejected by `sea_surface_estimator`'s chart-datum plausibility check (gabby log §13). Mission unblocked; durable choice tracked in [#138](https://github.com/rolker/unh_echoboats_project11/issues/138).

## What's in this PR

Per-deployment, per-host logs under `docs/logs/2026/`:

- `2026-05-19_dev_logs.md` — dev-side timeline + corrections + field-agent integrated entries + wrap-up + **post-mission data review section** (new)
- `2026-05-19_gabby_logs.md` — boat-side Linux/ROS host (gitcloud origin → cherry-picked from `gitcloud/jazzy`)
- `2026-05-19_salmon_logs.md` — operator station (gitcloud origin → cherry-picked from `gitcloud/jazzy`)
- Field-side `mru_transform` revert in `bizzyboat_project11/config/bizzyboat.yaml` (gitcloud commit `c36acfa` → `ece31dc` in this PR)

Plus:

- **`docs/roadmap.md`** updated across 6 themes with today's findings + the observability brainstorm direction
- **`docs/logs/README.md`** wrap-up section gets a new step 4: *dev integrates brief field-agent log highlights into the dev log Timeline so the dev log alone is at-a-glance complete*. Inspired by 2026-05-19 wrap-up surfacing that the dev log without integration was an incomplete narrative. Also includes a prototype-notice pointing to [workspace#477](https://github.com/rolker/ros2_agent_workspace/issues/477), where the whole deployment-logging workflow is being tracked as a candidate for a workspace-level capability.

mercat log: not in this PR — Windows host, lives outside the deployment-log workflow for now.

### Procedure correction inside this PR

Two earlier dev-log entries (14:22 and an earlier `024f875` "correction" commit) both repeated the same wrong premise — "field-host commits don't go through the deployment PR; `make sync` lands them on local `jazzy` directly." github-origin `jazzy` is protected; field-mode is the gitcloud-side carve-out only. Field-host commits still require a PR to land on github-origin `jazzy`. User-preferred reconciliation: cherry-pick the gitcloud commits onto the deployment branch, bundling everything for this deployment into PR #136. Captured inline in the dev log (14:22 corrective blockquote + 17:26 Timeline entry).

### Investigation that ran into a wall

A chain of work started against a salmon-side observation that `git bug bug show --format=json` returned empty `metadata.github-url` for the deployment issue's git-bug record — interpreted as "field-side can't map git-bug ↔ GitHub". Built on it: a workspace-side comment, an aggressive issue ([workspace#476](https://github.com/rolker/ros2_agent_workspace/issues/476)) framed around three "orphan" bugs, and a planned bridge-push action. Verifying just before push: of 34 open bugs in `unh_echoboats_project11`'s git-bug store, **all 34 are linked to GitHub issues** with `github-url` correctly populated — visible via the LIST JSON, not the SHOW JSON. Pure tooling artifact. Corrections posted as comments on the affected issues so the trail is traceable; lesson recorded as durable agent feedback (verify "missing data" claims against a known-present case before building on them). Workspace#476's two valid residual ideas (per-repo bridge configuration + host-suffix git-bug identity) stay on that issue for follow-up.

### Post-mission data review

Before close-out, ran four targeted analyses against the boat-side bags (extracted to SQLite at `~/data/logs/analysis/2026-05-19/bizzyboat.db` via `bag_to_sqlite --append`). Full tables + queries in the dev log's `## Post-mission data review` section. Top findings:

1. **Nav2's `lifecycle_manager_navigation` ALREADY publishes ERROR `DiagnosticStatus`** — `Nav2 Health` fired ERROR **873 times at 1 Hz** during today's silent-failure window (13:14:40–13:29:13 EDT). The signal exists. The gap is **chronic-noise hygiene on the diagnostics surface**: `udp_bridge: bizzy: operator: wifi` was ERROR 5147× across the deployment, plus `ping_monitor: salmon_direct` (2520×) and `router_op_direct` (2488×). Operator's toplevel rollup was permanently red from baseline; the new `Nav2 Health` ERROR couldn't stand out. **Reframes the brainstorm** — [`ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5#issuecomment-4494089803) lifecycle-subscription sub-task is partially redundant for Nav2; the load-bearing piece is now the diagnostics-noise hygiene work folded into [`#141`](https://github.com/rolker/unh_echoboats_project11/issues/141#issuecomment-4494089615).

2. **mavros `/global_position/global` has a monotonic upward Z drift of ~5 m/hour**, not just a frame-reference issue. With the boat on calm water and no GPS altitude updates feeding the EKF, Z drifts unconstrained from −21 m → −2.5 m over the deployment. `/bizzy/odom` pos_z jumps cleanly from −11.51 m → −23.78 m at 13:30 EDT (revert + full-stack relaunch). **Rules out Option C** (mavros /global + geoid compensation) from [`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138#issuecomment-4494089690) — even with geoid comp, drift would push the estimate outside the plausibility band within hours.

3. **udp_bridge stats stall is operator-side-bridge specific** — boat-side `/bizzy/udp_bridge/topic_statistics` published steadily at ~60 samples/min through every phase including the entire ≈1h17m Starlink-only window. Answers the open question on [`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20#issuecomment-4494089749). **Resend storm scales 23× when autonomy is active over half-broken comms** — not when WiFi is cut alone. Storm onset at 13:12 EDT (mission attempt), peak 132k msg/s + 19 MB/s through bridge during 13:16–13:29 (nav stack failure window), collapses exactly with the full-stack relaunch at 13:30.

4. **Velocity is healthy across sources** (mavros odom ≈ SBG ekf_nav within ~10 mm/s). The drift problem is altitude-specific to the EKF path.

5. **Battery profile is healthy** — 28.55 V start → 28.15 V end (~0.4 V drop over 2h 8m), V_min ~26.5 V under peak load (normal sag). Comfortable margin for a second deployment without recharging. For sharper projection, stitch with 2026-05-01 boat-side bag for longer effective discharge curve.

## Follow-up issues filed (12 + 8 comments)

| Source finding | Repo / Issue |
|---|---|
| M3 sonar missing pings (suspected ping-rate × depth) | [`unh_echoboats_project11#137`](https://github.com/rolker/unh_echoboats_project11/issues/137) |
| `mru_transform` durable nav-input choice | [`unh_echoboats_project11#138`](https://github.com/rolker/unh_echoboats_project11/issues/138) |
| `mikrotik_monitor` + `teltonika_monitor` crash on startup | [`rolker/ros2_network_monitor#23`](https://github.com/rolker/ros2_network_monitor/issues/23) |
| Replace `output='screen'` with `output='both'` in launches | [`unh_echoboats_project11#139`](https://github.com/rolker/unh_echoboats_project11/issues/139) |
| udp_bridge stats-timer publication stalls during Starlink-only ops | [`rolker/udp_bridge#20`](https://github.com/rolker/udp_bridge/issues/20) |
| udp_bridge resend-give-up "after N attempts" N varies 5/6/1 | [`rolker/udp_bridge#21`](https://github.com/rolker/udp_bridge/issues/21) |
| Remove stale `bencloud` ping target | [`unh_echoboats_project11#140`](https://github.com/rolker/unh_echoboats_project11/issues/140) |
| `/Operator/*` aggregator buckets STALE (now expanded to chronic-noise hygiene) | [`unh_echoboats_project11#141`](https://github.com/rolker/unh_echoboats_project11/issues/141) |
| Operator-side local costmap display: characterize + design path to CAMP | [`rolker/unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127) |
| Host thermals as `DiagnosticStatus` (lm-sensors + NVMe SMART) | [`unh_echoboats_project11#142`](https://github.com/rolker/unh_echoboats_project11/issues/142) |
| Install pre-commit hooks on salmon's workspace clone | [`unh_echoboats_project11#143`](https://github.com/rolker/unh_echoboats_project11/issues/143) |
| Brainstorm output: add observability mode to `ros2launch_session` | [`rolker/ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5) |
| Generalize deployment-logging workflow into a workspace-level capability | [`rolker/ros2_agent_workspace#477`](https://github.com/rolker/ros2_agent_workspace/issues/477) |

**Comments on existing issues** (from the wrap-up + post-mission analysis):

- [workspace#423](https://github.com/rolker/ros2_agent_workspace/issues/423) — SSH_AUTH_SOCK gap at agent startup ([orig](https://github.com/rolker/ros2_agent_workspace/issues/423#issuecomment-4492896368)) + retracted git-bug metadata observation ([correction](https://github.com/rolker/ros2_agent_workspace/issues/423#issuecomment-4493225349))
- [workspace#476](https://github.com/rolker/ros2_agent_workspace/issues/476) — orphan-claim correction ([comment](https://github.com/rolker/ros2_agent_workspace/issues/476#issuecomment-4493225257))
- [workspace#477](https://github.com/rolker/ros2_agent_workspace/issues/477) — initial README-updates mirror per the new prototype-notice ([comment](https://github.com/rolker/ros2_agent_workspace/issues/477#issuecomment-4493832165))
- [#141](https://github.com/rolker/unh_echoboats_project11/issues/141#issuecomment-4494089615) — post-mission chronic-noise scope expansion (Nav2 Health was published; gap was downstream)
- [#138](https://github.com/rolker/unh_echoboats_project11/issues/138#issuecomment-4494089690) — `mavros/global` Z drift evidence rules out Option C
- [udp_bridge#20](https://github.com/rolker/udp_bridge/issues/20#issuecomment-4494089749) — boat-side stats kept publishing; storm scales with autonomy activity
- [ros2launch_session#5](https://github.com/rolker/ros2launch_session/issues/5#issuecomment-4494089803) — lifecycle-subscription sub-task partially redundant for Nav2

The `ros2launch_session#5` design issue is the brainstorm-derived response to today's three silent-failure shapes (Nav2 lifecycle abort, monitor startup crashes, udp_bridge stats stall). The post-mission analysis reframed the lifecycle-subscription piece — Nav2 already publishes, so the load-bearing parts are now (a) the PID-watchdog + `ros2launch_session run` CLI sub-tasks on that issue, and (b) the chronic-noise hygiene work on `#141`. Together they cover the operator-side observability gap before the June 2026 class.

### Captured in the dev log, not separately filed

- Duplicate `/bizzy/sensors/sbg_device` graph entry (graph ghost from prior lifecycle; no real-PID conflict; watch for recurrence)
- NVMe Sensor 1 at 71.8°C on gabby (inside SSD throttle band, no climb across observation window; #142 is the actionable response)
- SBG `ros_standard: true` not producing standard topics — already tracked as git-bug `7c94549` ↔ `#117`

## 2026-05-20 wrap-up addenda

This section captures wrap-up work landing on top of the body above. The original "Pending on operator" list is now complete.

### Dev-log additions (committed)

- **Summary** + **Lessons Learned** at the top of `docs/logs/2026/2026-05-19_dev_logs.md` (operator-curated). Summary: "Successful test of Starlink-only operations, validating the fixes that came out of the previous OTH test." Lessons-Learned: finish previous-deployment data review before implementing changes for the next deployment — the wrong altitude reference ([`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138)) was already visible in the previous deployment's bag.
- **Battery cross-deployment comparison vs 2026-05-01** added under the post-mission data-review battery subsection. Matched-SoC start (28.6 V both), integrated PWM-deviation proxy, voltage at matched cumulative effort, PWM-excursion histogram. Conclusion: linear PWM-deviation isn't a sufficient discharge predictor (2026-05-19 was more bursty yet voltage dropped slower). Plan: continue collecting at the next deployment without recharging to extend the curve from the current ~28.15 V mid-plateau point.

### Roadmap revision (committed — 11 commits)

`docs/roadmap.md` rewritten section-by-section to reflect Summer Hydro 2026 + Lake Massabesic survey scope. Top framing now says June 4 class start (heavy dev done by then), June 15–~29 lake survey, 10 students in 3 rotating groups. Each section rebucketed into Must-finish-before-June-4 / Track / Defer-past-June-4 / Done. Highlights:

- **Sensor payload**: demoted to student-led tuning (`#137`) + verify-before-class (AML SVS bridge, mercat NTP) + open decision on sidescan (Garmin sidescan vs M3 imagery mode). NTRIP at the lake confirmed working.
- **Surface-obstacle awareness**: merged the old Camera + Perception → costmap sections. Display-first / planning-second framing. `unh_marine_perception#6` flagged as high-priority-but-unscheduled.
- **Navigation reliability**: `unh_marine_navigation#24` promoted from fallback to operational. Added boat-side bathy costmap placeholder (NHGranIT contours via [`unh_marine_autonomy#86`](https://github.com/rolker/unh_marine_autonomy/issues/86)).
- **Both nav at base_link**: tide-estimation chain explicitly load-bearing on this theme. Single FCU reconfig (`EK3_SRC1_POSZ=3` + `EK3_GPS_OFFS` + `GPS_POS1_X/Y/Z`) folds the mavros half of [`#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) into [`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138). `#112` marked CLOSED.
- **Class-ready operator UI**: heavily demoted — only [`#18`](https://github.com/rolker/unh_echoboats_project11/issues/18) (student deployment guide) is must-finish; rest is acceptable-workaround / student-deliverable.
- **Observability**: `#141` reframed (see below). Easy wins first (`#139`, `#140`, `ros2_network_monitor#23`, `#97`); [`ros2launch_session#5`](https://github.com/rolker/ros2launch_session/issues/5) demoted to stretch goal.
- **Network reliability**: demoted to maintenance mode. New future item [`#145`](https://github.com/rolker/unh_echoboats_project11/issues/145).
- **Over-horizon**: re-promoted after correcting a wrong scope assumption. Lake Massabesic survey is **OTH routinely** from a shore-based operator station; topic-budget cull + low-bandwidth status fallback + VPN-path indicator + [`#130`](https://github.com/rolker/unh_echoboats_project11/issues/130) all in class scope.
- **Autonomy robustness**: BT catchall now filed as [`rolker/unh_marine_navigation#25`](https://github.com/rolker/unh_marine_navigation/issues/25). Broader BT review of `run_tasks.xml` added as a placeholder.
- **Deferred / lower priority**: housekeeping — IzzyBoat WireGuard return path now points at [`#120`](https://github.com/rolker/unh_echoboats_project11/issues/120) parity tracker.

### Issue housekeeping

- **[`#144`](https://github.com/rolker/unh_echoboats_project11/issues/144)** — reframed (wire-vs-stats distinction, ~30× overstatement on operator-side msg/s metric) and **closed-recommended**. Cross-deployment comparison vs 2026-05-01 showed the storm signature is identical to a deployment we hadn't flagged as a bug, and 2026-05-19 was milder than 2026-05-01. Normal-but-loud bridge behavior under WiFi loss, not a regression.
- **[`#111`](https://github.com/rolker/unh_echoboats_project11/issues/111) — CLOSED**, folded into [`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138). SBG half was resolved live 2026-05-01 (sbgCenter Output Location); mavros half subsumes into #138's FCU reconfig.
- **[`#138`](https://github.com/rolker/unh_echoboats_project11/issues/138)** — appended 2026-05-20 update committing to Option C-as-FCU-reconfig (not in-bridge geoid compensation) and explaining how the single reconfig closes both this issue's Z-source question and #111's mavros-side base_link contract.
- **[`#141`](https://github.com/rolker/unh_echoboats_project11/issues/141)** — title + body reframed from "fix STALE buckets" to "remove diagnostic_aggregator from operator launches." Annunciator subscribes to `/diagnostics` directly; aggregator middleman has no operator-facing consumer.

### New issues + comments since the original body

| Source | Repo / Issue |
|---|---|
| BT `SkipUnknownTaskType` catchall silently marks tracklines done | [`rolker/unh_marine_navigation#25`](https://github.com/rolker/unh_marine_navigation/issues/25) |
| Concurrent Starlink + cell with safety-critical pinned to cell | [`unh_echoboats_project11#145`](https://github.com/rolker/unh_echoboats_project11/issues/145) |
| Restrict udp_bridge resend response to requesting connection | [`rolker/udp_bridge#23`](https://github.com/rolker/udp_bridge/issues/23) |
| udp_bridge "Giving up on resend" WARN too loud — fix proposal | [`rolker/udp_bridge#22` comment](https://github.com/rolker/udp_bridge/issues/22#issuecomment-4499809566) |
| #144 reframe + cross-deployment comparison + close-out | [`unh_echoboats_project11#144` final comment](https://github.com/rolker/unh_echoboats_project11/issues/144#issuecomment-4499414295) |

## Test plan

Field-deployment PR — the "test" is the deployment itself. Wrap-up merges the day's logs + the field-side workaround commit + the roadmap update + the README addition + post-mission data review. CI on this repo runs the standard pre-commit set on changed files.

Closes #135.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`

