### PR TITLE
docs: consolidate #150 bag-review topics as appendix to 2026-05-21 dev log

### DIFF
--- a/docs/logs/2026/2026-05-21_dev_logs.md
+++ b/docs/logs/2026/2026-05-21_dev_logs.md
@@ -610,3 +610,402 @@ log convention.
 > within mm. The ~0.5 m residual against the day's forecast (gabby §10 closure
 > walk-back) is therefore unlikely to be a datum-reference issue; more likely
 > small unmodeled offsets or forecast-vs-actual variability.
+
+
+# Appendix — #150 bag-review findings
+
+Consolidated from the topic-by-topic closure comments posted on
+[`#150`](https://github.com/rolker/unh_echoboats_project11/issues/150)
+during the 2026-05-22 bag review. The GitHub issue is the canonical
+durable record; this appendix preserves the narrative analysis end-to-end
+in-repo for offline reading and archival.
+
+Analysis artifacts (scripts, sqlite DB, frames) live under
+`~/data/logs/analysis/2026-05-21/` per the workspace's analysis-path
+convention — local-only by design, regenerable from the bags.
+
+## Topic 1 — #138 closure validation
+
+Full writeup: `~/data/logs/analysis/2026-05-21/01_138_closure.md`. Bag DB: `~/data/logs/analysis/2026-05-21_deployment.db`. Window restricted to algorithm-detected in-water 12:34:39 → 14:33:42 EDT (via `bag_analysis.launch_recovery.detect()`).
+
+### Vertical position (137 stationary 30 s buckets, both sources RTK-int throughout)
+
+| Comparison | Mean | Stdev | What it tells us |
+|---|---|---|---|
+| `mav_raw − mav_global` | +0.888 m | 7 mm | Matches `GPS_POS1_Z = 0.890`. **mavros /global is at base_link**, also confirmed via FCU param-level cross-check (`INS_POS1` + `GPS_POS1` self-consistent) |
+| `sbg_gps − sbg_ekf` | +0.925 m | 2 mm | Matches antenna-above-base_link (0.910 m). **SBG ekf_nav IS deported to CoR (= base_link)** per the flash config |
+| `sbg_ekf − mav_global` | **−0.594 m** | 18 mm | Both at base_link, yet SBG reads 0.59 m lower — anomaly |
+| `sbg_gps − mav_raw` | −0.557 m | 20 mm | Receiver-level disagreement at the antennas themselves |
+
+### Horizontal position (per-sample, 35,523 paired samples, body-frame projected)
+
+| Comparison | Expected body fwd | Observed body fwd | Stdev fwd |
+|---|---|---|---|
+| `sbg_gps − mav_raw` (antenna ↔ antenna) | −1.900 m | **−1.891 m** | 55 mm |
+| `sbg_ekf − mav_global` (base_link ↔ base_link) | (0, 0) | **−0.051 m** | 125 mm |
+
+Receivers agree on physical antenna positions to 9 mm horizontal. Both base_link outputs agree to ~5 cm horizontal. The 0.59 m disagreement is **vertical-only**.
+
+### Attitude (132 buckets)
+
+| Quantity | Mean | Stdev |
+|---|---|---|
+| Heading (SBG `gps_hdt.true_heading` − mavros compass) | **−0.015°** | 1.056° |
+| Roll residual (SBG_FRD + mavros_FLU, frame-conv'd) | +1.150° | 0.712° |
+| Pitch residual (SBG_FRD + mavros_FLU, frame-conv'd) | +0.272° | 0.248° |
+
+Zero heading bias. ~1° roll residual consistent with prior #110 finding (+1.79°) — likely small SBG mounting alignment. Sub-half-degree pitch.
+
+### Spec-vs-observed cross-check
+
+Pulled the [SBG Ellipse-N/D datasheet (MK068)](https://www.sbg-systems.com/wp-content/uploads/SBG-Ellipse-N-D-MK068.pdf) and the [u-blox ZED-F9P product summary](https://content.u-blox.com/sites/default/files/ZED-F9P_ProductSummary_UBX-17005151.pdf): combined RTK-fix precision is 0.01 m horizontal CEP and ~28 mm vertical 1-σ. Our observed Z stdev (18 mm) is within that floor. The Z mean offset of 0.59 m is **~20× combined vertical spec** — a real anomaly.
+
+### Outcomes
+
+- **#138 is closed correctly.** EK3 reconfig delivered `/mavros/global_position/global` at base_link. mru_transform→/global field commit (`f348f66`, in PR #153) restored the chain. Verified across 2 hours, no drift.
+- **gabby §11's interpretation overturned.** §11 read the 0.64 m gap as "SBG ekf_nav at IMU, not base_link, so #138 didn't move the needle." Data shows SBG IS deported to CoR=base_link; the 0.59 m offset is a receiver-level disagreement, not a lever-arm issue.
+- **~+0.5 m `tide_estimate` residual against NOAA forecast** is attributable to small freeboard (≤ 0.22 m, sonar face submerged per URDF) + forecast variability. Walked back gabby §10's "+0.03 m ✓" closure in PR #153 doc updates.
+- **Attitude**: both systems agree to within ~1° across all axes. No concerns.
+- **Horizontal**: 9 mm agreement between antenna positions; ~5 cm between base_link outputs. Any further tightening is URDF tape-measure precision — folded into #155.
+- **0.59 m SBG-vs-CUAV vertical disagreement** filed as **#156** — separate investigation (vertical-PCO / base-RTCM-height / receiver-specific Z handling).
+- **URDF measurement consolidation** tracked in **#155** — supersedes #110.
+
+Topic 1 ✓.
+
+## Topic 2 — udp_bridge#24 WARN demote validation
+
+Window: validated in-water 12:34:39 → 14:33:42 EDT.
+
+### Pass criteria
+
+| Metric | Result |
+|---|---|
+| `Giving up on resend` per-event WARN logs in valid window | **0** (vs **27,992** in 2h baseline 2026-05-19) |
+| PR #24 per-remote DiagnosticStatus alive | ✓ `wifi`, `vpn`, `resend give-ups` per-remote categories present |
+| `resend-give-ups` aggregator: WARN-state snapshots | 6,895 / 92,502 total (7.5%) |
+| `resend-give-ups` aggregator: ERROR-state snapshots | 1,208 / 92,502 (1.3%) |
+| Send-side TX failures (`send_failed_bytes_per_second`) | **0** throughout |
+| Send-side drops (`send_dropped_bytes_per_second`) | 0 → 5.4 kbps post-sonar (≤0.07% of 7-8 Mbps throughput) |
+| Operator-side bag size (already cited in #153) | 296 MB (2026-05-19) → 99 MB (2026-05-21) — same evidence |
+
+### Sonar-on confound
+
+M3 sonar enabled mid-mission at 13:19 EDT (per dev log).
+
+| Window | Mean send (kbps) | Mean msgs/s | Failed | Dropped |
+|---|---|---|---|---|
+| Pre-sonar 13:11→13:19 | 6,992 | 551 | 0 | 0 |
+| Post-sonar 13:19→14:33 | 7,691 | 625 | 0 | 5.4 |
+
+Sonar enable produced a ~10% increase in `udp_bridge` traffic — M3 raw pings are local-only (gabby → QINSy via mercat), not bridged. So the bridge load is essentially unaffected by sonar state; pre-vs-post-sonar comparison adds noise rather than signal.
+
+### Verdict
+
+Demote delivered as designed. The per-event "Giving up on resend" firehose into `/rosout` is gone (0 vs 27,992). The new per-remote `DiagnosticStatus` aggregator (`wifi`, `vpn`, `resend give-ups`) is surfacing comm-link health at appropriate WARN/ERROR granularity — ~9% of `/diagnostics` snapshots show a non-OK udp_bridge entry, consistent with normal lossy-OTH operation rather than a storm.
+
+Topic 2 ✓.
+
+## Topic 3 — bandwidth / Starlink saturation
+
+Window: validated in-water 12:34:39 → 14:33:42 EDT. Boat-side `/bizzy/udp_bridge/topic_statistics` + per-topic deserialized at 13:30 EDT (post-§12 fix, mid-session). Per-link caps from `bizzyboat.yaml`: wifi 12 Mbps, vpn/Starlink 8 Mbps.
+
+### Steady-state ~7.5 Mbps wire-out throughout (sum over both connections)
+
+| Time window | Mean send (kbps) | Msgs/s | Drops |
+|---|---|---|---|
+| Pre-launch settling (12:34-12:50) | 7,500-9,900 | 564-2870 | ~0.7 MB total (one spike) |
+| Mid-mission steady (12:50-13:39) | ~7,500 | ~590 | 0 |
+| Post-OTH-pivot (13:40-14:11) | ~7,400-7,900 | ~580 | 5.4 MB over 13:40-13:42 |
+| Late mission (14:11-14:33) | ~7,800-8,200 | ~585 | 3.3 MB over 14:11-14:17 |
+
+- Total cumulative dropped: **~41 Mbit over 2h ≈ 5.7 kbps avg** (≪ 0.1% of throughput).
+- `send_failed_bytes_per_second` **0** throughout.
+- No saturation in the give-up sense (topic 2 confirmed 0 give-ups).
+
+### Per-topic budget at 13:30 EDT (boat-side `udp_bridge/topic_statistics`)
+
+Each topic is sent to **both** the wifi and vpn connections simultaneously (per `bizzyboat.yaml`'s `connections_list: [wifi, vpn]` config — the operator picks whichever delivers each packet first / with fewer losses).
+
+| Topic | Per-connection kbps | Connections | Total wire-out kbps |
+|---|---|---|---|
+| 4× OAK ffmpeg (fwd/port/stbd/aft, 5 fps) | ~860 each | 2 (wifi + vpn) | **~6,880** (~93% of total) |
+| 4× OAK segmentation/compressed (5 Hz) | ~115 each | 1 | ~460 |
+| `local_costmap/costmap` (every 3 s) | 117 | 1 | 117 |
+| `/tf` (32 Hz) | 59 | 2 | 118 |
+| `/diagnostics` | 54 | 2 | 108 |
+| Telemetry (mavros, odom, IMU, GPS) | 15-25 each | 2 | ~340 |
+| **TOTAL across 91 topic-stat entries** | | | **~7,370 kbps** |
+
+So the **unique content** is ~3.7 Mbps, doubled to ~7.4 Mbps wire-out because of the dual-connection redundancy. 93% of the budget is OAK camera ffmpeg.
+
+### For OTH-only planning (#151 relevance)
+
+With both connections, observed = 7.4 Mbps wire-out / 20 Mbps combined cap = 37% utilization.
+
+If dropped to Starlink-only:
+- 3.7 Mbps unique content vs 8 Mbps VPN cap = 46% utilization → comfortable but not headroom-rich
+- Cutting OAK resolution per #151 would cut camera bandwidth proportionally, giving meaningful Starlink headroom
+
+### Caveat on the "OTH" segment
+
+The gabby log refers to an "OTH pivot" at 13:39 EDT, but the boat-side WiFi `DiagnosticStatus` was OK ~96% of the time with only sub-second WARN/ERR flickers across the valid window. WiFi never sustained a drop in this bag. So either:
+- The "OTH" narrative refers to something other than WiFi loss (operator-side visual line-of-sight, trackline reach, etc.), OR
+- WiFi was lossy enough to drive operator-side annunciators OTH-like, but the link stayed up.
+
+The numbers above therefore characterize the **full-link budget** (wifi + vpn carrying the load redundantly), not the pure-Starlink-only case. A future deployment with WiFi intentionally disabled (or genuinely out of range) would be needed to stress-test Starlink-only operation.
+
+### Correlation with topic 2 give-ups
+
+0 — topic 2 confirmed 0 give-up events in the valid window, so there's no correlation to plot.
+
+### Summary for the budget cull
+
+- Current full-link load: **7.4 Mbps**, 37% of combined cap. OAK ffmpeg = 93% of it.
+- Sustainable Starlink-only: requires sub-3.7 Mbps unique content. Current setup is right at the comfortable limit; #151 resolution tuning is the natural lever.
+- No new evidence of saturation events in this deployment. The chain handles transient drops gracefully via the demoted aggregator (topic 2).
+
+Topic 3 ✓.
+
+## Topic 4 — collision reconstruction
+
+Script: `~/data/logs/analysis/2026-05-21/09_collision_visualization.py`. Frames saved to `~/data/logs/analysis/2026-05-21/collision_frames/` (8× segmentation PNG + colored JPEG + costmap snapshots at T−25, T−20, T−15, T−10, T−5, T−2, T+0, T+2 s relative to impact).
+
+### Impact moment
+
+**13:56:55 EDT** — pinned via `/mavros/local_position/odom` velocity profile:
+- Speed dropped 0.4 → 0.02 m/s in <0.5 s
+- Held under 0.2 m/s for ~15 s post-impact (boat held against / stuck in platform)
+- Motion resumed slowly around 13:57:11
+
+### Approach dynamics
+
+- 13:56:00 → 13:56:04: accelerated 0.4 → 1.8 m/s (autonomy re-engaged)
+- 13:56:04 → 13:56:55: decelerated through 1.8 → 0.4 m/s (manual override fighting per gabby narrative)
+- 13:56:55: impact
+
+### Forward-camera segmentation (30 s before impact)
+
+| Offset (s) | non-water pixels (of 12,288) | fraction |
+|---|---|---|
+| −25 | 10,257 | 83.5% |
+| −20 |  9,925 | 80.8% |
+| −15 |  9,864 | 80.3% |
+| −10 |  9,910 | 80.6% |
+|  −5 | 10,018 | 81.5% |
+|  −2 | 10,246 | 83.4% |
+|   0 | 10,155 | 82.6% |
+|  +2 |  9,052 | 73.7% |
+
+- ~80% non-water consistently — segmentation DID register substantial non-water content throughout the approach
+- Multiple non-water classes visible in the RGB-colored segmentation viz
+- **Frame-to-frame non-water pixel count is nearly flat as boat approached** — suggesting the model isn't strongly differentiating "platform 5 m ahead" from baseline ambient non-water (sky, distant land, boat's own deck etc.)
+
+### Local costmap state (post-§19 forward-only workaround)
+
+- 1600×1600 cells at 0.25 m/cell (400×400 m), boat at center
+- 260-320k occupied cells (cost > 50) throughout the window — ~10-12% of costmap occupied
+- Two prominent obstacle regions visible in front of the boat at each snapshot (projected from forward camera per `seafloor_echoboat_project11#21` forward-only workaround)
+- The sea_surface_layer → costmap chain WAS running and accumulating obstacles
+
+### "Did the platform register?"
+
+Conditionally yes — the segmentation saw a structured non-water object ahead and the costmap accumulated obstacle regions in front of the boat. But the system never USED that information for avoidance because the trackline planner is collision-avoidance-free by design (per #150 framing), and the boat had been in manual override before re-engaging.
+
+What the data doesn't yes/no answer alone:
+- Visual identification of the platform specifically vs. ambient non-water (segmentation isn't multi-class enough to label "platform" vs. "sky" vs. "hull")
+- Whether the platform got more salient as boat approached (count is nearly flat across the approach window)
+
+Saved frames are available for human visual review (operator who was there can identify the platform shape in the colored seg JPEGs).
+
+### Procedural lesson capture
+
+Already in PR #153's `docs/logs/2026/2026-05-21_dev_logs.md` and `docs/roadmap.md`:
+
+> "When manually averting an obstacle mid-trackline, position the boat fully past it (along-track) before re-engaging autonomy. The cross-track-error correction will pull the boat straight back to the line, including through anything beside it."
+
+### Follow-up flag (not blocking #150)
+
+The "nearly flat non-water pixel count as boat approached" is suggestive of a perception gap — the segmentation may not be strongly differentiating proximate obstacles from ambient non-water content. Worth flagging into [`unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7) (end-to-end segmentation validation).
+
+Topic 4 ✓.
+
+## Topic 5 — battery voltage trend
+
+Script: `~/data/logs/analysis/2026-05-21/08_battery_voltage.py`. 86,008 voltage samples across the full boat-on window 12:17:00 → 14:41:04 EDT (144 min).
+
+**Per [[project_bizzyboat_no_current_meter]] — `BatteryState.current` is a placeholder (~0.01 A). All analysis here is voltage-only. Don't report current/watts.**
+
+### Headline numbers
+
+- **Start**: 27.04 V (consistent with "uncharged-ish" framing — fully charged is ~28+ V at rest)
+- **End**: 26.05 V
+- **Mean discharge**: −0.98 V over 2.4 h ⇒ **0.41 V/hr**
+- **Min observed (transient)**: 24.25 V at 14:25 EDT (~1.7 V below the bucket mean — thruster current spike)
+
+### Curve shape (5-min buckets)
+
+| Window | V mean trend | Notes |
+|---|---|---|
+| 12:17-12:30 | 27.05 V flat | Boat on cart, no thruster load |
+| 12:30-12:50 | 27.0 → 26.5 V (−0.5 V in 20 min) | Launch + Phase 1 first GOTOs — first heavy thruster engagement |
+| 12:50-13:35 | 26.7 → 26.5 V slow drift | Sustained moderate load |
+| 13:35-14:00 | 26.5 → 26.0 V (−0.5 V step) | Post-OTH-pivot; sustained autonomy |
+| 14:00-14:30 | hovering 26.0 V | Recovery-prep, slow-speed |
+| 14:30-14:41 | 26.05 V flat | Recovery + dock, light load |
+
+### Voltage at key mission events
+
+| Event | V | Δ from start |
+|---|---|---|
+| Launch (12:34) | 27.01 V | −0.03 V |
+| Phase 1 GOTOs (12:50) | 26.46 V | −0.57 V |
+| Sonar on (13:19) | 26.67 V | −0.36 V |
+| OTH pivot (13:39) | 26.26 V | −0.78 V |
+| Collision (13:57) | 26.23 V | −0.80 V |
+| Recovery (14:33) | 26.05 V | −0.98 V |
+
+### Transient dips
+
+5-min bucket *minimum* values drop as low as **24.25 V** (1.6-1.7 V below the bucket mean). These are thruster-activation current spikes pulling voltage down momentarily. Sub-25 V transients didn't trigger any LV cutoff today, but they bring the instantaneous voltage closer to a typical 24 V LVD threshold than the mean would suggest.
+
+### 2026-05-20 comparison
+
+The #150 topic-5 scope called for comparing to yesterday's tail-end voltage, but **no boat-side bag exists for 2026-05-20** in `~/data/logs/bizzyboat/` (boat was on for testing but apparently not recording — per [[project_bizzyboat_135_resume_state_2026-05-20-eod]]). Useful follow-up: turn on logging during dry-run testing days so this comparison is possible next time.
+
+### Class-prep implication (June 4 / Lake Massabesic)
+
+- Today's 0.4 V/hr × 4-hour session ≈ 1.6 V drop. Starting from 27 V → 25.4 V mean by session end. Comfortable above 24 V LVD baseline.
+- Transient dips of 1-2 V during heavy thrust mean **instantaneous voltage could dip below 24 V near session end** if running thrusters hard at a low battery state.
+- Recommendation: ensure batteries at ≥ 27 V before each session start; plan for one battery swap mid-day for back-to-back student groups.
+
+### No anomalous correlations
+
+No abnormal voltage behavior tied to specific mission events (collision, sonar-on, OTH pivot) beyond the expected load-discharge pattern.
+
+Topic 5 ✓.
+
+## Topic 6 — nav stack unhealthy root cause
+
+Window: 13:11:14 → 13:37:00 EDT (post-§12-restart through final successful bringup).
+
+### Timeline
+
+| Time (EDT) | Event |
+|---|---|
+| 13:09 | §12 mru_transform reconfig + stack restart |
+| 13:11:14 | bag-2 start; nav nodes launched |
+| 13:11:15 | **Bringup attempt #1**: `Activating controller_server` → `local_costmap`: TF timeout for `bizzy/map_tide` (frame not yet broadcast) |
+| **13:11:20** | `map_tide` TF first appears in `/tf` — ~5 s too late for #1 |
+| 13:11:15 → 13:25:47 | `bt_task_navigator` never reaches Active. Action server rejects goals. |
+| 13:25:47 / 13:26:12 | **Trackline goals rejected** (operator-initiated launch attempt) |
+| 13:32:13 | Bringup attempt #2 — fails (no bond connection) |
+| 13:34:37 | Bringup attempt #3 — fails |
+| 13:37:00 | **Bringup attempt #4 succeeds** — all servers connect with bond, stack healthy. **26 min after restart.** |
+
+### Root cause
+
+**Lifecycle activation race between `local_costmap` and `sea_surface_estimator`.** Each bringup attempt asks `local_costmap` to activate before `sea_surface_estimator` has produced its first `map_tide` TF. The costmap's `wait_for_transform` times out (~5 s default) before the TF appears (~6 s after the costmap node starts trying in this bag). Activation fails, and the bringup hangs in a failed state until the user manually retries. The 4th attempt's timing happened to line up.
+
+This is **exactly the #135 root cause pattern** — not a new failure mode.
+
+### What the #150 topic 6 prior got wrong
+
+Hypothesis going in: "multi-instance `sea_surface_layer` segfault was crashing `controller_server` before the trackline attempt; PR [`seafloor_echoboat_project11#21`](https://github.com/rolker/seafloor_echoboat_project11/pull/21)'s forward-only workaround should fix it."
+
+The bag refutes this:
+
+- **Multi-instance `sea_surface_layer` configured cleanly** — all four instances (`_forward`, `_port`, `_starboard`, `_aft`) initialized in `local_costmap` configuration with `Matching size of SeaSurfaceLayer to parent costmap` messages. No segfault. No error.
+- The activation failure happens at a **different lifecycle stage** (Activate, not Configure) and a **different node** (local_costmap, not sea_surface_layer).
+- ⇒ `seafloor_echoboat_project11#21`'s forward-only workaround would **not** have prevented this trackline rejection. It addresses a different (orthogonal) segfault that doesn't show up in this bag.
+
+The #146/#147 ERROR-log-capture work landed today now means we'd see the segfault if/when it actually happens; this deployment confirms it didn't.
+
+### Fix candidates
+
+1. **Patient activation**: increase the `local_costmap` `transform_tolerance` / TF-wait timeout so `sea_surface_estimator` has time to publish its first `map_tide`.
+2. **Placeholder map_tide at startup** (cleanest engineering fix): have `sea_surface_estimator` broadcast an immediate dummy/zero-tide `map_tide` TF at activation, refining as real data arrives. Removes the race.
+3. **Lifecycle dependency**: gate `local_costmap` activation on `sea_surface_estimator` having published at least one TF (topic-readiness check or lifecycle service dependency).
+4. **Field workaround for June 4** (cheapest): insert a ~10 s sleep in the launch sequence between core bringup and nav-stack bringup so `sea_surface_estimator` has time to compute its first estimate before any activation attempt.
+
+### Class-prep relevance
+
+A 26-min "4 retries" settling time after a boat reboot is bad UX with students present. If the boat is rebooted in the field (intentional or otherwise) during a class session, students would observe trackline launches failing for 20+ minutes with no obvious error message — just "Action server is inactive. Rejecting the goal." in `/rosout`. Worth a focused fix or workaround before June 4.
+
+Suggest filing this as a new issue (separate from #150) with the choice between options 1-4 above for the user to pick.
+
+Topic 6 ✓.
+
+## Topic 7 — mru_transform → /global validation
+
+Script: `~/data/logs/analysis/2026-05-21/07_topic7_mru_global_validation.py`. Window: 12:34:39 → 14:33:42 EDT.
+
+### Pass criteria
+
+| Criterion | Result |
+|---|---|
+| `map_tide` TF published throughout valid window | ✓ 71,037 samples (5 Hz, continuous) |
+| All samples in plausibility band `[-33.74, -19.42]` m | ✓ 0 out-of-band, observed range `[-25.93, -22.19]` m |
+| `sea_surface_estimator` suppression warnings in `/rosout` | ✓ **0** |
+| `sea_surface_estimator` messages of any severity in `/rosout` | ✓ **0** |
+| Trajectory tracks NOAA tide forecast | ✓ post-fix rise 13:14→14:24 = **+0.67 m**; NOAA forecast = +0.6 m (matches within 7 cm) |
+| Field-revert from 2026-05-19 (`c36acfa`) fully undone | ✓ confirmed |
+
+### Trajectory
+
+Pre-launch bag covers 12:34:39 → 13:10:45 EDT (pre-fix, `mru_transform` reading `raw/fix`); mid-mission bag covers 13:11:14 → 14:33:42 EDT (post-fix, on `/global`). The 1-min gap between bags is the §12 stack restart at 13:09 EDT.
+
+| Window | Mean `map_tide.z` | Per-bucket stdev | Notes |
+|---|---|---|---|
+| Pre-fix (12:34-13:04) | ~−25.3 m | 39-455 mm | mru_transform reading antenna alt; chain still in plausibility band |
+| Step at 13:09 EDT | drops by ~0.5 m | — | §12 source switch + chain restart |
+| Post-fix (13:14-14:24) | rises smoothly −25.82 → −25.15 m | 20-47 mm | rate-of-rise matches NOAA forecast |
+
+### Note on step magnitude
+
+The pre→post-fix step was ~0.5 m, less than the ~0.89 m gabby §10 predicted. The chain's `sea_surface_estimator` does additional processing on `/odom.z` (heave compensation etc.) before publishing `map_tide`, so the raw `raw/fix` → `/global` source change doesn't propagate 1:1 to the tide-surface output. Either way, the chain produces physically plausible values both pre- and post-fix; the §12 switch corrected the underlying frame from antenna-alt to base_link-alt as intended.
+
+The remaining ~+0.5 m residual against NOAA forecast (post-fix tide_estimate ≈ NOAA + 0.5 m) is the same residual identified in topic 1 — small freeboard not modeled + small unmodeled offsets. Not a topic 7 concern.
+
+Topic 7 ✓.
+
+## #150 wrap-up
+
+Topic 8 (bag-side resolution-reduction prep) dropped — Roland is testing 4-cam OAK over Starlink right now (post-2026-05-21) and it's looking acceptable. Resolution-reduction is therefore not on the critical path for #151, and the bag-side dry-run that topic 8 was meant to enable doesn't need to happen yet. If a future deployment shows the 4-cam-Starlink load is too tight, #151 (or a successor issue) can reopen the resolution lever then.
+
+### Topics done (7 of 8)
+
+| Topic | Status | Spinoffs |
+|---|---|---|
+| 1. #138 closure validation | ✓ | #155 (URDF), #156 (0.59 m Z disagreement) |
+| 2. udp_bridge#24 WARN demote validation | ✓ | — |
+| 3. Bandwidth / Starlink saturation | ✓ | — |
+| 4. Collision reconstruction | ✓ | perception gap flagged into unh_marine_perception#7 |
+| 5. Battery voltage trend | ✓ | class-prep recommendation captured |
+| 6. Nav stack unhealthy root cause | ✓ | **#157 (activation race fix — pre-class relevant)** |
+| 7. mru_transform /global validation | ✓ | — |
+| 8. Camera resolution prep | dropped | live-tested OK post-deployment |
+
+### Spinoff issues filed
+
+- **#155** — URDF consolidation (supersedes #110): SBG IMU + Trimble antennas + CUAV antenna refinement
+- **#156** — 0.59 m SBG-vs-CUAV ellipsoidal-Z disagreement investigation
+- **#157** — Nav stack activation race (`local_costmap` times out waiting for `sea_surface_estimator` first `map_tide` TF). **Pre-class relevant.**
+
+### Artifacts
+
+`~/data/logs/analysis/2026-05-21/`:
+- `01_138_closure.md` — topic 1 writeup
+- `03_position_residuals.sql` / `03_results.tsv` — vertical position residuals (137 stationary buckets)
+- `04_attitude_comparison.py` — heading/roll/pitch comparison (132 buckets)
+- `06_horizontal_per_sample.py` — per-sample horizontal residuals (35,523 paired samples)
+- `07_topic7_mru_global_validation.py` — map_tide TF + sea_surface_estimator validation
+- `08_battery_voltage.py` — voltage time-series + class-prep analysis
+- `09_collision_visualization.py` — collision frames extractor; outputs in `collision_frames/`
+- `~/data/logs/analysis/2026-05-21_deployment.db` — combined sqlite extraction of both 2026-05-21 boat bags
+
+Closing #150 as resolved.
+
+
+---
+**Authored-By**: `Claude Code Agent`  
+**Model**: `Claude Opus 4.7 (1M context)`


### PR DESCRIPTION
## Summary

Consolidates the 7 #150 topic-closure comments + wrap-up into a single readable appendix at the end of `docs/logs/2026/2026-05-21_dev_logs.md`. The GitHub issue is the canonical durable record; this appendix preserves the narrative analysis end-to-end in-repo for offline reading and archival.

Local-only artifacts (`~/data/logs/analysis/2026-05-21/` — sqlite DB, frames, Python/SQL scripts) stay outside the repo per the workspace's analysis-path convention; they're regenerable from the boat bags.

## What landed

- New "Appendix — #150 bag-review findings" section at the end of `docs/logs/2026/2026-05-21_dev_logs.md` (+399 lines, doc-only).
- Topics ordered numerically (1 → 7) + wrap-up. Each subsection demoted from `##` (issue-comment level) to `## Topic N — title` (in-doc section level).
- Per-comment `Authored-By` footers de-duped; single appendix-level signature at the end.

## Test plan

Doc-only change — no code or config touched. Smoke-checked the diff is purely an append after the existing timeline.

## Closes

Closes #158.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
