### PR TITLE
BizzyBoat nav2 instance overlay: sensor-rig + reflex (#184)

### DIFF
--- a/.agent/work-plans/issue-184/progress.md
+++ b/.agent/work-plans/issue-184/progress.md
@@ -1,0 +1,27 @@
+---
+issue: 184
+---
+
+# Issue #184 — BizzyBoat nav2 instance overlay: sensor-rig + reflex
+
+## Implementation Status (resume — 2026-05-26 21:44 -04:00)
+
+The echoboats half of the seafloor#3 step-2 cutover. Branch `feature/issue-184`
+@ `2a04fad`, PR #185 (draft).
+
+**Done:**
+- `bizzyboat_project11/config/nav2_overlay.yaml` — Bizzy's 4-OAK `sea_surface` rig +
+  `collision_monitor` reflex response (polygons, observation_sources, reflex_cloud),
+  moved out of the generic `echoboat_project11` base.
+- `bizzyboat_project11/launch/nav_launch.py` — passes `model:=240` +
+  `instance_params:=<overlay>` to the generic `nav2_bringup_launch.py`.
+
+**Verified:** composed `base + 240 + this overlay` == today's `nav2_params.yaml`
+(zero param diffs; Bizzy behavior preserved).
+
+**⚠ DEPLOY-TOGETHER with rolker/seafloor_echoboat_project11#3 / PR #29** (the base
+rig-agnostic reduction). Pulling one without the other drops Bizzy's rig/reflex.
+
+**Remaining:** `/review-code` on PR #185; live `ros2 launch` smoke test (4 sea_surface
+layers + reflex polygons + gating intact) before deploy. Depends on the composition
+mechanism in seafloor PR #29 (`instance_params` arg).

--- a/.agent/work-plans/issue-184/progress.md
+++ b/.agent/work-plans/issue-184/progress.md
@@ -22,6 +22,28 @@ The echoboats half of the seafloor#3 step-2 cutover. Branch `feature/issue-184`
 **⚠ DEPLOY-TOGETHER with rolker/seafloor_echoboat_project11#3 / PR #29** (the base
 rig-agnostic reduction). Pulling one without the other drops Bizzy's rig/reflex.
 
-**Remaining:** `/review-code` on PR #185; live `ros2 launch` smoke test (4 sea_surface
-layers + reflex polygons + gating intact) before deploy. Depends on the composition
-mechanism in seafloor PR #29 (`instance_params` arg).
+**Remaining:** live `ros2 launch` smoke test (4 sea_surface layers + reflex polygons +
+gating intact) before deploy — tracked on the deployment issue `unh_echoboats#186`.
+Depends on the composition mechanism in seafloor PR #29 (`instance_params` arg).
+
+## Local Review
+**Status**: complete
+**When**: 2026-05-27 12:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**PR**: #185 at `2a04fad` + working tree (boolean-consistency fixes)
+**Mode**: post-PR
+**Depth**: Standard (reason: deployed safety config — collision reflex + segmentation rig)
+**Must-fix**: 0 | **Suggestions**: 3 (all fixed)
+
+Both adversarial specialists ran clean. Claude (fresh-context) diffed the overlay
+field-by-field against the pre-#29 monolithic `nav2_params.yaml` (`27d3de9^`) and confirmed a
+**lossless restoration** — `local_costmap.plugins` re-includes `chart_layer`+`inflation_layer`
+alongside the 4 sea_surface layers (critical given list-replace merge), all collision
+polygon/reflex params identical, launch wiring + `<robot_namespace>` substitution ordering
+correct. Copilot independently confirmed the same. Static analysis clean after the boolean fix.
+
+### Findings
+- [x] (suggestion, Copilot ×3 + yamllint) capitalized booleans (`True` / `'False'`) vs repo lowercase convention — fixed to `true` / `'false'` — `nav2_overlay.yaml`, `nav_launch.py:32`
+- [ ] (note) `use_composition: 'false'` is safe — consumed via `IfCondition` (evaluator lowercases); the change is consistency-only.

--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -16,25 +16,25 @@ local_costmap:
                 "inflation_layer"]
       sea_surface_layer_forward:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
+        enabled: true
         segmentation_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation
         camera_info_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation/camera_info
         maximum_range: 150.0
       sea_surface_layer_port:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
+        enabled: true
         segmentation_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation
         camera_info_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation/camera_info
         maximum_range: 150.0
       sea_surface_layer_starboard:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
+        enabled: true
         segmentation_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation
         camera_info_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation/camera_info
         maximum_range: 150.0
       sea_surface_layer_aft:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
+        enabled: true
         segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
         camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
         maximum_range: 150.0
@@ -48,21 +48,21 @@ collision_monitor:
       action_type: "slowdown"
       slowdown_ratio: 0.3
       min_points: 4
-      visualize: True
+      visualize: true
       polygon_pub_topic: "collision_monitor/slowdown_polygon"
-      enabled: True
+      enabled: true
     CollisionStop:
       type: "polygon"
       points: "[[5.0, 2.0], [5.0, -2.0], [0.0, -2.0], [0.0, 2.0]]"
       action_type: "stop"
       min_points: 5
-      visualize: True
+      visualize: true
       polygon_pub_topic: "collision_monitor/stop_polygon"
-      enabled: True
+      enabled: true
     observation_sources: ["reflex_cloud"]
     reflex_cloud:
       type: "pointcloud"
       topic: "collision_monitor/pointcloud"
       min_height: -2.0
       max_height: 2.0
-      enabled: True
+      enabled: true

