### PR TITLE
Reflex collision-avoidance pointcloud for BizzyBoat — launch + record + bridge (#170 Phase A)

### DIFF
--- a/.agent/work-plans/issue-170/plan.md
+++ b/.agent/work-plans/issue-170/plan.md
@@ -1,0 +1,137 @@
+# Plan: Configure nav2 Collision Monitor for BizzyBoat (reflex safety layer)
+
+## Issue
+
+https://github.com/rolker/unh_echoboats_project11/issues/170
+
+## Context
+
+The Collision Monitor scaffolding **already exists** on BizzyBoat's
+autonomous `cmd_vel` path. The shared `echoboat_project11/config/nav2_params.yaml`
+(`seafloor_echoboat_project11`, used by bizzy *and* izzy — bizzy's
+`nav_launch.py` passes no params override) defines `collision_monitor:` with
+`cmd_vel_in_topic: cmd_vel_smoothed` → `cmd_vel_out_topic:
+piloting_mode/autonomous/cmd_vel`, i.e. it gates autonomous commands ahead of
+`mavros/setpoint_velocity/cmd_vel` — exactly #170's intent. **But** its only
+`observation_sources` is a `scan` (LaserScan) topic BizzyBoat does not publish,
+so the monitor is **blind today**.
+
+What #170 actually needs: feed the monitor the reflex PointCloud2 from
+`unh_marine_perception#17`'s `segments_to_pointcloud` (reflex mode:
+`target_frame=bizzy/base_link_level`, publishes `~/pointcloud`), and tune the
+polygons for boat momentum. BizzyBoat does not launch `segments_to_pointcloud`
+at all yet — only the four OAK segmentation-image nodes run
+(`oak_cameras_launch.py`).
+
+**Hard dependency**: perception#17 (draft PR #18) provides the reflex
+`target_frame`/`~/pointcloud` surface. Phase A cannot deploy until it merges to
+`jazzy`; it can be sim-tested in-workspace from the perception#17 worktree.
+
+## Approach
+
+Phased per discussion (user-confirmed). **Phase A** is this PR.
+
+### Phase A — publish + record + bridge the reflex cloud (this PR)
+
+1. **Launch a forward-OAK reflex instance** in
+   `bizzyboat_project11/launch/perception_launch.py` (already uses
+   `GroupAction`/`PushRosNamespace`/`IncludeLaunchDescription`). Include
+   `sea_surface_segmentation/launch/segments_to_pointcloud_launch.py` with
+   `name=segments_to_pointcloud_reflex`, `target_frame=bizzy/base_link_level`,
+   wrapped in a `GroupAction` whose `SetRemap`s wire the node to the forward
+   camera and to the **canonical** observation topic:
+   - `segmentation` → `sensors/cameras/oak_forward/segmentation`
+   - `segmentation/camera_info` → `sensors/cameras/oak_forward/segmentation/camera_info`
+   - `~/pointcloud` → `/bizzy/collision_monitor/pointcloud` (absolute dst to
+     avoid private-namespace remap ambiguity)
+
+   **Activation risk to verify**: the node is a `LifecycleNode` and won't
+   publish until configured+activated. `segments_to_pointcloud_launch.py`
+   computes its `LifecycleTransition` target name from
+   `LaunchConfiguration('ros_namespace')`, which `PushRosNamespace` does **not**
+   set — so under a pushed namespace the transition may target the wrong FQN
+   and never fire. Verify activation in sim; if it misfires, pass `ros_namespace`
+   explicitly or launch the reflex node directly (with its own transition)
+   rather than via the include. This is the load-bearing check for Phase A —
+   no activation means no cloud to record/bridge.
+
+2. **Record it.** Add `/bizzy/collision_monitor/pointcloud` to the explicit
+   `logger.topics` allowlist in `bizzyboat_project11/config/bizzyboat.yaml`.
+
+3. **Bridge it on both links.** Add a `collision_pointcloud` entry
+   (`source: collision_monitor/pointcloud`) to the WiFi *and* VPN topic lists
+   in `bizzyboat.yaml`. **Measured** size is tiny — 128×96 mask, ≤~53 projecting
+   `PointXYZI` points across the real 2026-05-22 obstacle-approach window,
+   <2 KB/msg, <0.1 Mbps @10 Hz — so VPN inclusion is safe (unlike the costmap
+   dropped in #68 for size). Start at `period: 1.0` (operator SA/debug; the
+   monitor consumes it on-boat); tunable.
+
+### Phase B — wire + tune the monitor (follow-up sub-issue, own plan)
+
+- Shared `nav2_params.yaml`: switch `observation_sources` from `scan` to a
+  `pointcloud` source on the **canonical** topic `collision_monitor/pointcloud`
+  (relative; namespaced per boat). Each boat remaps its reflex cloud to that
+  topic; izzy opts in later (it currently has `publish_pointcloud: false`, so the
+  switch is a no-op for izzy until then). Spans `seafloor_echoboat_project11`
+  (params) + bizzy launch (remap, done in Phase A).
+- Tune polygons for momentum: passive coast-down is ~10–15 m from ~1.5 m/s cruise
+  (#124 §2 / PR #172), so the slowdown/limit zone must extend well beyond ~15 m,
+  or the monitor must command reverse rather than zero throttle. Favor
+  slowdown/limit over hard stop; forward-arc only. Keep the polygon block shared
+  unless bizzy/izzy tuning must differ.
+- Sim-verify before field.
+
+### Phase C — offline trigger cataloging (validation; likely under #169)
+
+Replay logged forward segmentation (`~/data/logs/bizzy_images/`, 2026-04-21…05-22)
+through adapter + monitor, catalog every slow/stop trigger vs. track/speed
+(`/bizzy/odom`) to separate true positives from false positives for polygon
+tuning — no field time. Per the #170 issue comment.
+
+## Files to Change (Phase A)
+
+| File | Change |
+|------|--------|
+| `bizzyboat_project11/launch/perception_launch.py` | Add a `GroupAction` (SetRemap + include of `segments_to_pointcloud_launch.py`) launching the forward-OAK reflex instance → `/bizzy/collision_monitor/pointcloud` |
+| `bizzyboat_project11/config/bizzyboat.yaml` | Add the canonical topic to `logger.topics`; add `collision_pointcloud` entries to WiFi + VPN udp_bridge lists |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Phase A keeps node + record + bridge together so the cloud is observable end-to-end; merge-order dependency on perception#17 stated. |
+| Capture decisions, not just implementations | Canonical-topic-over-edit-shared-params and phasing decisions recorded; "measured, not heavy" recorded against #68 precedent. |
+| Test what breaks | Lifecycle-activation-under-namespace is the failure mode that yields a silent empty topic; called out as the sim check gating Phase A. |
+| Only what's needed | Phase A is launch + two config edits; monitor wiring/tuning deferred to B with its own review. |
+| Robustness (boat on open water) | Safety reflex is Phase B; Phase A first makes the feed recordable/visible so B is tuned against real data, not guesses. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | `layers/worktrees/issue-unh_echoboats_project11-170`. |
+| 0008 — ROS 2 conventions | Yes | snake_case params; reuse upstream launch via include + SetRemap; sensor_msgs/PointCloud2 unchanged. |
+| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Launch reflex node (new `/bizzy/collision_monitor/pointcloud`) | bag `logger.topics` + udp_bridge (wifi+vpn) | Yes (Phase A) |
+| Canonical observation topic name | Phase B `nav2_params.yaml` `observation_sources` + per-boat remap | Phase B (own plan) |
+| Depend on perception#17 surface | Merge perception#17 to `jazzy` before Phase A deploys | Stated; merge-order note |
+| (gap) no `.agents/README.md` in echoboats | Author one as a dedicated task | Out of scope — noted, not fixed here |
+
+## Open Questions
+
+- [ ] **Bridge period** for `collision_pointcloud` — plan assumes `period: 1.0`
+  on both links (it's operator SA/debug; monitor consumes on-boat). Confirm or
+  set unthrottled.
+- [ ] **Phase A merge gating** — open this PR now (sim-tested against the
+  perception#17 worktree) and hold for perception#17 merge, or wait until
+  perception#17 lands first? Plan assumes open-now-hold-ready.
+
+## Estimated Scope
+
+Phase A: single small PR (one launch addition + two config edits), gated on
+perception#17. Phases B and C are separate PRs/sub-issues with their own plans.

--- a/.agent/work-plans/issue-170/plan.md
+++ b/.agent/work-plans/issue-170/plan.md
@@ -45,15 +45,16 @@ Phased per discussion (user-confirmed). **Phase A** is this PR.
    - `~/pointcloud` → `/bizzy/collision_monitor/pointcloud` (absolute dst to
      avoid private-namespace remap ambiguity)
 
-   **Activation risk to verify**: the node is a `LifecycleNode` and won't
-   publish until configured+activated. `segments_to_pointcloud_launch.py`
-   computes its `LifecycleTransition` target name from
-   `LaunchConfiguration('ros_namespace')`, which `PushRosNamespace` does **not**
-   set — so under a pushed namespace the transition may target the wrong FQN
-   and never fire. Verify activation in sim; if it misfires, pass `ros_namespace`
-   explicitly or launch the reflex node directly (with its own transition)
-   rather than via the include. This is the load-bearing check for Phase A —
-   no activation means no cloud to record/bridge.
+   **Activation note**: the node is a `LifecycleNode` and won't publish until
+   configured+activated. `segments_to_pointcloud_launch.py` computes its
+   `LifecycleTransition` target name from `LaunchConfiguration('ros_namespace')`.
+   Verified that `PushRosNamespace` *does* set `ros_namespace` to the combined
+   absolute namespace (`launch_ros/actions/push_ros_namespace.py:82`), so under
+   the `oak_forward` group the transition target
+   (`/bizzy/sensors/cameras/oak_forward/segments_to_pointcloud_reflex`) matches
+   the node FQN and the configure→activate transition fires. Still the
+   load-bearing sim check for Phase A — confirm the topic actually publishes
+   (no activation = silent empty topic).
 
 2. **Record it.** Add `/bizzy/collision_monitor/pointcloud` to the explicit
    `logger.topics` allowlist in `bizzyboat_project11/config/bizzyboat.yaml`.
@@ -63,8 +64,9 @@ Phased per discussion (user-confirmed). **Phase A** is this PR.
    in `bizzyboat.yaml`. **Measured** size is tiny — 128×96 mask, ≤~53 projecting
    `PointXYZI` points across the real 2026-05-22 obstacle-approach window,
    <2 KB/msg, <0.1 Mbps @10 Hz — so VPN inclusion is safe (unlike the costmap
-   dropped in #68 for size). Start at `period: 1.0` (operator SA/debug; the
-   monitor consumes it on-boat); tunable.
+   dropped in #68 for size). **Unthrottled** (no `period`) on both links per
+   user decision — the monitor consumes it on-boat, and the bridged copy is
+   cheap enough to forward every message for operator SA/debug.
 
 ### Phase B — wire + tune the monitor (follow-up sub-issue, own plan)
 
@@ -124,14 +126,13 @@ tuning — no field time. Per the #170 issue comment.
 
 ## Open Questions
 
-- [ ] **Bridge period** for `collision_pointcloud` — plan assumes `period: 1.0`
-  on both links (it's operator SA/debug; monitor consumes on-boat). Confirm or
-  set unthrottled.
-- [ ] **Phase A merge gating** — open this PR now (sim-tested against the
-  perception#17 worktree) and hold for perception#17 merge, or wait until
-  perception#17 lands first? Plan assumes open-now-hold-ready.
+- [x] **Bridge period** — resolved: **unthrottled** (no `period`) on both links.
+- [x] **Phase A merge gating** — resolved: **no gating**. perception#17 is
+  progressing in parallel for a near-term deployment; land Phase A alongside it
+  rather than waiting. Sim-test against the perception#17 worktree.
 
 ## Estimated Scope
 
-Phase A: single small PR (one launch addition + two config edits), gated on
-perception#17. Phases B and C are separate PRs/sub-issues with their own plans.
+Phase A: single small PR (one launch addition + two config edits). Developed in
+parallel with perception#17 (no merge gating). Phases B and C are separate
+PRs/sub-issues with their own plans.

--- a/.agent/work-plans/issue-170/progress.md
+++ b/.agent/work-plans/issue-170/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 170
+---
+
+# Issue #170 — Configure nav2 Collision Monitor for BizzyBoat (reflex safety layer)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-26 09:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-170/plan.md` at `3345331`
+**PR**: https://github.com/rolker/unh_echoboats_project11/pull/178 (`[PLAN]` prefix)
+**Phases**: 3 (A = launch reflex node + record + bridge [this PR]; B = swap collision_monitor source + tune polygons; C = offline trigger cataloging)
+
+### Open questions
+- [ ] Bridge `period` for `collision_pointcloud` — plan assumes `1.0` on both links; confirm or set unthrottled.
+- [ ] Phase A merge gating — open-now-hold-ready (sim-test vs perception#17 worktree) vs wait for perception#17 to land first.

--- a/.agent/work-plans/issue-170/progress.md
+++ b/.agent/work-plans/issue-170/progress.md
@@ -16,3 +16,19 @@ issue: 170
 ### Open questions
 - [ ] Bridge `period` for `collision_pointcloud` — plan assumes `1.0` on both links; confirm or set unthrottled.
 - [ ] Phase A merge gating — open-now-hold-ready (sim-test vs perception#17 worktree) vs wait for perception#17 to land first.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-26 09:47 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-170 at `2a5f9ca`
+**Mode**: pre-push
+**Depth**: Standard (reason: safety-relevant launch + deployment config)
+**Must-fix**: 0 | **Suggestions**: 1
+
+### Findings
+- [ ] (suggestion) `target_frame: bizzy/base_link_level` hardcodes the namespace prefix; consistent with repo convention, accepted — `perception_launch.py:163`
+- [x] (debunked) adversarial "syntax error" in perception#17 lifecycle transition — disproved by evaluating the PythonExpression; Copilot concurred (no findings)
+- [ ] (verify) functional/sim check: confirm reflex node activates + publishes `/bizzy/collision_monitor/pointcloud` (bag-replay against perception#17). Load-bearing before deploy.

--- a/.agent/work-plans/issue-170/progress.md
+++ b/.agent/work-plans/issue-170/progress.md
@@ -14,7 +14,7 @@ issue: 170
 **Phases**: 3 (A = launch reflex node + record + bridge [this PR]; B = swap collision_monitor source + tune polygons; C = offline trigger cataloging)
 
 ### Open questions
-- [ ] Bridge `period` for `collision_pointcloud` — plan assumes `1.0` on both links; confirm or set unthrottled.
+- [x] Bridge `period` for `collision_pointcloud` — resolved as intentionally unthrottled on both links (matches PR/config and `plan.md`).
 - [ ] Phase A merge gating — open-now-hold-ready (sim-test vs perception#17 worktree) vs wait for perception#17 to land first.
 
 ## Local Review (Pre-Push)

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -71,6 +71,7 @@
             - hover_viz
             - local_costmap
             - local_costmap_footprint
+            - collision_pointcloud
             - oak_forward_ffmpeg
             - oak_segmentation_forward
             - oak_segmentation_forward_info
@@ -109,6 +110,8 @@
               hover_viz: {source: hover_visualization}
               local_costmap: {source: local_costmap/costmap, period: 3.0}
               local_costmap_footprint: {source: local_costmap/published_footprint}
+              # Reflex collision cloud (#170). Unthrottled — measured tiny (<2 KB/msg).
+              collision_pointcloud: {source: collision_monitor/pointcloud}
               odom: {source: odom}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg, queue_size: 100}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed}
@@ -152,6 +155,7 @@
             - heartbeat
             - heartbeat_nav
             - hover_viz
+            - collision_pointcloud
             - oak_forward_ffmpeg
             - oak_segmentation_forward
             - oak_segmentation_forward_info
@@ -179,6 +183,8 @@
               heartbeat: {source: marine/heartbeat}
               heartbeat_nav: {source: marine/status/mission_manager}
               hover_viz: {source: hover_visualization}
+              # Reflex collision cloud (#170). Unthrottled — measured tiny (<2 KB/msg).
+              collision_pointcloud: {source: collision_monitor/pointcloud}
               odom: {source: odom}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg, queue_size: 100}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 1.0}
@@ -286,6 +292,8 @@
       - /bizzy/hover_visualization
       - /bizzy/behavior_tree_log
       - /bizzy/collision_monitor_state
+      # Reflex collision-avoidance cloud (perception#17 adapter) — Collision Monitor source (#170)
+      - /bizzy/collision_monitor/pointcloud
       - /bizzy/local_costmap/published_footprint
       - /bizzy/marine/response
       - /marine/platforms

--- a/bizzyboat_project11/launch/perception_launch.py
+++ b/bizzyboat_project11/launch/perception_launch.py
@@ -12,6 +12,7 @@ from launch.substitutions import TextSubstitution
 from launch_ros.actions import Node
 from launch_ros.actions import PushRosNamespace
 from launch_ros.actions import SetParametersFromFile
+from launch_ros.actions import SetRemap
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -129,6 +130,40 @@ def generate_launch_description():
                                     'oak_cameras_launch.py'
                                 ])
                             ),
+                        ),
+
+                        # Reflex collision-avoidance pointcloud (#170): forward-OAK
+                        # segmentation projected to base_link_level for the nav2
+                        # Collision Monitor (perception#17 segments_to_pointcloud,
+                        # reflex mode). Under oak_forward/ so its relative
+                        # `segmentation` + `segmentation/camera_info` subscriptions
+                        # resolve to the forward camera; `~/pointcloud` is remapped
+                        # to the canonical /<ns>/collision_monitor/pointcloud topic
+                        # consumed by the bag/bridge configs and the Collision
+                        # Monitor (Phase B).
+                        GroupAction(
+                            actions=[
+                                PushRosNamespace('oak_forward'),
+                                SetRemap(
+                                    src='~/pointcloud',
+                                    dst=['/', namespace,
+                                         '/collision_monitor/pointcloud']
+                                ),
+                                IncludeLaunchDescription(
+                                    PythonLaunchDescriptionSource(
+                                        PathJoinSubstitution([
+                                            FindPackageShare(
+                                                'sea_surface_segmentation'),
+                                            'launch',
+                                            'segments_to_pointcloud_launch.py'
+                                        ])
+                                    ),
+                                    launch_arguments={
+                                        'name': 'segments_to_pointcloud_reflex',
+                                        'target_frame': 'bizzy/base_link_level',
+                                    }.items()
+                                ),
+                            ]
                         ),
                     ]
                 ),


