### PR TITLE
§2 performance characterization + raise yaw-rate cap 0.5→1.0 (behavior change)

### DIFF
--- a/.agent/work-plans/issue-124/progress.md
+++ b/.agent/work-plans/issue-124/progress.md
@@ -78,3 +78,9 @@ curve spun to #88).
 - [ ] (#5) narrow `except Exception: pass` (dynamics.py:178, dynamics_extra.py:99) to curve_fit RuntimeError/ValueError
 - [ ] (#6) progress.md turning-round entry says 0.5→0.8 (final 1.0) — add correcting note
 - [ ] (optional) perf/robustness: xte.py vectorization; dynamics_extra DB-existence guard/hardcoded names; turning.py velocity_body guard
+
+## Correction — yaw cap value of record
+The "turning + yaw-cap round" entry above records `max_yaw_speed 0.5→0.8`; the
+cap was subsequently **finalized at 1.0 rad/s** (vehicle-capability backstop)
+— see the `config(helm): set max_yaw_speed to 1.0` commit and the External
+Review entry. **1.0 is the value of record.**

--- a/.agent/work-plans/issue-124/progress.md
+++ b/.agent/work-plans/issue-124/progress.md
@@ -29,3 +29,22 @@ no-current-meter constraint all verified clean.
 - [x] (suggestion) cruise m/s↔kt pairing (1.5↔3.0 implies 1.54) — standardised to 1.52 m/s — `bizzyboat_performance.md`, `bizzyboat_hardware.md`
 - [x] (suggestion) coast-down "~0.2 m/s²" was the max not median — restated ~0.15 (up to ~0.25) — `bizzyboat_performance.md`, `bizzyboat_hardware.md`
 - [x] (suggestion) "fit quality tracks current" mis-attributed — reworded to heading-arc + speed steadiness; slack "≈0" → ~0.1 within fit noise — `bizzyboat_performance.md`, `README.md`
+
+## Local Review (Pre-Push) — turning + yaw-cap round
+**Status**: complete
+**When**: 2026-05-25 12:10
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved (after fixes)
+
+**Branch**: feature/issue-124 at `915571e`
+**Mode**: pre-push
+**Scope**: turn-radius item — turning.py, Turning section, max_yaw_speed 0.5→0.8 (behavior change)
+
+Fresh-context review + user domain correction caught real defects, all fixed before push:
+- [x] (must-fix) doc claimed "MANUAL turns didn't exceed clamp at cruise" — false; MANUAL is unclamped and hit 0.74 rad/s at cruise. Reworded.
+- [x] (must-fix) "8.3% pinned at 0.5" was the 05-01 low end — now stated as 8%→39% across deployments (~21% pooled).
+- [x] (must-fix) "0.5 is a placeholder / no tuning notes" — wrong; deployment log shows it was reduced 1.5→0.5 during an April steering-reversal debug. Reframed.
+- [x] (user correction) steering is VECTORED THRUST, not a rudder → yaw authority scales with thrust (throttle), not boat speed. Re-did the steering-effectiveness analysis as a throttle×deflection grid; rewrote the physics framing.
+- [x] (user correction) steering-reversal is a stationary controls-check artifact, orthogonal to max_yaw_speed → 0.8 bump cleared to proceed.
+
+max_yaw_speed 0.5→0.8 is a behavior change: unvalidated for sustained GUIDED cruise turns → flagged for next-deployment validation (#88 controlled sweep).

--- a/.agent/work-plans/issue-124/progress.md
+++ b/.agent/work-plans/issue-124/progress.md
@@ -48,3 +48,14 @@ Fresh-context review + user domain correction caught real defects, all fixed bef
 - [x] (user correction) steering-reversal is a stationary controls-check artifact, orthogonal to max_yaw_speed → 0.8 bump cleared to proceed.
 
 max_yaw_speed 0.5→0.8 is a behavior change: unvalidated for sustained GUIDED cruise turns → flagged for next-deployment validation (#88 controlled sweep).
+
+## §2 completion — course-keeping (XTE)
+**When**: 2026-05-25 13:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Added xte.py + Course-keeping section (PR #172). Track-holding ~0.13 m RMS
+(consistent across 3 deployments, matches 04-24 "sub-meter"); XTE-vs-plan
+~0.4–0.8 m. Self-reviewed (two bugs found+fixed during dev: pandas `.mode`
+attribute shadowing, and plan-matching contamination → switched headline to
+the robust line-fit-residual metric). §2 now complete (max-reverse + mid-PWM
+curve spun to #88).

--- a/.agent/work-plans/issue-124/progress.md
+++ b/.agent/work-plans/issue-124/progress.md
@@ -1,0 +1,31 @@
+---
+issue: 124
+---
+
+# Issue #124 — Post-mission data review — 2026-05-01 BizzyBoat deployment
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-25 10:45
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-124 at `249009e`
+**Mode**: pre-push
+**Depth**: Standard (reason: 699 LOC across 7 files incl. Python, project repo)
+**Must-fix**: 0 | **Suggestions**: 6 (all addressed before push)
+
+Covers §2 (Performance characterization). Two adversarial specialists
+(Claude fresh-context + Copilot CLI v1.0.51) ran; the Claude subagent
+independently re-ran both analysis scripts and confirmed every
+per-deployment number reproduces exactly. No must-fix bugs; coordinate
+conventions, circle-fit algebra, surge/decay slopes, and the
+no-current-meter constraint all verified clean.
+
+### Findings (all resolved)
+- [x] (suggestion) accel gate admitted reverse-start transitions — tightened to near-idle start (`1470≤before≤1560`) — `dynamics.py`
+- [x] (suggestion) no-arg run did 3 DBs but README said "all" — default now globs all 7 — `dynamics.py`
+- [x] (suggestion) degenerate-window threshold too broad (10 min) — tightened to 2 min + comment — `dynamics.py`
+- [x] (suggestion) cruise m/s↔kt pairing (1.5↔3.0 implies 1.54) — standardised to 1.52 m/s — `bizzyboat_performance.md`, `bizzyboat_hardware.md`
+- [x] (suggestion) coast-down "~0.2 m/s²" was the max not median — restated ~0.15 (up to ~0.25) — `bizzyboat_performance.md`, `bizzyboat_hardware.md`
+- [x] (suggestion) "fit quality tracks current" mis-attributed — reworded to heading-arc + speed steadiness; slack "≈0" → ~0.1 within fit noise — `bizzyboat_performance.md`, `README.md`

--- a/.agent/work-plans/issue-124/progress.md
+++ b/.agent/work-plans/issue-124/progress.md
@@ -71,12 +71,12 @@ curve spun to #88).
 **Verdict**: 6 valid (all doc/tooling-accuracy, none touch analysis conclusions); 3 false-positive/addressed; several optional perf/robustness
 
 ### Actions
-- [ ] (#1) "sub-decimeter" wording wrong for ~0.13 m RMS — fix performance.md:25 + hardware.md:303 ("decimeter-scale")
-- [ ] (#2) turning.py:134 output prints stale "@0.8 rad/s" — change to 1.0 (the chosen cap)
-- [ ] (#3) turning.py:4 docstring frames max_yaw_speed=0.5 as current — note 0.5-during-data → 1.0
-- [ ] (#4) README:61/65 — turning.py (mavros/state) + xte.py (plan+odom) need the full deployment DB; not covered by the *_nav.db recipe/run examples
-- [ ] (#5) narrow `except Exception: pass` (dynamics.py:178, dynamics_extra.py:99) to curve_fit RuntimeError/ValueError
-- [ ] (#6) progress.md turning-round entry says 0.5→0.8 (final 1.0) — add correcting note
+- [x] (#1) "sub-decimeter" wording wrong for ~0.13 m RMS — fix performance.md:25 + hardware.md:303 ("decimeter-scale")
+- [x] (#2) turning.py:134 output prints stale "@0.8 rad/s" — change to 1.0 (the chosen cap)
+- [x] (#3) turning.py:4 docstring frames max_yaw_speed=0.5 as current — note 0.5-during-data → 1.0
+- [x] (#4) README:61/65 — turning.py (mavros/state) + xte.py (plan+odom) need the full deployment DB; not covered by the *_nav.db recipe/run examples
+- [x] (#5) narrow `except Exception: pass` (dynamics.py:178, dynamics_extra.py:99) to curve_fit RuntimeError/ValueError
+- [x] (#6) progress.md turning-round entry says 0.5→0.8 (final 1.0) — add correcting note
 - [ ] (optional) perf/robustness: xte.py vectorization; dynamics_extra DB-existence guard/hardcoded names; turning.py velocity_body guard
 
 ## Correction — yaw cap value of record
@@ -84,3 +84,8 @@ The "turning + yaw-cap round" entry above records `max_yaw_speed 0.5→0.8`; the
 cap was subsequently **finalized at 1.0 rad/s** (vehicle-capability backstop)
 — see the `config(helm): set max_yaw_speed to 1.0` commit and the External
 Review entry. **1.0 is the value of record.**
+
+## External Review — re-review round (3295647)
+Copilot re-reviewed the triage-fix commit; 2 new minor items, both addressed:
+- performance.md binding-discussion opener read present-tense ("set to 0.5") → reworded to "during the analyzed deployments … since raised to 1.0".
+- this entry's Actions checkboxes were unchecked while done → checked off #1–#6 (optional perf items remain intentionally undone).

--- a/.agent/work-plans/issue-124/progress.md
+++ b/.agent/work-plans/issue-124/progress.md
@@ -59,3 +59,22 @@ Added xte.py + Course-keeping section (PR #172). Track-holding ~0.13 m RMS
 attribute shadowing, and plan-matching contamination → switched headline to
 the robust line-fit-residual metric). §2 now complete (max-reverse + mid-PWM
 curve spun to #88).
+
+## External Review
+**Status**: complete
+**When**: 2026-05-25 16:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #172 at `da6ec14`
+**Reviews**: 5 (all Copilot bot), 22 inline + 2 conversation (author's own — no action)
+**CI**: no real CI (only copilot-pull-request-reviewer marker = success)
+**Verdict**: 6 valid (all doc/tooling-accuracy, none touch analysis conclusions); 3 false-positive/addressed; several optional perf/robustness
+
+### Actions
+- [ ] (#1) "sub-decimeter" wording wrong for ~0.13 m RMS — fix performance.md:25 + hardware.md:303 ("decimeter-scale")
+- [ ] (#2) turning.py:134 output prints stale "@0.8 rad/s" — change to 1.0 (the chosen cap)
+- [ ] (#3) turning.py:4 docstring frames max_yaw_speed=0.5 as current — note 0.5-during-data → 1.0
+- [ ] (#4) README:61/65 — turning.py (mavros/state) + xte.py (plan+odom) need the full deployment DB; not covered by the *_nav.db recipe/run examples
+- [ ] (#5) narrow `except Exception: pass` (dynamics.py:178, dynamics_extra.py:99) to curve_fit RuntimeError/ValueError
+- [ ] (#6) progress.md turning-round entry says 0.5→0.8 (final 1.0) — add correcting note
+- [ ] (optional) perf/robustness: xte.py vectorization; dynamics_extra DB-existence guard/hardcoded names; turning.py velocity_body guard

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     output_type: twist
     max_speed: 2.0
-    max_yaw_speed: 0.8  # raised from 0.5 — see #124 §2 (vectored thrust; validate sustained cruise turn)
+    max_yaw_speed: 1.0  # vehicle-capability backstop (was 0.5); survey-turn limit belongs in Nav2 smoother — see #124 §2
 
 /**/platform_sender:
   ros__parameters:

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     output_type: twist
     max_speed: 2.0
-    max_yaw_speed: 0.5
+    max_yaw_speed: 0.8  # raised from 0.5 — see #124 §2 (vectored thrust; validate sustained cruise turn)
 
 /**/platform_sender:
   ros__parameters:

--- a/bizzyboat_project11/docs/bizzyboat_hardware.md
+++ b/bizzyboat_project11/docs/bizzyboat_hardware.md
@@ -298,8 +298,8 @@ and [`../../docs/analysis/dynamics/`](../../docs/analysis/dynamics/)
 | Hard-launch acceleration | ~0.6 m/s² peak, τ ≈ 2.5 s | idle → full |
 | Coast-down deceleration | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s | passive; ~10–15 m to stop from cruise |
 | Max reverse speed | ~1.4 m/s (2.7 kt) peak, provisional | sustained reverse under-sampled — see [#88](https://github.com/rolker/unh_echoboats_project11/issues/88) |
-| Yaw-rate cap (autonomy) | 0.8 rad/s (`helm_manager.max_yaw_speed`) | raised from 0.5; vectored thrust → ~0.9 rad/s pivot at full throttle; sustained cruise turn unvalidated |
-| Min turn radius @ cruise | ~1.9 m at the 0.8 cap | set by the yaw clamp; <1 m pivot at low speed |
+| Yaw-rate cap (autonomy) | 1.0 rad/s (`helm_manager.max_yaw_speed`) | raised from 0.5 to the helm default = vehicle-capability backstop; ~0.9 rad/s pivot at full throttle; sustained cruise turn unvalidated |
+| Min turn radius @ cruise | ~1.5 m at the 1.0 cap | set by the yaw clamp; <1 m pivot at low speed |
 
 - All speeds are **speed-through-water** (tidal current removed); observed
   speed-over-ground varies with current and heading.

--- a/bizzyboat_project11/docs/bizzyboat_hardware.md
+++ b/bizzyboat_project11/docs/bizzyboat_hardware.md
@@ -300,7 +300,7 @@ and [`../../docs/analysis/dynamics/`](../../docs/analysis/dynamics/)
 | Max reverse speed | ~1.4 m/s (2.7 kt) peak, provisional | sustained reverse under-sampled — see [#88](https://github.com/rolker/unh_echoboats_project11/issues/88) |
 | Yaw-rate cap (autonomy) | 1.0 rad/s (`helm_manager.max_yaw_speed`) | raised from 0.5 to the helm default = vehicle-capability backstop; ~0.9 rad/s pivot at full throttle; sustained cruise turn unvalidated |
 | Min turn radius @ cruise | ~1.5 m at the 1.0 cap | set by the yaw clamp; <1 m pivot at low speed |
-| Course-keeping (track-holding) | ~0.13 m RMS on straight legs | sub-decimeter; XTE vs commanded line ~0.5 m. Not survey-limiting |
+| Course-keeping (track-holding) | ~0.13 m RMS on straight legs | decimeter-scale; XTE vs commanded line ~0.5 m. Not survey-limiting |
 
 - All speeds are **speed-through-water** (tidal current removed); observed
   speed-over-ground varies with current and heading.

--- a/bizzyboat_project11/docs/bizzyboat_hardware.md
+++ b/bizzyboat_project11/docs/bizzyboat_hardware.md
@@ -281,6 +281,34 @@ drive the `mavros: Battery` diagnostic and annunciator indicators only.
 
 ---
 
+## Measured Performance
+
+Speed and acceleration measured from logged-bag analysis across 7 in-water
+deployments (2026-04-24 → 2026-05-22), current-corrected to
+speed-through-water (STW). Full method, per-deployment data, and
+reproducible scripts:
+[`../../docs/bizzyboat_performance.md`](../../docs/bizzyboat_performance.md)
+and [`../../docs/analysis/dynamics/`](../../docs/analysis/dynamics/)
+([#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §2).
+
+| Metric | Value | Notes |
+|---|---|---|
+| Max forward speed | ~1.9 m/s (3.7 kt) STW | full throttle (ESC PWM 2000) |
+| Cruise speed | ~1.52 m/s (3.0 kt) STW | PWM 1750–1850; well-determined |
+| Hard-launch acceleration | ~0.6 m/s² peak, τ ≈ 2.5 s | idle → full |
+| Coast-down deceleration | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s | passive; ~10–15 m to stop from cruise |
+| Max reverse speed | ~1.4 m/s (2.7 kt) peak, provisional | sustained reverse under-sampled — see [#88](https://github.com/rolker/unh_echoboats_project11/issues/88) |
+
+- All speeds are **speed-through-water** (tidal current removed); observed
+  speed-over-ground varies with current and heading.
+- Cruise (~1.5 m/s) sits comfortably above the manufacturer's declared
+  survey speed of 1 m/s (Batteries §, *Declared endurance*).
+- Reverse speed and deceleration / crash-stop braking distance are
+  provisional pending the controlled field experiment in
+  [#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
+
+---
+
 ## Autonomy Interface
 
 - FCU speaks MAVLink 2 via USB to the onboard PC (gabby).

--- a/bizzyboat_project11/docs/bizzyboat_hardware.md
+++ b/bizzyboat_project11/docs/bizzyboat_hardware.md
@@ -298,6 +298,8 @@ and [`../../docs/analysis/dynamics/`](../../docs/analysis/dynamics/)
 | Hard-launch acceleration | ~0.6 m/s² peak, τ ≈ 2.5 s | idle → full |
 | Coast-down deceleration | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s | passive; ~10–15 m to stop from cruise |
 | Max reverse speed | ~1.4 m/s (2.7 kt) peak, provisional | sustained reverse under-sampled — see [#88](https://github.com/rolker/unh_echoboats_project11/issues/88) |
+| Yaw-rate cap (autonomy) | 0.8 rad/s (`helm_manager.max_yaw_speed`) | raised from 0.5; vectored thrust → ~0.9 rad/s pivot at full throttle; sustained cruise turn unvalidated |
+| Min turn radius @ cruise | ~1.9 m at the 0.8 cap | set by the yaw clamp; <1 m pivot at low speed |
 
 - All speeds are **speed-through-water** (tidal current removed); observed
   speed-over-ground varies with current and heading.

--- a/bizzyboat_project11/docs/bizzyboat_hardware.md
+++ b/bizzyboat_project11/docs/bizzyboat_hardware.md
@@ -300,6 +300,7 @@ and [`../../docs/analysis/dynamics/`](../../docs/analysis/dynamics/)
 | Max reverse speed | ~1.4 m/s (2.7 kt) peak, provisional | sustained reverse under-sampled — see [#88](https://github.com/rolker/unh_echoboats_project11/issues/88) |
 | Yaw-rate cap (autonomy) | 1.0 rad/s (`helm_manager.max_yaw_speed`) | raised from 0.5 to the helm default = vehicle-capability backstop; ~0.9 rad/s pivot at full throttle; sustained cruise turn unvalidated |
 | Min turn radius @ cruise | ~1.5 m at the 1.0 cap | set by the yaw clamp; <1 m pivot at low speed |
+| Course-keeping (track-holding) | ~0.13 m RMS on straight legs | sub-decimeter; XTE vs commanded line ~0.5 m. Not survey-limiting |
 
 - All speeds are **speed-through-water** (tidal current removed); observed
   speed-over-ground varies with current and heading.

--- a/docs/analysis/dynamics/README.md
+++ b/docs/analysis/dynamics/README.md
@@ -12,6 +12,7 @@ acceleration/deceleration dynamics.
 |---|---|
 | [`dynamics.py`](dynamics.py) | Max/cruise speed (circle-fit current removal) + acceleration (first-order surge fit) per deployment. |
 | [`dynamics_extra.py`](dynamics_extra.py) | Battery↔STW correlation, coast-down deceleration, reverse bound. |
+| [`turning.py`](turning.py) | Turn rate by flight mode, steering-PWM→yaw effectiveness, turn radius (yaw-rate-cap analysis). |
 | [`queries.sql`](queries.sql) | Reference SQL: PWM-channel identification, in-water window, and the heading-contamination demonstration. |
 
 ## Method in one paragraph

--- a/docs/analysis/dynamics/README.md
+++ b/docs/analysis/dynamics/README.md
@@ -63,6 +63,11 @@ ros2 run bag_analysis bag_to_sqlite \
 # Run the analysis (uses the workspace venv: numpy/pandas/scipy)
 .venv/bin/python3 docs/analysis/dynamics/dynamics.py        # all deployments
 .venv/bin/python3 docs/analysis/dynamics/dynamics_extra.py  # battery/decel/reverse
+# turning.py + xte.py need the FULL <date>_deployment.db (turning.py uses
+# mavros/state; xte.py needs the plan + odom tables) — NOT the focused
+# *_nav.db topic list above. Run them against 05-01/21/22 deployment DBs:
+.venv/bin/python3 docs/analysis/dynamics/turning.py         # turn rate / steering / radius
+.venv/bin/python3 docs/analysis/dynamics/xte.py             # course-keeping (XTE)
 ```
 
 **Topic availability**: PWM (`rc/out`) and `gps_vel` are in every

--- a/docs/analysis/dynamics/README.md
+++ b/docs/analysis/dynamics/README.md
@@ -13,6 +13,7 @@ acceleration/deceleration dynamics.
 | [`dynamics.py`](dynamics.py) | Max/cruise speed (circle-fit current removal) + acceleration (first-order surge fit) per deployment. |
 | [`dynamics_extra.py`](dynamics_extra.py) | Battery↔STW correlation, coast-down deceleration, reverse bound. |
 | [`turning.py`](turning.py) | Turn rate by flight mode, steering-PWM→yaw effectiveness, turn radius (yaw-rate-cap analysis). |
+| [`xte.py`](xte.py) | Course-keeping on straight legs: track-holding precision (line-fit residual) + XTE vs the planned path. |
 | [`queries.sql`](queries.sql) | Reference SQL: PWM-channel identification, in-water window, and the heading-contamination demonstration. |
 
 ## Method in one paragraph

--- a/docs/analysis/dynamics/README.md
+++ b/docs/analysis/dynamics/README.md
@@ -1,0 +1,90 @@
+# BizzyBoat performance characterization — analysis tooling
+
+Reproducible analysis behind [`docs/bizzyboat_performance.md`](../../bizzyboat_performance.md)
+and [#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §2
+(Performance characterization). Pools 7 in-water deployments
+(2026-04-24 → 2026-05-22) to extract steady-state speed, current, and
+acceleration/deceleration dynamics.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| [`dynamics.py`](dynamics.py) | Max/cruise speed (circle-fit current removal) + acceleration (first-order surge fit) per deployment. |
+| [`dynamics_extra.py`](dynamics_extra.py) | Battery↔STW correlation, coast-down deceleration, reverse bound. |
+| [`queries.sql`](queries.sql) | Reference SQL: PWM-channel identification, in-water window, and the heading-contamination demonstration. |
+
+## Method in one paragraph
+
+All speed signals (`mavros/global_position/raw/gps_vel`,
+`mavros/local_position/velocity_body`) are **speed-over-ground**, so they
+contain tidal current. At a fixed throttle the boat's ground-velocity
+vector is `v_ground = STW·(heading unit) + current`; over many headings
+the `(east, north)` samples trace a **circle of radius STW centred on the
+current vector**. An algebraic (Kåsa) circle fit to the steady, straight,
+fixed-throttle cloud recovers speed-through-water *and* the current vector
+together — no per-pair heading matching. Acceleration uses a first-order
+surge model `v(t) = v∞·(1 − e^(−t/τ))` fitted to clean throttle steps;
+deceleration uses the mirror decay on throttle-to-idle chops.
+
+Throttle PWM is `mavros/rc/out.ch_0` (ESC; `ch_1` mirrors it; `ch_2`/`ch_3`
+are the vectored-thrust steering servos). The EKF `velocity_body` is used
+where present (2026-05-01 onward) and `gps_vel` elsewhere — both are the
+universal signals recorded in every deployment.
+
+## Reproducing — local-only artifacts
+
+The scripts read prebuilt per-deployment SQLite extracts from
+`~/data/logs/analysis/` on the dev workstation. They are **not** committed
+(0.5–3 GB each) but are regeneratable from the bags:
+
+```bash
+# Deployments with a full DB already (camera + everything): 05-01, 05-21, 05-22
+#   <date>_deployment.db
+
+# Deployments needing a focused nav extract (04-24/27/29, 05-19):
+#   <date>_nav.db  — small, nav/actuator topics only
+source .agent/scripts/setup.bash
+source layers/main/sensors_ws/install/setup.bash
+ros2 run bag_analysis bag_to_sqlite \
+  --bag ~/data/logs/bizzyboat/<date>T<first-session> \
+  --output ~/data/logs/analysis/<date>_nav.db \
+  --topics /bizzy/mavros/rc/out \
+           /bizzy/mavros/global_position/raw/gps_vel \
+           /bizzy/mavros/global_position/raw/fix \
+           /bizzy/mavros/local_position/velocity_body \
+           /bizzy/mavros/imu/data \
+           /bizzy/mavros/setpoint_velocity/cmd_vel \
+           /bizzy/piloting_mode/autonomous/cmd_vel
+# append each subsequent session of the same day with --append.
+
+# Run the analysis (uses the workspace venv: numpy/pandas/scipy)
+.venv/bin/python3 docs/analysis/dynamics/dynamics.py        # all deployments
+.venv/bin/python3 docs/analysis/dynamics/dynamics_extra.py  # battery/decel/reverse
+```
+
+**Topic availability**: PWM (`rc/out`) and `gps_vel` are in every
+deployment. The EKF `velocity_body` and SBG topics start at 2026-05-01;
+`global_position/global` (used for crane-edge window detection) is absent
+in April, so April nav DBs fall back to the full bag time-range.
+
+## NOAA current cross-check
+
+The fitted current vector is validated against NOAA CO-OPS predicted
+tidal current at station **ACT0731 (Clark Island)** — the main-channel
+station, not the side-pocket ACT0726. Station axis: flood→270° / ebb→85°.
+The two deployments whose windows straddled NOAA slack (05-22, 04-27) fit
+only ~0.1 m/s current (within those fits' rms); magnitudes are
+order-consistent on the others. Direction is
+approximate — the pier work area deviates from the main-channel axis, and
+direction is the circle fit's least-constrained parameter on partial arcs.
+
+## Follow-up
+
+The circle-fit / surge-fit logic should graduate into
+[`rolker/marine_tools`](https://github.com/rolker/marine_tools)'s
+`bag_analysis` package as a reusable `dynamics` extractor (same path the
+§1 `network_perlink.py` walker is slated to take). Controlled
+steady-hold / step / reverse / crash-stop runs to fill the high-throttle
+and reverse gaps are tracked in
+[#88](https://github.com/rolker/unh_echoboats_project11/issues/88).

--- a/docs/analysis/dynamics/dynamics.py
+++ b/docs/analysis/dynamics/dynamics.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""BizzyBoat performance characterization (unh_echoboats_project11#124 §2).
+
+Reusable across deployments. Universal signals present in every bag:
+  - PWM throttle : t_bizzy_mavros_rc_out.ch_0  (ESC; ch_1 mirrors)
+  - ground vel   : t_bizzy_mavros_global_position_raw_gps_vel  (ENU m/s)
+                   vel_x = east, vel_y = north  -> SOG, COG
+Higher-quality cross-check where present (05-01 onward):
+  - body twist   : t_bizzy_mavros_local_position_velocity_body (EKF, m/s)
+
+Current removal: at a fixed throttle the boat's ground-velocity vector is
+  v_ground = STW * (unit heading-through-water) + current
+so over many headings the (ve, vn) samples trace a circle of radius STW
+centred on the current vector. An algebraic circle fit to the steady,
+straight, fixed-throttle cloud yields STW (speed through water) and the
+current vector together -- no per-pair heading matching required.
+"""
+from __future__ import annotations
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import curve_fit
+
+MS_TO_KT = 1.94384
+ANALYSIS = Path.home() / "data/logs/analysis"
+
+
+def has_table(con, name):
+    return con.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone() is not None
+
+
+def circle_fit(ve, vn):
+    """Algebraic (Kasa) circle fit. Returns (cur_e, cur_n, R, rms, arc_deg)."""
+    ve = np.asarray(ve, float)
+    vn = np.asarray(vn, float)
+    A = np.c_[2 * ve, 2 * vn, np.ones(len(ve))]
+    b = ve ** 2 + vn ** 2
+    (ce, cn, c), *_ = np.linalg.lstsq(A, b, rcond=None)
+    R = float(np.sqrt(max(c + ce * ce + cn * cn, 0.0)))
+    rms = float(np.sqrt(np.mean(
+        (np.hypot(ve - ce, vn - cn) - R) ** 2)))
+    # heading coverage of the cloud relative to the fitted centre
+    ang = np.degrees(np.arctan2(vn - cn, ve - ce)) % 360
+    arc = _arc_span(ang)
+    return float(ce), float(cn), R, rms, arc
+
+
+def _arc_span(ang):
+    """Largest gap complement: how many degrees of arc the points span."""
+    s = np.sort(ang % 360)
+    if len(s) < 2:
+        return 0.0
+    gaps = np.diff(np.r_[s, s[0] + 360])
+    return float(360 - gaps.max())
+
+
+def load(db):
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    meta = dict(con.execute("SELECT key,value FROM _bag_meta").fetchall())
+    rc = pd.read_sql_query(
+        "SELECT t_ns, ch_0 AS pwm FROM t_bizzy_mavros_rc_out ORDER BY t_ns",
+        con)
+    gv = pd.read_sql_query(
+        "SELECT t_ns, vel_x AS ve, vel_y AS vn "
+        "FROM t_bizzy_mavros_global_position_raw_gps_vel ORDER BY t_ns", con)
+    vb = None
+    if has_table(con, "t_bizzy_mavros_local_position_velocity_body"):
+        vb = pd.read_sql_query(
+            "SELECT t_ns, vel_x, omega_z "
+            "FROM t_bizzy_mavros_local_position_velocity_body ORDER BY t_ns",
+            con)
+    con.close()
+
+    def _ns(key, default):
+        v = meta.get(key)
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return int(default)
+    lo = _ns("launch_t_ns", rc.t_ns.min())
+    hi = _ns("recovery_t_ns", rc.t_ns.max())
+    # Fall back to full bag range only when the launch/recovery detector
+    # produced a degenerate window (missing / 'null' / near-zero -- e.g.
+    # April bags lack /global altitude). 2 min guards a real short run
+    # from being expanded into on-deck/crane segments.
+    if hi - lo < 120e9:
+        lo, hi = int(rc.t_ns.min()), int(rc.t_ns.max())
+
+    def asof(left, right):
+        L = left.assign(_t=pd.to_datetime(left.t_ns, unit="ns"))
+        R = (right.assign(_t=pd.to_datetime(right.t_ns, unit="ns"))
+             .drop(columns="t_ns"))
+        m = pd.merge_asof(L.sort_values("_t"), R.sort_values("_t"),
+                          on="_t", direction="nearest",
+                          tolerance=pd.Timedelta("200ms"))
+        return m.drop(columns="_t")
+
+    d = asof(gv, rc)
+    if vb is not None:
+        d = asof(d, vb)
+    d = d[(d.t_ns >= lo) & (d.t_ns <= hi)].dropna(
+        subset=["pwm", "ve", "vn"]).reset_index(drop=True)
+    d["sog"] = np.hypot(d.ve, d.vn)
+    d["cog"] = np.degrees(np.arctan2(d.ve, d.vn)) % 360
+    return d, lo, hi
+
+
+def steady_straight(d, pwm_lo, pwm_hi, dt):
+    """Steady (stable PWM & SOG) and straight (low heading change) samples."""
+    w = max(3, int(round(3.0 / dt)))
+    pwm_ptp = d.pwm.rolling(w, center=True).apply(np.ptp, raw=True)
+    sog_std = d.sog.rolling(w, center=True).std()
+    # heading rate from COG (unwrapped) -- straight if it barely changes
+    cog_u = np.unwrap(np.radians(d.cog.values))
+    cog_rate = np.abs(np.gradient(cog_u, d.t_ns.values / 1e9))
+    m = ((d.pwm >= pwm_lo) & (d.pwm <= pwm_hi)
+         & (pwm_ptp <= 25) & (sog_std <= 0.07)
+         & (cog_rate < 0.1) & (d.sog > 0.05))
+    return d[m]
+
+
+def fit_speed(d, label, pwm_lo, pwm_hi, dt):
+    seg = steady_straight(d, pwm_lo, pwm_hi, dt)
+    if len(seg) < 40:
+        print(f"  {label:18s} pwm[{pwm_lo}-{pwm_hi}]: "
+              f"only {len(seg)} steady samples -- skip")
+        return None
+    ce, cn, R, rms, arc = circle_fit(seg.ve, seg.vn)
+    cur = np.hypot(ce, cn)
+    cur_dir = np.degrees(np.arctan2(ce, cn)) % 360  # compass set-direction
+    # naive (uncorrected) max/median SOG for contrast
+    print(f"  {label:18s} pwm[{pwm_lo}-{pwm_hi}] n={len(seg):5d} "
+          f"arc={arc:3.0f}deg | STW={R:.2f} m/s ({R*MS_TO_KT:.2f} kt) "
+          f"cur={cur:.2f} m/s twd {cur_dir:.0f}deg "
+          f"| rawSOG med={seg.sog.median():.2f} max={seg.sog.max():.2f} "
+          f"(rms {rms:.3f})")
+    return dict(label=label, n=len(seg), arc=arc, stw=R, cur=cur,
+                cur_dir=cur_dir, rms=rms, sog_med=seg.sog.median())
+
+
+def accel_fits(d, dt):
+    """First-order surge fits on clean throttle step-ups (strict gate)."""
+    w = max(3, int(round(3.0 / dt)))
+    pwm = d.pwm.values
+    t = d.t_ns.values
+    use_body = "vel_x" in d.columns and d.vel_x.notna().any()
+    v = (d.vel_x.values if use_body
+         else (d.sog.values * np.sign(d.pwm.values - 1500)))
+    out = []
+    i = w
+    while i < len(d) - 6 * w:
+        before = pwm[i - w:i].mean()
+        after = pwm[i + w:i + 4 * w].mean()
+        post_std = pwm[i + w:i + 6 * w].std()
+        # require a near-idle start (not a reverse-to-forward transition)
+        if 1470 <= before <= 1560 and (after - before) >= 200 \
+                and post_std < 40:
+            tt = (t[i:i + 6 * w] - t[i]) / 1e9
+            vv = v[i:i + 6 * w]
+            v0 = vv[0]
+            try:
+                def model(x, vinf, tau):
+                    return v0 + (vinf - v0) * (1 - np.exp(-x / tau))
+                p, _ = curve_fit(model, tt, vv, p0=[vv[-1], 3.0],
+                                 bounds=([v0 - 0.1, 0.3], [4.0, 25.0]))
+                vinf, tau = p
+                rms = np.sqrt(np.mean((model(tt, *p) - vv) ** 2))
+                if (vinf - v0) >= 0.5 and tau < 22 and rms < 0.12:
+                    out.append((after, vinf - v0, tau,
+                                (vinf - v0) / tau, rms))
+                    i += 6 * w
+                    continue
+            except Exception:
+                pass
+        i += w
+    return out, ("velocity_body" if use_body else "gps_vel(signed SOG)")
+
+
+def analyze(db):
+    label = Path(db).stem.replace("_deployment", "").replace("_nav", "")
+    d, lo, hi = load(db)
+    dt = float(np.median(np.diff(d.t_ns)) / 1e9)
+    dur = (hi - lo) / 3600e9
+    has_body = "vel_x" in d.columns
+    print(f"\n### {label}  ({dur:.2f} h, {len(d)} samples, ~{1/dt:.1f} Hz, "
+          f"body_vel={'yes' if has_body else 'NO'})")
+    print(" max-speed (circle-fit current removal):")
+    res = {}
+    res["fwd_max"] = fit_speed(d, "FWD max (>=1950)", 1950, 2000, dt)
+    res["fwd_mid"] = fit_speed(d, "FWD mid (1750-1850)", 1750, 1850, dt)
+    res["rev_max"] = fit_speed(d, "REV max (<=1100)", 1000, 1100, dt)
+    fits, vsrc = accel_fits(d, dt)
+    if fits:
+        arr = np.array(fits)  # cols: after_pwm, dV, tau, surge, rms
+        hard = arr[arr[:, 0] >= 1850]
+        ramp = arr[arr[:, 0] < 1850]
+        print(f" acceleration (src={vsrc}):")
+        if len(hard):
+            print(f"   hard launch (->pwm>=1850, n={len(hard)}): "
+                  f"peak surge med={np.median(hard[:, 3]):.2f} "
+                  f"max={hard[:, 3].max():.2f} m/s^2, "
+                  f"tau med={np.median(hard[:, 2]):.1f}s, "
+                  f"dV med={np.median(hard[:, 1]):.2f}")
+        if len(ramp):
+            print(f"   survey ramp (->pwm<1850, n={len(ramp)}): "
+                  f"peak surge med={np.median(ramp[:, 3]):.2f} m/s^2, "
+                  f"tau med={np.median(ramp[:, 2]):.1f}s, "
+                  f"dV med={np.median(ramp[:, 1]):.2f}")
+    else:
+        print(f" acceleration: no clean step-ups (src={vsrc})")
+    return label, res, fits
+
+
+if __name__ == "__main__":
+    # No args -> every available per-deployment DB (full + focused nav).
+    dbs = sys.argv[1:] or [
+        str(p) for p in (sorted(ANALYSIS.glob("2026-*_deployment.db"))
+                         + sorted(ANALYSIS.glob("2026-*_nav.db")))
+    ]
+    for db in dbs:
+        if Path(db).exists():
+            analyze(db)
+        else:
+            print(f"\n### {db}: MISSING")

--- a/docs/analysis/dynamics/dynamics.py
+++ b/docs/analysis/dynamics/dynamics.py
@@ -175,8 +175,8 @@ def accel_fits(d, dt):
                                 (vinf - v0) / tau, rms))
                     i += 6 * w
                     continue
-            except Exception:
-                pass
+            except (RuntimeError, ValueError):
+                pass  # curve_fit non-convergence / bad input = no clean event
         i += w
     return out, ("velocity_body" if use_body else "gps_vel(signed SOG)")
 

--- a/docs/analysis/dynamics/dynamics_extra.py
+++ b/docs/analysis/dynamics/dynamics_extra.py
@@ -96,8 +96,8 @@ def decel_fits(db, dt):
                     out.append(((v0 - vinf) / tau, tau, v0, vinf, rms))
                     i += 6 * w
                     continue
-            except Exception:
-                pass
+            except (RuntimeError, ValueError):
+                pass  # curve_fit non-convergence / bad input = no clean event
         i += w
     src = "velocity_body" if use_body else "gps_vel(SOG)"
     if out:

--- a/docs/analysis/dynamics/dynamics_extra.py
+++ b/docs/analysis/dynamics/dynamics_extra.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Battery-sag, deceleration, and reverse-bound analysis (#124 §2).
+
+Builds on dynamics.py. Voltage only -- BizzyBoat has no current meter
+(BatteryState.current is a ~0 placeholder); never report current/watts.
+"""
+from __future__ import annotations
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import curve_fit
+
+from dynamics import (ANALYSIS, MS_TO_KT, load, steady_straight, circle_fit,
+                      has_table)
+
+
+def load_voltage(db):
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    if not has_table(con, "t_bizzy_mavros_battery"):
+        con.close()
+        return None
+    v = pd.read_sql_query(
+        "SELECT t_ns, voltage FROM t_bizzy_mavros_battery "
+        "WHERE voltage > 0 ORDER BY t_ns", con)
+    con.close()
+    return v
+
+
+def merge_voltage(d, v):
+    L = d.assign(_t=pd.to_datetime(d.t_ns, unit="ns"))
+    R = (v.assign(_t=pd.to_datetime(v.t_ns, unit="ns")).drop(columns="t_ns"))
+    return pd.merge_asof(L.sort_values("_t"), R.sort_values("_t"),
+                         on="_t", direction="nearest",
+                         tolerance=pd.Timedelta("2s")).drop(columns="_t")
+
+
+def battery_vs_stw(db, dt):
+    """Time-binned full-throttle STW vs concurrent battery voltage."""
+    d, lo, hi = load(db)
+    v = load_voltage(db)
+    if v is None:
+        print("  (no battery topic)")
+        return
+    seg = steady_straight(d, 1950, 2000, dt)
+    if len(seg) < 120:
+        print(f"  full-throttle steady n={len(seg)} too few for time bins")
+        return
+    seg = merge_voltage(seg, v).dropna(subset=["voltage"])
+    seg = seg.sort_values("t_ns")
+    # split mission into 4 time quartiles of the full-throttle samples
+    seg["q"] = pd.qcut(seg.t_ns, 4, labels=False, duplicates="drop")
+    print("  quartile |  elapsed |  n  | mean V | STW(circle) | arc")
+    for q, g in seg.groupby("q"):
+        if len(g) < 40:
+            continue
+        ce, cn, R, rms, arc = circle_fit(g.ve, g.vn)
+        el0 = (g.t_ns.min() - lo) / 3600e9
+        el1 = (g.t_ns.max() - lo) / 3600e9
+        print(f"     {int(q)}    | {el0:.2f}-{el1:.2f}h | {len(g):4d} | "
+              f"{g.voltage.mean():.2f} V | {R:.2f} m/s ({R*MS_TO_KT:.2f} kt) "
+              f"| {arc:.0f}deg (rms {rms:.2f})")
+
+
+def decel_fits(db, dt):
+    """Coast-down: throttle chopped from high to idle -> first-order decay."""
+    d, lo, hi = load(db)
+    use_body = "vel_x" in d.columns and d.vel_x.notna().any()
+    v = d.vel_x.values if use_body else d.sog.values
+    pwm = d.pwm.values
+    t = d.t_ns.values
+    w = max(3, int(round(3.0 / dt)))
+    out = []
+    i = w
+    while i < len(d) - 6 * w:
+        before = pwm[i - w:i].mean()
+        after = pwm[i + w:i + 4 * w].mean()
+        post_std = pwm[i + w:i + 6 * w].std()
+        # chop to idle from a meaningfully higher throttle, then hold idle
+        if before > 1680 and 1470 <= after <= 1530 and post_std < 30:
+            tt = (t[i:i + 6 * w] - t[i]) / 1e9
+            vv = v[i:i + 6 * w]
+            v0 = vv[0]
+            if v0 < 0.4:
+                i += w
+                continue
+            try:
+                def model(x, vinf, tau):
+                    return vinf + (v0 - vinf) * np.exp(-x / tau)
+                p, _ = curve_fit(model, tt, vv, p0=[0.1, 3.0],
+                                 bounds=([-0.2, 0.3], [v0, 25.0]))
+                vinf, tau = p
+                rms = np.sqrt(np.mean((model(tt, *p) - vv) ** 2))
+                if (v0 - vinf) >= 0.4 and tau < 22 and rms < 0.12:
+                    out.append(((v0 - vinf) / tau, tau, v0, vinf, rms))
+                    i += 6 * w
+                    continue
+            except Exception:
+                pass
+        i += w
+    src = "velocity_body" if use_body else "gps_vel(SOG)"
+    if out:
+        a = np.array(out)
+        print(f"  coast-down ({len(out)} chops, src={src}): "
+              f"peak decel med={np.median(a[:, 0]):.2f} "
+              f"max={a[:, 0].max():.2f} "
+              f"m/s^2 | tau med={np.median(a[:, 1]):.1f}s | "
+              f"from v med={np.median(a[:, 2]):.2f} m/s")
+    else:
+        print(f"  coast-down: no clean chop events (src={src})")
+
+
+def reverse_bound(db):
+    d, lo, hi = load(db)
+    if "vel_x" not in d.columns:
+        # April: body-forward unavailable; use signed SOG at reverse throttle
+        rev = d[d.pwm <= 1150]
+        if len(rev):
+            print(f"  reverse: peak SOG at pwm<=1150 = {rev.sog.max():.2f} "
+                  f"m/s (heading-uncorrected; body-frame unavailable)")
+        return
+    rev = d[d.pwm <= 1150]
+    if len(rev):
+        peak_kt = abs(rev.vel_x.min()) * MS_TO_KT
+        full_rev_med = d[d.pwm <= 1050].vel_x.median()
+        print(f"  reverse: peak body vel_x = {rev.vel_x.min():.2f} m/s "
+              f"({peak_kt:.2f} kt); "
+              f"median at full-reverse(<=1050) = {full_rev_med:.2f} m/s "
+              f"[sustained straight reverse under-sampled]")
+
+
+def main():
+    full = {"2026-05-01": ANALYSIS / "2026-05-01_deployment.db",
+            "2026-05-21": ANALYSIS / "2026-05-21_deployment.db",
+            "2026-05-22": ANALYSIS / "2026-05-22_deployment.db"}
+    print("=== Battery sag: full-throttle STW vs voltage over the mission ===")
+    for name, db in full.items():
+        d, lo, hi = load(str(db))
+        dt = float(np.median(np.diff(d.t_ns)) / 1e9)
+        print(f"\n# {name}")
+        battery_vs_stw(str(db), dt)
+
+    print("\n=== Deceleration (coast-down) + reverse bound ===")
+    alldb = {**{"2026-04-27": ANALYSIS / "2026-04-27_nav.db"}, **full}
+    for name, db in alldb.items():
+        if not Path(db).exists():
+            continue
+        d, lo, hi = load(str(db))
+        dt = float(np.median(np.diff(d.t_ns)) / 1e9)
+        print(f"\n# {name}")
+        decel_fits(str(db), dt)
+        reverse_bound(str(db))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/analysis/dynamics/queries.sql
+++ b/docs/analysis/dynamics/queries.sql
@@ -1,0 +1,42 @@
+-- Reference SQL for BizzyBoat performance characterization (#124 §2).
+-- Run against a per-deployment extract, e.g. ~/data/logs/analysis/2026-05-01_deployment.db
+-- All times are nanoseconds since Unix epoch (UTC) in t_ns columns.
+-- The circle-fit / surge-fit analysis itself lives in dynamics.py /
+-- dynamics_extra.py (it needs least-squares, not expressible in SQL);
+-- these queries cover the parts that are.
+
+-- ============================================================================
+-- Throttle-channel identification
+-- ============================================================================
+-- ch_0/ch_1 are the two ESC (throttle) outputs and move together; ch_2/ch_3
+-- are the vectored-thrust steering servos (sit near 1500 centre). ch_0 is the
+-- throttle variable used throughout the analysis.
+SELECT 'ch_0' AS chan, MIN(ch_0), ROUND(AVG(ch_0)) avg, MAX(ch_0) FROM t_bizzy_mavros_rc_out
+UNION ALL SELECT 'ch_1', MIN(ch_1), ROUND(AVG(ch_1)), MAX(ch_1) FROM t_bizzy_mavros_rc_out
+UNION ALL SELECT 'ch_2', MIN(ch_2), ROUND(AVG(ch_2)), MAX(ch_2) FROM t_bizzy_mavros_rc_out
+UNION ALL SELECT 'ch_3', MIN(ch_3), ROUND(AVG(ch_3)), MAX(ch_3) FROM t_bizzy_mavros_rc_out;
+
+-- ============================================================================
+-- In-water window (where present)
+-- ============================================================================
+SELECT key, value FROM _bag_meta WHERE key IN ('launch_t_ns', 'recovery_t_ns');
+
+-- ============================================================================
+-- Heading-contamination demonstration (why current removal is required)
+-- ============================================================================
+-- At a FIXED full-throttle (ch_0 >= 1950) the raw speed-over-ground varies
+-- 3x with heading, because tidal current adds/subtracts along the leg. This
+-- is the artefact the circle fit removes: binning speed by PWM alone (the
+-- 2026-04-24 method) is biased by whatever heading mix the mission ran.
+-- COG bucket = compass octant of the gps_vel ENU vector (vel_x=E, vel_y=N).
+SELECT
+  CAST((DEGREES(ATAN2(vel_x, vel_y)) + 360) / 45 AS INTEGER) % 8 AS cog_octant,
+  COUNT(*)                                         AS n,
+  ROUND(AVG(SQRT(vel_x*vel_x + vel_y*vel_y)), 2)   AS sog_avg_ms,
+  ROUND(MAX(SQRT(vel_x*vel_x + vel_y*vel_y)), 2)   AS sog_max_ms
+FROM t_bizzy_mavros_global_position_raw_gps_vel gv
+JOIN t_bizzy_mavros_rc_out rc
+  ON rc.t_ns BETWEEN gv.t_ns - 100000000 AND gv.t_ns + 100000000
+WHERE rc.ch_0 >= 1950
+GROUP BY cog_octant
+ORDER BY cog_octant;

--- a/docs/analysis/dynamics/turning.py
+++ b/docs/analysis/dynamics/turning.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """BizzyBoat turning performance (#124 §2 turn-radius item).
 
-Question: the helm clamps cmd_vel angular.z at max_yaw_speed=0.5 rad/s
-(bizzyboat.yaml). Is that a placeholder, and what can the boat actually do?
+Question: the helm clamped cmd_vel angular.z at max_yaw_speed=0.5 rad/s
+during these deployments (bizzyboat.yaml; since raised to 1.0 — #124 §2).
+Was that a placeholder, and what can the boat actually do?
 
 Signals (05-01+ have velocity_body.omega_z = measured yaw rate):
   - yaw rate   : t_bizzy_mavros_local_position_velocity_body.omega_z (rad/s)
@@ -129,9 +130,9 @@ def analyze(db):
         peak_spd = float(d.loc[yr.idxmax(), "vel_x"])
         print(f"   peak |yaw| {yr.max():.2f} rad/s at spd "
               f"{peak_spd:.2f} m/s -> R={abs(peak_spd) / yr.max():.1f} m")
-    # radius the 0.5 clamp imposes at cruise vs physical
-    print(f" radius @ cruise 1.52 m/s: clamp(0.5)={1.52/0.5:.1f} m, "
-          f"@0.8 rad/s={1.52/0.8:.1f} m, @0.97={1.52/0.97:.1f} m")
+    # turn radius at cruise: old clamp vs new cap vs physical peak
+    print(f" radius @ cruise 1.52 m/s: old-clamp(0.5)={1.52/0.5:.1f} m, "
+          f"new-cap(1.0)={1.52/1.0:.1f} m, peak(0.97)={1.52/0.97:.1f} m")
 
 
 if __name__ == "__main__":

--- a/docs/analysis/dynamics/turning.py
+++ b/docs/analysis/dynamics/turning.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""BizzyBoat turning performance (#124 §2 turn-radius item).
+
+Question: the helm clamps cmd_vel angular.z at max_yaw_speed=0.5 rad/s
+(bizzyboat.yaml). Is that a placeholder, and what can the boat actually do?
+
+Signals (05-01+ have velocity_body.omega_z = measured yaw rate):
+  - yaw rate   : t_bizzy_mavros_local_position_velocity_body.omega_z (rad/s)
+  - speed      : same table vel_x (body-forward, m/s)
+  - steering   : t_bizzy_mavros_rc_out.ch_2  (servo PWM; ch_3 == ch_2)
+  - throttle   : ch_0
+  - mode       : t_bizzy_mavros_state.mode  (GUIDED clamped / MANUAL not)
+"""
+from __future__ import annotations
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ANALYSIS = Path.home() / "data/logs/analysis"
+
+
+def asof(left, right, tol="200ms", direction="nearest"):
+    L = left.assign(_t=pd.to_datetime(left.t_ns, unit="ns"))
+    R = (right.assign(_t=pd.to_datetime(right.t_ns, unit="ns"))
+         .drop(columns="t_ns"))
+    m = pd.merge_asof(L.sort_values("_t"), R.sort_values("_t"), on="_t",
+                      direction=direction, tolerance=pd.Timedelta(tol))
+    return m.drop(columns="_t")
+
+
+def load(db):
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    meta = dict(con.execute("SELECT key,value FROM _bag_meta").fetchall())
+    vb = pd.read_sql_query(
+        "SELECT t_ns, vel_x, omega_z FROM "
+        "t_bizzy_mavros_local_position_velocity_body ORDER BY t_ns", con)
+    rc = pd.read_sql_query(
+        "SELECT t_ns, ch_0 AS thr, ch_2 AS steer FROM "
+        "t_bizzy_mavros_rc_out ORDER BY t_ns", con)
+    has_state = con.execute(
+        "SELECT 1 FROM sqlite_master WHERE name='t_bizzy_mavros_state'"
+    ).fetchone()
+    st = (pd.read_sql_query(
+        "SELECT t_ns, mode FROM t_bizzy_mavros_state ORDER BY t_ns", con)
+        if has_state else None)
+    con.close()
+
+    def _ns(k, d):
+        try:
+            return int(meta[k])
+        except (KeyError, TypeError, ValueError):
+            return int(d)
+    lo = _ns("launch_t_ns", vb.t_ns.min())
+    hi = _ns("recovery_t_ns", vb.t_ns.max())
+    if hi - lo < 120e9:
+        lo, hi = int(vb.t_ns.min()), int(vb.t_ns.max())
+
+    d = asof(vb, rc)
+    if st is not None:
+        d = asof(d, st, tol="2s", direction="backward")
+    d = d[(d.t_ns >= lo) & (d.t_ns <= hi)].dropna(
+        subset=["omega_z", "steer"]).reset_index(drop=True)
+    return d
+
+
+def analyze(db):
+    label = Path(db).stem.replace("_deployment", "").replace("_nav", "")
+    d = load(db)
+    dt = float(np.median(np.diff(d.t_ns)) / 1e9)
+    print(f"\n### {label}  ({len(d)} samples, ~{1/dt:.1f} Hz)")
+
+    # --- 1. yaw rate by mode: clamped (GUIDED) vs physical (MANUAL) --------
+    if "mode" in d.columns:
+        print(" yaw rate |omega_z| by mode (rad/s):")
+        for mode, g in d.groupby("mode"):
+            if len(g) < 50 or mode in ("", None):
+                continue
+            w_abs = g.omega_z.abs()
+            print(f"   {mode:8s} n={len(g):6d}  "
+                  f"p99={w_abs.quantile(0.99):.2f}  max={w_abs.max():.2f}  "
+                  f"mean_spd={g.vel_x.mean():.2f}")
+
+    # --- 2. steering center (zero-yaw PWM) ---------------------------------
+    straight = d[(d.omega_z.abs() < 0.03) & (d.thr > 1600)]
+    center = straight.steer.median() if len(straight) > 50 else 1500.0
+    print(f" steering center (zero-yaw, fwd): {center:.0f} PWM")
+
+    # --- 3. vectored-thrust steering authority ----------------------------
+    # Steering turns the thrusters, so yaw moment ~ thrust(throttle) x
+    # sin(thruster angle). Throttle (thrust), NOT boat speed, is the driver
+    # (a rudder would need water flow; this pivots at zero speed).
+    d["defl"] = d.steer - center
+    d["defl_bin"] = (d.defl / 150).round() * 150
+    thr_edges = [1500, 1650, 1800, 2001]
+    thr_lbl = ["thr1500-1650", "thr1650-1800", "thr1800-2000"]
+    d["thr_bin"] = pd.cut(d.thr, thr_edges, labels=thr_lbl, right=False)
+    g = d[(d.defl.abs() <= 525) & d.thr_bin.notna()]
+    piv = g.pivot_table(values="omega_z", index="thr_bin",
+                        columns="defl_bin", aggfunc="median")
+    cnt = g.pivot_table(values="omega_z", index="thr_bin",
+                        columns="defl_bin", aggfunc="size")
+    piv = piv.where(cnt >= 25)  # blank cells with <25 samples
+    print(" median yaw (rad/s) by throttle x steering deflection (PWM):")
+    print(piv.round(2).to_string())
+    # demonstrate throttle (thrust) drives yaw at fixed steering:
+    fix = d[(d.defl.between(150, 350))]
+    print(" at fixed steering (+150..+350 PWM), yaw vs throttle:")
+    for lbl, gg in fix.groupby("thr_bin", observed=True):
+        if len(gg) >= 25:
+            print(f"   {lbl}: yaw={gg.omega_z.median():+.2f} rad/s "
+                  f"(n={len(gg)}, mean_spd={gg.vel_x.mean():.2f} m/s)")
+    pk = d.loc[d.omega_z.abs().idxmax()]
+    print(f" peak-yaw sample: |yaw|={abs(pk.omega_z):.2f} rad/s at "
+          f"thr={pk.thr:.0f}, defl={pk.defl:+.0f} PWM, spd={pk.vel_x:.2f} m/s "
+          f"-> vectored-thrust pivot, not speed-driven")
+
+    # --- 4. turn radius R = speed / |omega| on sustained turns -------------
+    yr = d.omega_z.abs()
+    sustained = d[(yr > 0.3) & (d.vel_x.abs() > 0.4)].copy()
+    if len(sustained):
+        sustained["R"] = sustained.vel_x.abs() / sustained.omega_z.abs()
+        print(f" sustained turns (|omega|>0.3, spd>0.4): n={len(sustained)}")
+        print(f"   turn radius: min={sustained.R.min():.1f} m  "
+              f"median={sustained.R.median():.1f} m  "
+              f"p10={sustained.R.quantile(0.10):.1f} m")
+        peak_spd = float(d.loc[yr.idxmax(), "vel_x"])
+        print(f"   peak |yaw| {yr.max():.2f} rad/s at spd "
+              f"{peak_spd:.2f} m/s -> R={abs(peak_spd) / yr.max():.1f} m")
+    # radius the 0.5 clamp imposes at cruise vs physical
+    print(f" radius @ cruise 1.52 m/s: clamp(0.5)={1.52/0.5:.1f} m, "
+          f"@0.8 rad/s={1.52/0.8:.1f} m, @0.97={1.52/0.97:.1f} m")
+
+
+if __name__ == "__main__":
+    dbs = sys.argv[1:] or [
+        str(p) for p in sorted(ANALYSIS.glob("2026-*_deployment.db"))]
+    for db in dbs:
+        if Path(db).exists():
+            analyze(db)

--- a/docs/analysis/dynamics/xte.py
+++ b/docs/analysis/dynamics/xte.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""BizzyBoat course-keeping / cross-track error on straight legs (#124 §2).
+
+True XTE: perpendicular distance from the boat's track to the planned path.
+The plan is published in `bizzy/map_tide` and odom in `bizzy/odom`; per the
+logged TF these frames are horizontally coincident (odom->map_tide
+translation = 0,0,-23.5 — vertical tide datum only), so plan x/y and odom
+x/y are directly comparable with no transform.
+
+Filtered to straight (low yaw rate), moving, GUIDED-mode samples — i.e.
+autonomous straight-line following, which is what "course-keeping" means.
+"""
+from __future__ import annotations
+import os
+import re
+import sqlite3
+import sys
+
+import numpy as np
+import pandas as pd
+
+ANALYSIS = os.path.expanduser("~/data/logs/analysis")
+_PT = re.compile(r"Point\(x=([-0-9.e]+), y=([-0-9.e]+)")
+
+
+def load(db):
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    meta = dict(con.execute("SELECT key,value FROM _bag_meta").fetchall())
+    odom = pd.read_sql_query(
+        "SELECT t_ns, pos_x, pos_y, vel_x, omega_z FROM t_bizzy_odom "
+        "ORDER BY t_ns", con)
+    plans = con.execute(
+        "SELECT t_ns, json FROM t_bizzy_plan WHERE json IS NOT NULL "
+        "AND length(json) > 50 ORDER BY t_ns").fetchall()
+    has_state = con.execute(
+        "SELECT 1 FROM sqlite_master WHERE name='t_bizzy_mavros_state'"
+    ).fetchone()
+    st = (pd.read_sql_query(
+        "SELECT t_ns, mode FROM t_bizzy_mavros_state ORDER BY t_ns", con)
+        if has_state else None)
+    con.close()
+
+    def _ns(k, d):
+        try:
+            return int(meta[k])
+        except (KeyError, TypeError, ValueError):
+            return int(d)
+    lo = _ns("launch_t_ns", odom.t_ns.min())
+    hi = _ns("recovery_t_ns", odom.t_ns.max())
+    if hi - lo < 120e9:
+        lo, hi = int(odom.t_ns.min()), int(odom.t_ns.max())
+
+    # parse each plan json -> Nx2 polyline of (x, y)
+    plan_t = np.array([t for t, _ in plans])
+    plan_xy = [np.array(_PT.findall(j), float) for _, j in plans]
+
+    if st is not None:
+        L = odom.assign(_t=pd.to_datetime(odom.t_ns, unit="ns"))
+        R = (st.assign(_t=pd.to_datetime(st.t_ns, unit="ns"))
+             .drop(columns="t_ns"))
+        odom = pd.merge_asof(L.sort_values("_t"), R.sort_values("_t"),
+                             on="_t", direction="backward",
+                             tolerance=pd.Timedelta("2s")).drop(columns="_t")
+    odom = odom[(odom.t_ns >= lo) & (odom.t_ns <= hi)].reset_index(drop=True)
+    return odom, plan_t, plan_xy
+
+
+def pt_to_polyline(px, py, poly):
+    """Min perpendicular distance from point(s) to a polyline (Nx2)."""
+    a = poly[:-1]
+    b = poly[1:]
+    ab = b - a
+    ab2 = (ab ** 2).sum(1)
+    ab2[ab2 == 0] = 1e-9
+    out = np.empty(len(px))
+    for i in range(len(px)):
+        ap = np.column_stack((px[i] - a[:, 0], py[i] - a[:, 1]))
+        t = np.clip((ap * ab).sum(1) / ab2, 0, 1)
+        proj = a + t[:, None] * ab
+        d = np.hypot(px[i] - proj[:, 0], py[i] - proj[:, 1])
+        out[i] = d.min()
+    return out
+
+
+def analyze(db):
+    label = os.path.basename(db).split("_")[0]
+    odom, plan_t, plan_xy = load(db)
+    dt = float(np.median(np.diff(odom.t_ns)) / 1e9)
+    # straight + moving + GUIDED
+    m = (odom.omega_z.abs() < 0.05) & (odom.vel_x > 0.5)
+    if "mode" in odom.columns:
+        m &= (odom["mode"] == "GUIDED")  # .mode is a DataFrame method!
+    seg = odom[m].copy()
+    print(f"\n### {label}: {len(seg)} straight/moving/GUIDED samples "
+          f"(~{1/dt:.0f} Hz)")
+    if len(seg) < 100 or len(plan_t) == 0:
+        print("  insufficient data")
+        return
+
+    # active plan index per sample (most recent plan at or before t_ns)
+    idx = np.searchsorted(plan_t, seg.t_ns.values, side="right") - 1
+    seg = seg[idx >= 0]
+    idx = idx[idx >= 0]
+    xte = np.empty(len(seg))
+    px = seg.pos_x.values
+    py = seg.pos_y.values
+    for pi in np.unique(idx):
+        poly = plan_xy[pi]
+        if len(poly) < 2:
+            xte[idx == pi] = np.nan
+            continue
+        sel = idx == pi
+        xte[sel] = pt_to_polyline(px[sel], py[sel], poly)
+    # Per-leg metrics on contiguous straight runs (gap > 2 s breaks a leg).
+    # Two measures per leg:
+    #   resid  = RMS perpendicular scatter about the leg's own best-fit line
+    #            (track-holding *precision*; plan-independent, robust).
+    #   planx  = RMS distance to the active planned path (adds bias from the
+    #            commanded line; noisier — stale/multi-line plan matching).
+    seg = seg.assign(xte=xte)
+    seg["run"] = (seg.t_ns.diff() > 2e9).cumsum()
+    legs = []
+    for _, g in seg.groupby("run"):
+        dur = (g.t_ns.iloc[-1] - g.t_ns.iloc[0]) / 1e9
+        if dur < 8 or len(g) < 30:
+            continue
+        xy = np.column_stack((g.pos_x.values, g.pos_y.values))
+        xy = xy - xy.mean(0)
+        # smaller-singular-vector projection = perpendicular residual
+        _, _, vt = np.linalg.svd(xy, full_matrices=False)
+        resid = xy @ vt[1]
+        gx = g.xte.values
+        gx = gx[np.isfinite(gx) & (gx < 10.0)]
+        legs.append((dur, np.sqrt(np.mean(resid ** 2)), resid.max(),
+                     np.sqrt(np.mean(gx ** 2)) if len(gx) else np.nan,
+                     len(g)))
+    if not legs:
+        print("  no sustained straight legs")
+        return
+    a = np.array(legs)  # dur, resid_rms, resid_max, planx_rms, n
+    print(f"  {len(legs)} straight legs >=8s | track-holding RMS (about own "
+          f"line): median={np.median(a[:, 1]):.2f} m, "
+          f"best={a[:, 1].min():.2f}, worst={a[:, 1].max():.2f}")
+    px_rms = a[np.isfinite(a[:, 3]), 3]
+    if len(px_rms):
+        print(f"  XTE vs planned path (incl. bias): median-leg-RMS="
+              f"{np.median(px_rms):.2f} m, worst={px_rms.max():.2f} m")
+
+
+if __name__ == "__main__":
+    dbs = sys.argv[1:] or [
+        f"{ANALYSIS}/2026-05-01_deployment.db",
+        f"{ANALYSIS}/2026-05-21_deployment.db",
+        f"{ANALYSIS}/2026-05-22_deployment.db",
+    ]
+    for db in dbs:
+        if os.path.exists(db):
+            analyze(db)

--- a/docs/bizzyboat_dynamics_2026-04-24.md
+++ b/docs/bizzyboat_dynamics_2026-04-24.md
@@ -1,5 +1,15 @@
 # BizzyBoat dynamics — preliminary findings (2026-04-24)
 
+> **Superseded for speed/current.** This single-deployment snapshot is *not*
+> current-corrected — its PWM→speed table is biased by the heading/current
+> mix of that day (see the heading-contamination note in
+> [`bizzyboat_performance.md`](bizzyboat_performance.md)). For
+> current-corrected speed and acceleration specs pooled across all
+> deployments, use [`bizzyboat_performance.md`](bizzyboat_performance.md)
+> ([#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §2).
+> This doc is retained as the original dated analysis and for its
+> efficiency / V-drop observations.
+
 Captured from analysis of the 2026-04-24 in-water bags (`~/data/logs/bizzyboat/`,
 five sessions covering 09:48–14:08 between crane deploy and recover). This is a
 *preliminary* characterization, not a calibration; gaps in the data are flagged

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -1,0 +1,155 @@
+# BizzyBoat performance characterization
+
+Current-corrected speed and acceleration/deceleration dynamics, pooled
+across 7 in-water deployments (2026-04-24 → 2026-05-22). This is a living
+document; numbers are derived from logged-bag analysis and are refined as
+deployments accumulate.
+
+- **Issue**: [#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §2 (Performance characterization)
+- **Reproducible analysis**: [`docs/analysis/dynamics/`](analysis/dynamics/) (method, scripts, regen recipe)
+- **Supersedes for speed**: [`docs/bizzyboat_dynamics_2026-04-24.md`](bizzyboat_dynamics_2026-04-24.md) (single-deployment, *not* current-corrected)
+- **Controlled-experiment follow-up**: [#88](https://github.com/rolker/unh_echoboats_project11/issues/88)
+
+## TL;DR specifications
+
+| Metric | Value | Confidence |
+|---|---|---|
+| **Max forward speed** | **~1.9 m/s (3.7 kt)** STW, full throttle | Good — two clean independent fits agree |
+| **Cruise speed** | **~1.52 m/s (3.0 kt)** STW @ PWM 1750–1850 | High — three clean fits agree exactly |
+| **Hard-launch acceleration** | **~0.6 m/s² peak**, τ ≈ 2.5 s (reaches ~1.6 m/s) | Moderate — few clean step events |
+| **Survey throttle ramp** | ~0.1 m/s², τ ≈ 8 s | Good |
+| **Coast-down deceleration** | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s (~10–15 m to stop from cruise) | Moderate |
+| **Max reverse speed** | ~1.4 m/s (2.7 kt) peak, briefly | Low — sustained reverse under-sampled |
+
+All speeds are **speed-through-water (STW)**, current-removed. Throttle is
+expressed as ESC PWM (`mavros/rc/out.ch_0`): 1500 = neutral, 2000 = full
+ahead, 1000 = full astern.
+
+## Why current removal matters
+
+Every speed signal on the boat (`gps_vel`, EKF `velocity_body`) is
+**speed-over-ground** and therefore contains tidal current. The effect is
+first-order, not a nuisance: at a *fixed* full throttle the raw
+speed-over-ground varies up to **3×** with heading (≈0.8 m/s upstream vs
+≈2.3 m/s downstream on 2026-05-01). Binning speed against PWM alone — the
+preliminary 2026-04-24 method — therefore measures whatever heading/current
+mix the mission happened to run, not the boat.
+
+The fix (see [`analysis/dynamics/`](analysis/dynamics/)): at a fixed throttle
+the ground-velocity vectors over varied headings trace a circle of radius =
+STW centred on the current vector. A circle fit recovers both. Fit quality
+tracks **heading-arc coverage and speed steadiness**, not current magnitude:
+the cleanest circles (rms ≤ 0.06 m/s) are the cruise fits, which pair a wide
+heading spread with stable speed. A weak-current full-throttle fit can still
+be noisy if its heading arc is partial.
+
+## Forward speed
+
+Circle-fit STW at full throttle (PWM 1950–2000) across deployments:
+
+| Deployment | STW | fit rms | fitted current | note |
+|---|---|---|---|---|
+| 2026-04-27 | **1.94 m/s (3.78 kt)** | 0.21 | 0.10 | |
+| 2026-05-21 | **1.91 m/s (3.71 kt)** | 0.14 | 0.47 | cleanest high-n fit |
+| 2026-05-22 | 1.55 m/s (3.01 kt) | 0.20 | 0.10 | noisier fit |
+| 2026-05-01 | 1.33 m/s (2.58 kt) | 0.20 | 0.61 | noisier, high current |
+
+(2026-04-24/29 and 05-19 had too few sustained full-throttle samples.)
+
+The two cleanest fits agree at **~1.9 m/s (3.7 kt)**, taken as the max
+forward STW. The lower values come from noisier fits (high current, partial
+heading arcs), **not** from a slower boat — see the battery note below.
+
+**Cruise (PWM 1750–1850)** is exceptionally well-determined — three
+independent *clean* fits (rms ≤ 0.06 m/s):
+
+| Deployment | STW | fit rms |
+|---|---|---|
+| 2026-04-29 | 1.51 m/s | 0.050 |
+| 2026-05-19 | 1.53 m/s | 0.059 |
+| 2026-05-21 | 1.53 m/s | 0.058 |
+
+→ **~1.52 m/s (3.0 kt)**. The intermediate PWM band (1550–1750) is not
+cleanly resolved from opportunistic survey data (insufficient heading
+diversity at fixed sub-cruise throttle); the controlled steady-hold runs in
+[#88](https://github.com/rolker/unh_echoboats_project11/issues/88) are the
+way to fill in the curve between idle, cruise, and full.
+
+### Battery sag — tested, not detected
+
+The full-throttle spread (1.33–1.94 m/s) was hypothesised to be battery
+voltage sag over long missions. **It is not supported by the data**:
+within-mission full-throttle STW does not track voltage, and across
+deployments the gross voltage difference does not either (2026-05-22 ran at
+22–23 V yet its STW sits *between* the 26–27 V days). The spread is
+fit-quality-driven. BizzyBoat has no current meter, so true electrical power
+is unmeasurable; only battery voltage is logged (and used here as context,
+never as power).
+
+## Acceleration
+
+First-order surge fits `v(t) = v∞·(1 − e^(−t/τ))` on clean throttle steps
+(EKF `velocity_body`, 2026-05-01+):
+
+- **Hard launch (idle → full throttle)**: peak surge **≈0.6 m/s²**,
+  τ ≈ 2.5 s, settling near ~1.6 m/s. Consistent across the (few) clean
+  launch events.
+- **Gentle survey throttle ramp**: peak surge ≈0.1 m/s², τ ≈ 8 s.
+
+## Deceleration
+
+Coast-down (throttle chopped to neutral, passive drag only), first-order
+decay fit:
+
+- Peak deceleration **~0.15 m/s²** (median; up to ~0.25), τ ≈ 9–10 s,
+  from a cruise of ~1.5 m/s.
+- Implication: passive stopping distance is **~10–15 m** from cruise. **The
+  boat does not stop quickly on throttle-off** — fast stops require active
+  reverse thrust, which is the braking authority and is under-characterised
+  (see Reverse).
+
+## Reverse
+
+Reverse is under-determined. The boat rarely holds a straight reverse
+heading, so the circle fit starves (no heading diversity). What the data
+bounds:
+
+- **Peak reverse**: body-frame ~1.4 m/s (2.7 kt) reached *briefly*
+  (−1.37 m/s on 05-01, −1.42 on 05-21).
+- Sustained straight-reverse STW is not reliably measurable from
+  opportunistic data.
+
+A dedicated straight-reverse + crash-stop run is needed for a firm reverse
+spec and braking distance — folded into
+[#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
+
+## Tidal current — magnitudes, NOAA-validated
+
+The fitted current vectors (0 – 0.6 m/s across deployments) are validated
+against NOAA CO-OPS predictions at station ACT0731 (Clark Island):
+
+- The two deployments whose windows straddled NOAA **slack water**
+  (2026-05-22, 2026-04-27) fit only **~0.1 m/s** current (within these
+  fits' ~0.2 m/s rms) — consistent with the method tracking genuine tide
+  rather than imposing a spurious offset.
+- Magnitudes are order-consistent on the flooding/ebbing days.
+- Direction is approximate (fitted vectors rotate off the 270°/85° channel
+  axis): the pier work area deviates from the main-channel station, and
+  direction is the circle fit's least-constrained parameter on partial arcs.
+
+## Resolved: "1.5 m/s commanded, ~1.0 m/s tracked"
+
+The standing observation from the 2026-05-01 mission (#124) — autonomy
+commanding 1.5 m/s while the boat tracked ~1.0 m/s — is explained: on
+upstream survey legs a ~0.5–0.6 m/s current subtracts directly from
+speed-over-ground, and at full throttle the boat's STW ceiling left no
+headroom to compensate. It is **current plus throttle ceiling, not an
+autonomy/controller cap**.
+
+## Open gaps (→ #88)
+
+- Intermediate PWM→speed points (1550–1750) via steady-hold runs.
+- High-throttle tail with deliberate reciprocal legs (cleaner max STW).
+- Straight-reverse speed and active crash-stop braking distance.
+- Graduate the circle-fit / surge-fit tooling into `marine_tools`
+  `bag_analysis` as a reusable `dynamics` extractor.

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -20,6 +20,8 @@ deployments accumulate.
 | **Survey throttle ramp** | ~0.1 m/s², τ ≈ 8 s | Good |
 | **Coast-down deceleration** | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s (~10–15 m to stop from cruise) | Moderate |
 | **Max reverse speed** | ~1.4 m/s (2.7 kt) peak, briefly | Low — sustained reverse under-sampled |
+| **Yaw-rate cap (autonomy)** | **0.8 rad/s** (raised from 0.5) | config clamp; ~0.9 rad/s pivot at full throttle (vectored thrust) |
+| **Min turn radius @ cruise** | ~1.9 m at the 0.8 cap (was ~3 m at 0.5) | set by the yaw clamp, not the hull |
 
 All speeds are **speed-through-water (STW)**, current-removed. Throttle is
 expressed as ESC PWM (`mavros/rc/out.ch_0`): 1500 = neutral, 2000 = full
@@ -123,6 +125,82 @@ A dedicated straight-reverse + crash-stop run is needed for a firm reverse
 spec and braking distance — folded into
 [#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
 
+## Turning
+
+Analysis in [`analysis/dynamics/turning.py`](analysis/dynamics/turning.py),
+using the EKF yaw rate (`velocity_body.omega_z`), steering servo PWM
+(`rc/out.ch_2`; `ch_3` is bit-identical — a single slaved steering DOF),
+and flight mode (`mavros/state`).
+
+Steering is **vectored thrust** — the thrusters themselves rotate (servos
+`ch_2`/`ch_3`, bit-identical = one slaved steering DOF), there is no rudder.
+So yaw authority comes from **thrust × steering angle**, not from water flow
+over a control surface, and works at any boat speed.
+
+### The yaw-rate cap and how binding it is
+
+The helm clamps `cmd_vel.angular.z` to `max_yaw_speed`, which `bizzyboat.yaml`
+set to **0.5 rad/s** (the helm's own default is 1.0; sim nodes hardcode 0.5).
+0.5 was not a tuned-to-capability value: per the deployment log it was
+reduced 1.5 → 0.5 during an April steering-direction-reversal investigation
+(for steering "range/resolution"). That reversal is a **stationary
+controls-check artifact** — it still occurs with the boat on the trailer
+(no yaw feedback, suspected `PILOT_STEER_TYPE=0` PID windup) and is
+**orthogonal to this parameter**; on-water steering has been sound across
+clean autonomous missions.
+
+The cap is **binding**: the crabbing path-follower emits raw heading error
+as `angular.z` (range ±π, no proportional shaping), and the fraction of
+nonzero yaw commands pinned at the 0.5 ceiling ranges **8% (05-01) to 39%
+(05-22)** across deployments (~21% pooled) — so the clamp directly sets
+line-transition sharpness ("turn at max until aligned").
+
+### Yaw authority is thrust-driven (PWM as steering-angle proxy)
+
+Median yaw rate (rad/s) by throttle × steering deflection (`ch_2 − ~1435`
+centre; full deflection ±~500):
+
+| throttle | full-left (−450) | centre | full-right (+450) |
+|---|---|---|---|
+| idle (1500–1650) | ≈ 0 | 0 | ≈ 0 |
+| mid (1650–1800) | −0.15 | 0 | +0.18 |
+| full (1800–2000) | −0.32 to −0.43 | 0 | +0.35 to +0.44 |
+
+At **idle, full steering yields ~zero yaw** (no thrust to vector); at **full
+throttle, steering yields strong yaw even at zero speed** — the peak sample
+is **0.91 rad/s at full throttle + near-full steering + 0.08 m/s** (pivoting
+in place). This is the vectored-thrust signature: turning authority scales
+with thrust, not speed.
+
+### What that means at cruise
+
+In GUIDED the achieved yaw is gated at the clamp (cruise p99 0.39–0.45);
+**unclamped MANUAL turns reached 0.74 rad/s at cruise** (speeds to ~1.8 m/s),
+so the boat *does* exceed 0.5 at speed — what's missing is a *sustained
+commanded* turn at the higher rate. Because vectoring thrust to turn diverts
+it from forward, the boat **slows into a hard turn** (and lower speed means
+*more* yaw authority, not less — no rudder-style stall). Turn radius is
+therefore set by the yaw clamp, not the hull: ~3 m at cruise under 0.5,
+~1.9 m under 0.8.
+
+### Change applied + caveat
+
+`max_yaw_speed` raised **0.5 → 0.8 rad/s**. 0.8 sits below the demonstrated
+full-throttle authority (~0.9 pivot) and above the MANUAL cruise transient
+(0.74), and the vectored-thrust mechanism means there is no speed-dependent
+stall to worry about. **Still validate on the next deployment**: confirm
+GUIDED cruise turns track the higher command without oscillation, and watch
+steering-direction consistency at the higher rate (given the stationary
+reversal history). Also weigh the survey-quality tradeoff (tighter
+line-transitions vs. sonar settling on the new line). A controlled
+yaw-vs-throttle sweep is folded into
+[#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
+
+This governs the **crabbing-follower → helm** path observed driving the
+boat; if the stack switches to the Nav2 path (`cmd_vel_nav` → velocity
+smoother → `cmd_vel_smoothed`), that smoother's angular limit would also
+need raising.
+
 ## Tidal current — magnitudes, NOAA-validated
 
 The fitted current vectors (0 – 0.6 m/s across deployments) are validated
@@ -151,5 +229,8 @@ autonomy/controller cap**.
 - Intermediate PWM→speed points (1550–1750) via steady-hold runs.
 - High-throttle tail with deliberate reciprocal legs (cleaner max STW).
 - Straight-reverse speed and active crash-stop braking distance.
+- **Yaw-rate vs steering vs speed sweep** — validate the raised 0.8 rad/s
+  cap at cruise (commanded step-turns in a safe area); the clamp gated this
+  in all logged data.
 - Graduate the circle-fit / surge-fit tooling into `marine_tools`
   `bag_analysis` as a reusable `dynamics` extractor.

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -195,16 +195,18 @@ oscillation, and watch steering-direction consistency at the higher rate
 (given the stationary reversal history). A controlled yaw-vs-throttle sweep
 is folded into [#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
 
-**Survey-turn gentleness is now unenforced — known gap.** A "turn gently for
-survey lines" limit belongs at the Nav2 layer, not the helm. Bizzy's
-(EchoBoat-inherited) Nav2 config *does* set the velocity_smoother angular
-`max_velocity = 0.45 rad/s`, but the logged data shows it was **not binding**
-(the FCU clamped at exactly the helm value, never 0.45, and the crabbing
-follower emits raw ±π with no shaping). So with the helm opened to 1.0,
-nothing effective currently bounds line-transition sharpness. Making the
-smoother's survey limit actually bind — and giving Bizzy its own Nav2
-override instead of inheriting the EchoBoat's (which also carries a 2.75 m/s
-linear limit vs Bizzy's ~1.9 m/s) — is a deferred follow-up (see Open gaps).
+**Survey-turn gentleness is currently unenforced — by design, for now.** A
+"turn gently for survey lines" limit belongs at the Nav2 layer, not the helm.
+The cmd_vel filter chain that would host it — the **velocity_smoother and
+other cmd_vel filters were deliberately disconnected during an earlier
+boat-troubleshooting pass** — so the helm clamp is presently the *sole*
+cmd_vel governor. (Consistent with the logs: the FCU clamped at exactly the
+helm value, never the smoother's configured 0.45, and the crabbing follower
+emits raw ±π with no shaping.) So with the helm opened to 1.0, nothing bounds
+line-transition sharpness right now. Re-enabling the filter chain and siting
+the survey yaw limit in the smoother — ideally with a Bizzy-specific Nav2
+config rather than the inherited EchoBoat one — is deferred until there's a
+real need (see Open gaps).
 
 ## Tidal current — magnitudes, NOAA-validated
 
@@ -237,8 +239,10 @@ autonomy/controller cap**.
 - **Yaw-rate vs throttle sweep** — validate the raised 1.0 rad/s cap at
   cruise (commanded step-turns in a safe area); the clamp gated this in all
   logged data.
-- **Restore an effective survey-turn limit** at the Nav2 layer: make the
-  velocity_smoother angular limit actually bind on Bizzy's path, and give
-  Bizzy its own Nav2 config instead of inheriting the EchoBoat's.
+- **If/when a real need arises** (survey-turn gentleness or cmd_vel
+  smoothing): re-enable the cmd_vel filter chain (velocity_smoother et al.,
+  deliberately disconnected during earlier troubleshooting) and site the
+  survey yaw limit in the smoother, with a Bizzy-specific Nav2 config rather
+  than the inherited EchoBoat one. No action unless needed.
 - Graduate the circle-fit / surge-fit tooling into `marine_tools`
   `bag_analysis` as a reusable `dynamics` extractor.

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -20,8 +20,8 @@ deployments accumulate.
 | **Survey throttle ramp** | ~0.1 m/s², τ ≈ 8 s | Good |
 | **Coast-down deceleration** | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s (~10–15 m to stop from cruise) | Moderate |
 | **Max reverse speed** | ~1.4 m/s (2.7 kt) peak, briefly | Low — sustained reverse under-sampled |
-| **Yaw-rate cap (autonomy)** | **0.8 rad/s** (raised from 0.5) | config clamp; ~0.9 rad/s pivot at full throttle (vectored thrust) |
-| **Min turn radius @ cruise** | ~1.9 m at the 0.8 cap (was ~3 m at 0.5) | set by the yaw clamp, not the hull |
+| **Yaw-rate cap (autonomy)** | **1.0 rad/s** (raised from 0.5; = helm default) | vehicle-capability backstop; ~0.9 rad/s pivot at full throttle (vectored thrust) |
+| **Min turn radius @ cruise** | ~1.5 m at the 1.0 cap (was ~3 m at 0.5) | set by the yaw clamp, not the hull |
 
 All speeds are **speed-through-water (STW)**, current-removed. Throttle is
 expressed as ESC PWM (`mavros/rc/out.ch_0`): 1500 = neutral, 2000 = full
@@ -181,25 +181,30 @@ commanded* turn at the higher rate. Because vectoring thrust to turn diverts
 it from forward, the boat **slows into a hard turn** (and lower speed means
 *more* yaw authority, not less — no rudder-style stall). Turn radius is
 therefore set by the yaw clamp, not the hull: ~3 m at cruise under 0.5,
-~1.9 m under 0.8.
+~1.5 m under the new 1.0 cap.
 
 ### Change applied + caveat
 
-`max_yaw_speed` raised **0.5 → 0.8 rad/s**. 0.8 sits below the demonstrated
-full-throttle authority (~0.9 pivot) and above the MANUAL cruise transient
-(0.74), and the vectored-thrust mechanism means there is no speed-dependent
-stall to worry about. **Still validate on the next deployment**: confirm
-GUIDED cruise turns track the higher command without oscillation, and watch
-steering-direction consistency at the higher rate (given the stationary
-reversal history). Also weigh the survey-quality tradeoff (tighter
-line-transitions vs. sonar settling on the new line). A controlled
-yaw-vs-throttle sweep is folded into
-[#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
+`max_yaw_speed` raised **0.5 → 1.0 rad/s** — i.e. set to the helm's own
+default, treating this clamp as the **vehicle-capability backstop** rather
+than an operational limit. 1.0 sits just above the demonstrated peak (~0.9
+pivot, 0.97 raw), so the helm now rarely clamps — the boat turns as hard as
+it can, with no speed-dependent stall (vectored thrust). **Validate on the
+next deployment**: confirm GUIDED cruise turns track the command without
+oscillation, and watch steering-direction consistency at the higher rate
+(given the stationary reversal history). A controlled yaw-vs-throttle sweep
+is folded into [#88](https://github.com/rolker/unh_echoboats_project11/issues/88).
 
-This governs the **crabbing-follower → helm** path observed driving the
-boat; if the stack switches to the Nav2 path (`cmd_vel_nav` → velocity
-smoother → `cmd_vel_smoothed`), that smoother's angular limit would also
-need raising.
+**Survey-turn gentleness is now unenforced — known gap.** A "turn gently for
+survey lines" limit belongs at the Nav2 layer, not the helm. Bizzy's
+(EchoBoat-inherited) Nav2 config *does* set the velocity_smoother angular
+`max_velocity = 0.45 rad/s`, but the logged data shows it was **not binding**
+(the FCU clamped at exactly the helm value, never 0.45, and the crabbing
+follower emits raw ±π with no shaping). So with the helm opened to 1.0,
+nothing effective currently bounds line-transition sharpness. Making the
+smoother's survey limit actually bind — and giving Bizzy its own Nav2
+override instead of inheriting the EchoBoat's (which also carries a 2.75 m/s
+linear limit vs Bizzy's ~1.9 m/s) — is a deferred follow-up (see Open gaps).
 
 ## Tidal current — magnitudes, NOAA-validated
 
@@ -229,8 +234,11 @@ autonomy/controller cap**.
 - Intermediate PWM→speed points (1550–1750) via steady-hold runs.
 - High-throttle tail with deliberate reciprocal legs (cleaner max STW).
 - Straight-reverse speed and active crash-stop braking distance.
-- **Yaw-rate vs steering vs speed sweep** — validate the raised 0.8 rad/s
-  cap at cruise (commanded step-turns in a safe area); the clamp gated this
-  in all logged data.
+- **Yaw-rate vs throttle sweep** — validate the raised 1.0 rad/s cap at
+  cruise (commanded step-turns in a safe area); the clamp gated this in all
+  logged data.
+- **Restore an effective survey-turn limit** at the Nav2 layer: make the
+  velocity_smoother angular limit actually bind on Bizzy's path, and give
+  Bizzy its own Nav2 config instead of inheriting the EchoBoat's.
 - Graduate the circle-fit / surge-fit tooling into `marine_tools`
   `bag_analysis` as a reusable `dynamics` extractor.

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -140,8 +140,10 @@ over a control surface, and works at any boat speed.
 
 ### The yaw-rate cap and how binding it is
 
-The helm clamps `cmd_vel.angular.z` to `max_yaw_speed`, which `bizzyboat.yaml`
-set to **0.5 rad/s** (the helm's own default is 1.0; sim nodes hardcode 0.5).
+During the analyzed deployments the helm clamped `cmd_vel.angular.z` to
+`max_yaw_speed` = **0.5 rad/s** (`bizzyboat.yaml`; the helm's own default is
+1.0, sim nodes hardcode 0.5) — **since raised to 1.0** (see *Change applied*
+below).
 0.5 was not a tuned-to-capability value: per the deployment log it was
 reduced 1.5 → 0.5 during an April steering-direction-reversal investigation
 (for steering "range/resolution"). That reversal is a **stationary

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -22,6 +22,7 @@ deployments accumulate.
 | **Max reverse speed** | ~1.4 m/s (2.7 kt) peak, briefly | Low — sustained reverse under-sampled |
 | **Yaw-rate cap (autonomy)** | **1.0 rad/s** (raised from 0.5; = helm default) | vehicle-capability backstop; ~0.9 rad/s pivot at full throttle (vectored thrust) |
 | **Min turn radius @ cruise** | ~1.5 m (was ~3 m) | governed by planner `minimum_turning_radius` 3.0→1.5 m; helm 1.0 cap now aligns |
+| **Course-keeping (track-holding)** | **~0.13 m RMS** on straight legs | sub-decimeter; not a survey-limiting factor (XTE vs commanded line ~0.5 m) |
 
 All speeds are **speed-through-water (STW)**, current-removed. Throttle is
 expressed as ESC PWM (`mavros/rc/out.ch_0`): 1500 = neutral, 2000 = full
@@ -218,6 +219,29 @@ line-transition sharpness right now. Re-enabling the filter chain and siting
 the survey yaw limit in the smoother — ideally with a Bizzy-specific Nav2
 config rather than the inherited EchoBoat one — is deferred until there's a
 real need (see Open gaps).
+
+## Course-keeping (XTE on straight legs)
+
+Analysis in [`analysis/dynamics/xte.py`](analysis/dynamics/xte.py), over
+straight, moving, GUIDED-mode legs (≥8 s) across 05-01 / 05-21 / 05-22. Two
+measures per leg:
+
+- **Track-holding precision** — RMS perpendicular scatter about the leg's own
+  best-fit line (plan-independent; how *steadily* it holds a straight line):
+  **~0.13 m RMS median** (best legs ~0.02 m, worst ~1.4 m), and remarkably
+  **consistent across all three deployments**. The boat holds a line to ~0.1 m
+  — course-keeping is *not* a survey-limiting factor.
+- **XTE vs the commanded line** — RMS distance to the active `/bizzy/plan`
+  (the plan's `map_tide` frame and odom are horizontally coincident per the
+  logged TF — `odom→map_tide` translation is `(0, 0, −23.5)`, vertical datum
+  only — so no transform needed): **median-leg-RMS ~0.4–0.8 m**, broadly
+  sub-meter and consistent with the preliminary 04-24 observation
+  ("sub-meter, max 0.61 m"). This adds the constant cross-track *bias* the
+  track-holding metric fits out, but is noisier — its high tail (worst ~10 m)
+  is plan-matching artifact (stale / adjacent-line), not real wander.
+
+Net: tight track-holding (~0.13 m precision), sub-meter absolute accuracy to
+the commanded line. Comfortably within survey line-spacing tolerances.
 
 ## Tidal current — magnitudes, NOAA-validated
 

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -22,7 +22,7 @@ deployments accumulate.
 | **Max reverse speed** | ~1.4 m/s (2.7 kt) peak, briefly | Low — sustained reverse under-sampled |
 | **Yaw-rate cap (autonomy)** | **1.0 rad/s** (raised from 0.5; = helm default) | vehicle-capability backstop; ~0.9 rad/s pivot at full throttle (vectored thrust) |
 | **Min turn radius @ cruise** | ~1.5 m (was ~3 m) | governed by planner `minimum_turning_radius` 3.0→1.5 m; helm 1.0 cap now aligns |
-| **Course-keeping (track-holding)** | **~0.13 m RMS** on straight legs | sub-decimeter; not a survey-limiting factor (XTE vs commanded line ~0.5 m) |
+| **Course-keeping (track-holding)** | **~0.13 m RMS** on straight legs | decimeter-scale; not a survey-limiting factor (XTE vs commanded line ~0.5 m) |
 
 All speeds are **speed-through-water (STW)**, current-removed. Throttle is
 expressed as ESC PWM (`mavros/rc/out.ch_0`): 1500 = neutral, 2000 = full

--- a/docs/bizzyboat_performance.md
+++ b/docs/bizzyboat_performance.md
@@ -21,7 +21,7 @@ deployments accumulate.
 | **Coast-down deceleration** | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s (~10–15 m to stop from cruise) | Moderate |
 | **Max reverse speed** | ~1.4 m/s (2.7 kt) peak, briefly | Low — sustained reverse under-sampled |
 | **Yaw-rate cap (autonomy)** | **1.0 rad/s** (raised from 0.5; = helm default) | vehicle-capability backstop; ~0.9 rad/s pivot at full throttle (vectored thrust) |
-| **Min turn radius @ cruise** | ~1.5 m at the 1.0 cap (was ~3 m at 0.5) | set by the yaw clamp, not the hull |
+| **Min turn radius @ cruise** | ~1.5 m (was ~3 m) | governed by planner `minimum_turning_radius` 3.0→1.5 m; helm 1.0 cap now aligns |
 
 All speeds are **speed-through-water (STW)**, current-removed. Throttle is
 expressed as ESC PWM (`mavros/rc/out.ch_0`): 1500 = neutral, 2000 = full
@@ -179,9 +179,20 @@ In GUIDED the achieved yaw is gated at the clamp (cruise p99 0.39–0.45);
 so the boat *does* exceed 0.5 at speed — what's missing is a *sustained
 commanded* turn at the higher rate. Because vectoring thrust to turn diverts
 it from forward, the boat **slows into a hard turn** (and lower speed means
-*more* yaw authority, not less — no rudder-style stall). Turn radius is
-therefore set by the yaw clamp, not the hull: ~3 m at cruise under 0.5,
-~1.5 m under the new 1.0 cap.
+*more* yaw authority, not less — no rudder-style stall).
+
+For **Nav2-planned** motion the binding constraint is not the helm clamp but
+the planner's `minimum_turning_radius` (`SmacPlannerHybrid`): a planned arc
+that radius wide never demands more yaw than `v / R`. It was **3.0 m**
+(≈ 0.5 rad/s at cruise — which exactly matched the *old* helm clamp) and has
+been **reduced to 1.5 m** ([seafloor_echoboat_project11#24](https://github.com/rolker/seafloor_echoboat_project11/pull/24),
+shared config) ≈ 1.0 rad/s at cruise — now aligned with the raised helm cap.
+So planned line-transitions tighten from ~3 m to ~1.5 m; the helm cap only
+bites on heading-error transients, hover, and manual. (Whether the Smac
+planner is actually in the loop for survey line-transitions vs. the trackline
+being fed straight to the follower is unconfirmed from logs — the filter
+chain was disconnected during troubleshooting — so verify on the next
+deployment.)
 
 ### Change applied + caveat
 

--- a/docs/logs/2026/2026-05-01_dev_logs.md
+++ b/docs/logs/2026/2026-05-01_dev_logs.md
@@ -1758,9 +1758,47 @@ Full trail at [`docs/analysis/2026-05-01/`](../../analysis/2026-05-01/) — star
 - [#131](https://github.com/rolker/unh_echoboats_project11/issues/131) — gabby: apply sysctl UDP receive-buffer tuning
 - [`rolker/udp_bridge#19`](https://github.com/rolker/udp_bridge/issues/19) — Add per-topic priority/class scheduling to the rate-limiter
 
-### Not yet done — §2 through §9 of #124
+### §2 through §9 — now resolved or tracked
 
-Performance, power, autonomy/BT, SBG-vs-FCU, sonar, perception,
-comms-loss, operator UX. The bag → SQLite DB is in place; queries
-against the deployment data should be straightforward continuations
-of the §1 pattern (see [`network_queries.sql`](../../analysis/2026-05-01/network_queries.sql)).
+Completed or routed to dedicated issues during the 2026-05-25 review pass.
+See the wrap-up appendix below.
+
+# Appendix — #124 post-mission review (wrap-up)
+
+Consolidated close-out of [#124](https://github.com/rolker/unh_echoboats_project11/issues/124)
+— the post-mission data review of this deployment. GitHub issues are the
+canonical durable record; this appendix preserves the end-to-end picture
+in-repo. §1 detail is in the "Post-mission analysis (2026-05-18)" section
+above; §2 detail is in [`docs/bizzyboat_performance.md`](../../bizzyboat_performance.md)
+with reproducible scripts under [`docs/analysis/dynamics/`](../../analysis/dynamics/).
+
+## Section status (9 of 9 — done or tracked)
+
+| § | Topic | Outcome |
+|---|---|---|
+| 1 | Networking / udp_bridge | ✓ Done — PR #132; spinoffs #130, #131, `udp_bridge#19` |
+| 2 | Performance | ✓ Done — PR #172; max-reverse + mid-PWM curve → #88 |
+| 3 | Power | → #167 (cross-deployment power-usage) |
+| 4 | Autonomy / BT | BT-abort forensic → `unh_marine_navigation#25` (recurrence of closed `#18`); mode-transition timeline = standard analysis (#169 convention) |
+| 5 | SBG vs FCU | → #156 (ellipsoidal-Z disagreement), #117 (sbg standard topics) |
+| 6 | Sonar / time-sync | → #137 (M3 intermittent missing pings) |
+| 7 | Perception | mooring-ball near-miss → #170 (collision-monitor validation); forward segmentation in `bizzy_images/` starts 14:25 EDT (~4 min after the 14:21 event) |
+| 8 | Comms-loss recovery | covered under §1; outage path-attribution = standard link-stats analysis (#169 convention) |
+| 9 | Operator UX | → #166 (CAMP froze ×2), #171 (annunciator gaps) |
+
+## §2 headline findings
+
+- Max forward **~1.9 m/s (3.7 kt)** STW; cruise **~1.52 m/s (3.0 kt)** — current-corrected (circle-fit), NOAA-validated.
+- Hard-launch accel **~0.6 m/s²**; coast-down **~0.15 m/s²** (~10–15 m to stop from cruise).
+- Turning is **vectored-thrust** (yaw ∝ thrust × steering, not speed); ~0.9 rad/s pivot. Resolved the "1.5 cmd / 1.0 tracked" observation = current + throttle ceiling.
+- Course-keeping **~0.13 m RMS** track-holding — not survey-limiting.
+- **Config changes** (field-untested → validate via #173): helm `max_yaw_speed` 0.5→1.0; planner `minimum_turning_radius` 3.0→1.5 (`seafloor_echoboat_project11#24`).
+
+## Artifacts (local-only, regenerable from bags)
+
+- `~/data/logs/analysis/2026-05-01_deployment.db` — combined sqlite extraction
+- `docs/analysis/dynamics/` — `dynamics.py`, `dynamics_extra.py`, `turning.py`, `xte.py`, `queries.sql`
+- `docs/analysis/2026-05-01/` — §1 network analysis + queries
+- `docs/bizzyboat_performance.md` — living §2 characterization
+
+#124 is fully consolidated — every section done or tracked. Closing on merge of PR #172.


### PR DESCRIPTION
## Summary

Post-mission review [#124](https://github.com/rolker/unh_echoboats_project11/issues/124) **§2 — Performance characterization.** Pools **7 in-water deployments** (2026-04-24 → 2026-05-22) to extract current-corrected speed and acceleration/deceleration dynamics, resolving several standing observations from the 2026-05-01 mission.

This is the §2 analog of the merged §1 networking analysis ([#132](https://github.com/rolker/unh_echoboats_project11/pull/132)).

## Headline results

| Metric | Value | Confidence |
|---|---|---|
| Max forward speed | **~1.9 m/s (3.7 kt)** STW, full throttle | Good (two clean fits agree) |
| Cruise speed | **~1.52 m/s (3.0 kt)** STW @ PWM 1750–1850 | High (three clean fits agree) |
| Hard-launch acceleration | ~0.6 m/s² peak, τ ≈ 2.5 s | Moderate |
| Coast-down deceleration | ~0.15 m/s² (up to ~0.25), τ ≈ 9–10 s (~10–15 m to stop) | Moderate |
| Max reverse speed | ~1.4 m/s (2.7 kt) peak, provisional | Low (under-sampled → #88) |

- **"1.5 m/s commanded / ~1.0 m/s tracked" resolved**: tidal current (~0.5–0.6 m/s on upstream legs) plus full-throttle STW ceiling — not an autonomy cap.
- **Battery-sag hypothesis tested and *not* detected** across 22–27 V.
- Fitted currents **validated against NOAA ACT0731** (the two slack-straddling windows fit ~0.1 m/s).

## Method

All on-boat speed signals are speed-over-ground (contain current). At fixed throttle the ground-velocity vectors over varied headings trace a circle of radius = speed-through-water centred on the current vector; a circle fit recovers both. Acceleration/deceleration use first-order surge/decay fits. Universal signals (`rc/out` PWM + `gps_vel`) are present in every deployment; EKF `velocity_body` cross-checks 2026-05-01+.

## What's in the PR

- `docs/bizzyboat_performance.md` — new living, cross-deployment characterization.
- `docs/analysis/dynamics/` — reproducible scripts (`dynamics.py`, `dynamics_extra.py`), reference `queries.sql`, and README with the bag→SQLite regen recipe.
- `bizzyboat_project11/docs/bizzyboat_hardware.md` — new **Measured Performance** section.
- `docs/bizzyboat_dynamics_2026-04-24.md` — superseded-for-speed note (the preliminary doc was not current-corrected).

## Verification

- `flake8` clean on both scripts; no-arg run covers all 7 deployments.
- Pre-push `/review-code` (Standard): two fresh-context adversarial specialists (Claude + Copilot CLI). The Claude subagent independently re-ran the scripts and confirmed every per-deployment number reproduces exactly. 0 must-fix; 6 suggestions folded in before push (see `.agent/work-plans/issue-124/progress.md`).

## Follow-ups (→ [#88](https://github.com/rolker/unh_echoboats_project11/issues/88))

- Intermediate PWM→speed points + cleaner high-throttle tail via controlled steady-hold / reciprocal runs.
- Straight-reverse speed and active crash-stop braking distance.
- Graduate the circle-fit / surge-fit tooling into `marine_tools` `bag_analysis` as a reusable extractor.

Part of #124 §2

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`



Closes #124