--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -1,0 +1,68 @@
+# BizzyBoat (EchoBoat 240) nav2 instance overlay — Part of seafloor#3 step 2.
+# Merged on top of echoboat_project11's nav2_params.base.yaml + nav2_params.240.yaml
+# at launch (passed as `instance_params` to nav2_bringup_launch.py). Carries the
+# sensor-rig + reflex config that used to live in the generic base, driven by
+# Bizzy's 4-OAK camera rig and reflex deployment (not the hull model).
+# <robot_namespace> is substituted by nav2_bringup's ReplaceString after merge.
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      # 4-OAK sea_surface segmentation rig (replaces base's [chart_layer, inflation_layer]).
+      plugins: ["chart_layer",
+                "sea_surface_layer_forward",
+                "sea_surface_layer_port",
+                "sea_surface_layer_starboard",
+                "sea_surface_layer_aft",
+                "inflation_layer"]
+      sea_surface_layer_forward:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation/camera_info
+        maximum_range: 150.0
+      sea_surface_layer_port:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation/camera_info
+        maximum_range: 150.0
+      sea_surface_layer_starboard:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation/camera_info
+        maximum_range: 150.0
+      sea_surface_layer_aft:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
+        maximum_range: 150.0
+
+collision_monitor:
+  ros__parameters:
+    polygons: ["CollisionSlowdown", "CollisionStop"]
+    CollisionSlowdown:
+      type: "polygon"
+      points: "[[20.0, 3.0], [20.0, -3.0], [0.0, -3.0], [0.0, 3.0]]"
+      action_type: "slowdown"
+      slowdown_ratio: 0.3
+      min_points: 4
+      visualize: True
+      polygon_pub_topic: "collision_monitor/slowdown_polygon"
+      enabled: True
+    CollisionStop:
+      type: "polygon"
+      points: "[[5.0, 2.0], [5.0, -2.0], [0.0, -2.0], [0.0, 2.0]]"
+      action_type: "stop"
+      min_points: 5
+      visualize: True
+      polygon_pub_topic: "collision_monitor/stop_polygon"
+      enabled: True
+    observation_sources: ["reflex_cloud"]
+    reflex_cloud:
+      type: "pointcloud"
+      topic: "collision_monitor/pointcloud"
+      min_height: -2.0
+      max_height: 2.0
+      enabled: True

--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -7,7 +7,9 @@
 local_costmap:
   local_costmap:
     ros__parameters:
-      # 4-OAK sea_surface segmentation rig (replaces base's [chart_layer, inflation_layer]).
+      # 4-OAK sea_surface segmentation rig. Deep-merge replaces lists wholesale, so this
+      # list restates the base's chart_layer + inflation_layer (they are NOT dropped) and
+      # adds the four sea_surface layers between them.
       plugins: ["chart_layer",
                 "sea_surface_layer_forward",
                 "sea_surface_layer_port",

--- a/bizzyboat_project11/launch/nav_launch.py
+++ b/bizzyboat_project11/launch/nav_launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
             launch_arguments={
                 'namespace': namespace,
                 'use_namespace': 'true',
-                'use_composition': 'False',
+                'use_composition': 'false',
                 # BizzyBoat is an EchoBoat 240; supply its sensor-rig + reflex
                 # overlay on top of the generic base + 240 hull params (seafloor#3).
                 'model': '240',

--- a/bizzyboat_project11/launch/nav_launch.py
+++ b/bizzyboat_project11/launch/nav_launch.py
@@ -30,6 +30,14 @@ def generate_launch_description():
                 'namespace': namespace,
                 'use_namespace': 'true',
                 'use_composition': 'False',
+                # BizzyBoat is an EchoBoat 240; supply its sensor-rig + reflex
+                # overlay on top of the generic base + 240 hull params (seafloor#3).
+                'model': '240',
+                'instance_params': PathJoinSubstitution([
+                    FindPackageShare('bizzyboat_project11'),
+                    'config',
+                    'nav2_overlay.yaml',
+                ]),
             }.items()
         ),
     ])


### PR DESCRIPTION
Closes #184. Part of rolker/seafloor_echoboat_project11#3 (step 2 cutover).

## What

Moves BizzyBoat's nav2 **sensor-rig + reflex** config out of the generic
`echoboat_project11` base into a BizzyBoat instance overlay:

- `bizzyboat_project11/config/nav2_overlay.yaml` — the 4-OAK `sea_surface_layer`s +
  `local_costmap.plugins` list, and the `collision_monitor` reflex response
  (`CollisionSlowdown`/`CollisionStop` polygons, `observation_sources`, `reflex_cloud`).
- `bizzyboat_project11/launch/nav_launch.py` — passes `model:=240` +
  `instance_params:=<overlay>` to the generic `nav2_bringup_launch.py`, which composes
  `base + 240 + this overlay`.

The `collision_monitor` gating wiring stays in the generic base (both hulls use it).

## ⚠️ Deploy as a pair

This is one half of an atomic cross-repo cutover. The other half — making the generic
base rig-agnostic — is **rolker/seafloor_echoboat_project11#3 / PR #29**. **Both must
merge and reach gabby together.** If gabby pulls the seafloor base-reduction without
this overlay, BizzyBoat loses its sea_surface layers and reflex polygons.

## Test plan

- [x] Composed params (`base + 240 + this overlay`) verified **semantically identical**
      to today's `nav2_params.yaml` (zero param diffs).
- [ ] Live `ros2 launch bizzyboat_project11 nav_launch.py` smoke test on the built stack
      (confirm 4 sea_surface layers + reflex polygons present, gating intact) — before deploy.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
