### PR TITLE
fix(annunciator): threshold BizzyBoat battery row on voltage (#162)

### DIFF
--- a/.agent/work-plans/issue-162/progress.md
+++ b/.agent/work-plans/issue-162/progress.md
@@ -1,0 +1,42 @@
+---
+issue: 162
+---
+
+# Issue #162 — Battery annunciator stays green at <BATT_LOW_VOLT — threshold-to-color mapping broken
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-26 10:36 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #179 at `3303189`
+**Sources**: 1 (Copilot R1 @ `3303189`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (copilot-pull-request-reviewer: success)
+
+No prior local-review timeline existed for #162 (no `progress.md` before this
+entry), so the single Copilot review is the only review source.
+
+### Findings
+- [ ] (deployment-dependency, triage) PR #179's config depends on the
+  rqt_annunciator engine change in `rolker/rqt_operator_tools#35` (PR #36),
+  which is **OPEN / unmerged**. The `value_key` + `thresholds` + `{:.2f} V`
+  keys are only understood by the #36 engine. #179 must not merge/deploy
+  before #36 lands and a rebuilt `rqt_operator_tools` is on the operator
+  station — otherwise the row falls back to pre-#36 behavior (and Copilot's
+  format-on-string failure could become real on the old engine). — `bizzyboat_project11/config/bizzyboat_annunciator.yaml`
+
+### False positives
+- (Copilot) `bizzyboat_annunciator.yaml:40` — claimed `{:.2f}` format on the
+  `diagnostic_msgs/KeyValue.value` string "may error out (Unknown format code
+  'f' for str)". The consuming engine
+  (`rqt_annunciator/config_model.py::evaluate_diagnostic`, `has_thresholds`
+  path used by this row) converts the selected KeyValue to float at
+  `val = float(selected)` — returning ERROR + `Voltage?` flag if non-numeric —
+  *before* `self.format.format(val)` applies `{:.2f}` to the float. That format
+  call is additionally wrapped in `try/except (ValueError, TypeError,
+  IndexError, KeyError)` → `str(val)` fallback. Tested in
+  `test_config_model.py` with `value_key='Voltage'`, `_KV('Voltage','22.4')`
+  (a string) and `{:.2f}` format. With the #36 engine the failure mode cannot
+  occur. (Copilot's caveat "unless the engine explicitly converts to float" is
+  satisfied by the engine.)

--- a/bizzyboat_project11/config/bizzyboat_annunciator.yaml
+++ b/bizzyboat_project11/config/bizzyboat_annunciator.yaml
@@ -35,7 +35,11 @@ indicators:
   - name: Battery
     source: diagnostics
     diagnostic_name: "mavros: Battery"
-    format: "{}"
+    value_key: Voltage
+    format: "{:.2f} V"
+    thresholds:
+      warn: "value < 23.0"
+      error: "value < 21.5"
 
   - name: GPS
     source: diagnostics


### PR DESCRIPTION
Closes #162

## Summary

Colors the BizzyBoat **Battery** annunciator row by the `mavros: Battery` diagnostic's `Voltage` KeyValue instead of the producer's `DiagnosticStatus.level`. On this vehicle the FCU battery monitor is unconfigured (no current meter, bogus `percentage`), so the diagnostic `level` stays `OK` regardless of voltage — which is why the row stayed green down to ~22 V during the 2026-05-22 deployment (#160).

```yaml
- name: Battery
  source: diagnostics
  diagnostic_name: "mavros: Battery"
  value_key: Voltage
  format: "{:.2f} V"
  thresholds:
    warn: "value < 23.0"     # FCU BATT_LOW_VOLT
    error: "value < 21.5"    # FCU BATT_CRT_VOLT
```

The row now goes **yellow < 23.0 V** and **red < 21.5 V** (matching the FCU thresholds), combined with the diagnostic's own level (the more-severe wins).

## ⛔ Blocked on engine support — keep as draft

This relies on diagnostics value-threshold support added in **[rolker/rqt_operator_tools#35](https://github.com/rolker/rqt_operator_tools/pull/36)** (`value_key` + `thresholds` on `source: diagnostics` rows). **Do not merge / deploy until that lands** and the boat's `rqt_operator_tools` is updated.

## ⚠️ Verify before shipping

- [ ] Confirm the exact KeyValue **casing** on the live `mavros: Battery` diagnostic on gabby (this assumes `Voltage`; the bundled `diagnostic_test_publisher` uses lowercase `voltage`). Don't guess — check the running stack. *Fail-safe:* if the casing is wrong the engine shows `Voltage?` / **ERROR**, not a silent green, so a mismatch fails loud.
- [ ] On-water check (per #162 Verification): row green > 23.0 V; yellow < 23.0 V sustained ~10 s; red < 21.5 V; correct after a mavros restart.

## Related / not in this PR

- **#171** (operator-annunciator gaps — battery/SV/FCU on the *operator* config) is a separate, broader issue; this PR only fixes the **boat** annunciator's existing Battery row per #162.

## Test plan

Config-only change; the threshold/level-combine logic is unit-tested in the engine PR (rqt_operator_tools#35). Functional verification is the on-water checklist above.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