### PR DESCRIPTION
Closes #170

> **Status (Phase A landed):** reflex node launch + bag recording + udp_bridge
> (both links, unthrottled) are implemented and pass pre-push review (Standard
> tier, 0 must-fix). Developed in parallel with perception#17 (no merge gating).
> **Remaining gate before deploy:** functional sim/bag-replay confirming the
> reflex node activates and publishes `/bizzy/collision_monitor/pointcloud`.
> Phase B (Collision Monitor source-swap + polygon tuning) is a separate PR.

---

# Plan: Configure nav2 Collision Monitor for BizzyBoat (reflex safety layer)

## Issue

https://github.com/rolker/unh_echoboats_project11/issues/170

## Context

The Collision Monitor scaffolding **already exists** on BizzyBoat's
autonomous `cmd_vel` path. The shared `echoboat_project11/config/nav2_params.yaml`
(`seafloor_echoboat_project11`, used by bizzy *and* izzy — bizzy's
`nav_launch.py` passes no params override) defines `collision_monitor:` with
`cmd_vel_in_topic: cmd_vel_smoothed` → `cmd_vel_out_topic:
piloting_mode/autonomous/cmd_vel`, i.e. it gates autonomous commands ahead of
`mavros/setpoint_velocity/cmd_vel` — exactly #170's intent. **But** its only
`observation_sources` is a `scan` (LaserScan) topic BizzyBoat does not publish,
so the monitor is **blind today**.

What #170 actually needs: feed the monitor the reflex PointCloud2 from
`unh_marine_perception#17`'s `segments_to_pointcloud` (reflex mode:
`target_frame=bizzy/base_link_level`, publishes `~/pointcloud`), and tune the
polygons for boat momentum. BizzyBoat does not launch `segments_to_pointcloud`
at all yet — only the four OAK segmentation-image nodes run
(`oak_cameras_launch.py`).

**Hard dependency**: perception#17 (draft PR #18) provides the reflex
`target_frame`/`~/pointcloud` surface. Phase A cannot deploy until it merges to
`jazzy`; it can be sim-tested in-workspace from the perception#17 worktree.

## Approach

Phased per discussion (user-confirmed). **Phase A** is this PR.

### Phase A — publish + record + bridge the reflex cloud (this PR)

1. **Launch a forward-OAK reflex instance** in
   `bizzyboat_project11/launch/perception_launch.py` (already uses
   `GroupAction`/`PushRosNamespace`/`IncludeLaunchDescription`). Include
   `sea_surface_segmentation/launch/segments_to_pointcloud_launch.py` with
   `name=segments_to_pointcloud_reflex`, `target_frame=bizzy/base_link_level`,
   wrapped in a `GroupAction` whose `SetRemap`s wire the node to the forward
   camera and to the **canonical** observation topic:
   - `segmentation` → `sensors/cameras/oak_forward/segmentation`
   - `segmentation/camera_info` → `sensors/cameras/oak_forward/segmentation/camera_info`
   - `~/pointcloud` → `/bizzy/collision_monitor/pointcloud` (absolute dst to
     avoid private-namespace remap ambiguity)

   **Activation note**: the node is a `LifecycleNode` and won't publish until
   configured+activated. `segments_to_pointcloud_launch.py` computes its
   `LifecycleTransition` target name from `LaunchConfiguration('ros_namespace')`.
   Verified that `PushRosNamespace` *does* set `ros_namespace` to the combined
   absolute namespace (`launch_ros/actions/push_ros_namespace.py:82`), so under
   the `oak_forward` group the transition target
   (`/bizzy/sensors/cameras/oak_forward/segments_to_pointcloud_reflex`) matches
   the node FQN and the configure→activate transition fires. Still the
   load-bearing sim check for Phase A — confirm the topic actually publishes
   (no activation = silent empty topic).

2. **Record it.** Add `/bizzy/collision_monitor/pointcloud` to the explicit
   `logger.topics` allowlist in `bizzyboat_project11/config/bizzyboat.yaml`.

3. **Bridge it on both links.** Add a `collision_pointcloud` entry
   (`source: collision_monitor/pointcloud`) to the WiFi *and* VPN topic lists
   in `bizzyboat.yaml`. **Measured** size is tiny — 128×96 mask, ≤~53 projecting
   `PointXYZI` points across the real 2026-05-22 obstacle-approach window,
   <2 KB/msg, <0.1 Mbps @10 Hz — so VPN inclusion is safe (unlike the costmap
   dropped in #68 for size). **Unthrottled** (no `period`) on both links per
   user decision — the monitor consumes it on-boat, and the bridged copy is
   cheap enough to forward every message for operator SA/debug.

### Phase B — wire + tune the monitor (follow-up sub-issue, own plan)

- Shared `nav2_params.yaml`: switch `observation_sources` from `scan` to a
  `pointcloud` source on the **canonical** topic `collision_monitor/pointcloud`
  (relative; namespaced per boat). Each boat remaps its reflex cloud to that
  topic; izzy opts in later (it currently has `publish_pointcloud: false`, so the
  switch is a no-op for izzy until then). Spans `seafloor_echoboat_project11`
  (params) + bizzy launch (remap, done in Phase A).
- Tune polygons for momentum: passive coast-down is ~10–15 m from ~1.5 m/s cruise
  (#124 §2 / PR #172), so the slowdown/limit zone must extend well beyond ~15 m,
  or the monitor must command reverse rather than zero throttle. Favor
  slowdown/limit over hard stop; forward-arc only. Keep the polygon block shared
  unless bizzy/izzy tuning must differ.
- Sim-verify before field.

### Phase C — offline trigger cataloging (validation; likely under #169)

Replay logged forward segmentation (`~/data/logs/bizzy_images/`, 2026-04-21…05-22)
through adapter + monitor, catalog every slow/stop trigger vs. track/speed
(`/bizzy/odom`) to separate true positives from false positives for polygon
tuning — no field time. Per the #170 issue comment.

## Files to Change (Phase A)

| File | Change |
|------|--------|
| `bizzyboat_project11/launch/perception_launch.py` | Add a `GroupAction` (SetRemap + include of `segments_to_pointcloud_launch.py`) launching the forward-OAK reflex instance → `/bizzy/collision_monitor/pointcloud` |
| `bizzyboat_project11/config/bizzyboat.yaml` | Add the canonical topic to `logger.topics`; add `collision_pointcloud` entries to WiFi + VPN udp_bridge lists |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Phase A keeps node + record + bridge together so the cloud is observable end-to-end; merge-order dependency on perception#17 stated. |
| Capture decisions, not just implementations | Canonical-topic-over-edit-shared-params and phasing decisions recorded; "measured, not heavy" recorded against #68 precedent. |
| Test what breaks | Lifecycle-activation-under-namespace is the failure mode that yields a silent empty topic; called out as the sim check gating Phase A. |
| Only what's needed | Phase A is launch + two config edits; monitor wiring/tuning deferred to B with its own review. |
| Robustness (boat on open water) | Safety reflex is Phase B; Phase A first makes the feed recordable/visible so B is tuned against real data, not guesses. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | `layers/worktrees/issue-unh_echoboats_project11-170`. |
| 0008 — ROS 2 conventions | Yes | snake_case params; reuse upstream launch via include + SetRemap; sensor_msgs/PointCloud2 unchanged. |
| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| Launch reflex node (new `/bizzy/collision_monitor/pointcloud`) | bag `logger.topics` + udp_bridge (wifi+vpn) | Yes (Phase A) |
| Canonical observation topic name | Phase B `nav2_params.yaml` `observation_sources` + per-boat remap | Phase B (own plan) |
| Depend on perception#17 surface | Merge perception#17 to `jazzy` before Phase A deploys | Stated; merge-order note |
| (gap) no `.agents/README.md` in echoboats | Author one as a dedicated task | Out of scope — noted, not fixed here |

## Open Questions

- [x] **Bridge period** — resolved: **unthrottled** (no `period`) on both links.
- [x] **Phase A merge gating** — resolved: **no gating**. perception#17 is
  progressing in parallel for a near-term deployment; land Phase A alongside it
  rather than waiting. Sim-test against the perception#17 worktree.

## Estimated Scope

Phase A: single small PR (one launch addition + two config edits). Developed in
parallel with perception#17 (no merge gating). Phases B and C are separate
PRs/sub-issues with their own plans.
