### PR TITLE
Forward windowed local-costmap + nav-feedback topics to operator

### DIFF
--- a/.agent/work-plans/issue-187/progress.md
+++ b/.agent/work-plans/issue-187/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 187
+---
+
+# Issue #187 — Forward windowed local-costmap + nav-feedback topics to operator
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-27 14:21 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #188 at `e293ede`
+**Sources**: 2 (Copilot @ `e293ede`, local self-validation)
+**Cross-source confirmations**: 0
+**CI**: all-pass (copilot reviewer check; no build/test CI on this repo)
+
+### Findings
+- [ ] No issues found. LGTM. Copilot reviewed 3/3 files and generated no comments; local validation confirmed udp_bridge topics_list↔map consistency (WiFi 44/44, VPN 34/34), raw local_costmap removed, nav_launch.py compiles, package.xml well-formed.
+
+### False positives
+- (none)

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -69,9 +69,12 @@
             - heartbeat
             - heartbeat_nav
             - hover_viz
-            - local_costmap
+            - local_costmap_windowed
             - local_costmap_footprint
             - collision_pointcloud
+            - collision_slowdown_polygon
+            - collision_stop_polygon
+            - collision_monitor_state
             - oak_forward_ffmpeg
             - oak_segmentation_forward
             - oak_segmentation_forward_info
@@ -108,10 +111,17 @@
               heartbeat: {source: marine/heartbeat}
               heartbeat_nav: {source: marine/status/mission_manager}
               hover_viz: {source: hover_visualization}
-              local_costmap: {source: local_costmap/costmap, period: 3.0}
+              # Cropped local-costmap window for operator SA (unh_marine_navigation#38,
+              # #127). Replaces the raw local_costmap, whose full grid lost ~78% over
+              # the bridge. Full rate on WiFi.
+              local_costmap_windowed: {source: local_costmap/costmap_windowed}
               local_costmap_footprint: {source: local_costmap/published_footprint}
-              # Reflex collision cloud (#170). Unthrottled — measured tiny (<2 KB/msg).
+              # Reflex collision feedback (#170). Cloud measured tiny (<2 KB/msg);
+              # danger-zone polygons + state are smaller. Unthrottled on WiFi.
               collision_pointcloud: {source: collision_monitor/pointcloud}
+              collision_slowdown_polygon: {source: collision_monitor/slowdown_polygon}
+              collision_stop_polygon: {source: collision_monitor/stop_polygon}
+              collision_monitor_state: {source: collision_monitor_state}
               odom: {source: odom}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg, queue_size: 100}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed}
@@ -155,7 +165,13 @@
             - heartbeat
             - heartbeat_nav
             - hover_viz
+            - local_costmap_windowed
+            - local_costmap_footprint
+            - path_follower_visualization
             - collision_pointcloud
+            - collision_slowdown_polygon
+            - collision_stop_polygon
+            - collision_monitor_state
             - oak_forward_ffmpeg
             - oak_segmentation_forward
             - oak_segmentation_forward_info
@@ -188,6 +204,17 @@
               # path (1 MB/s cap); 1 Hz is enough for operator SA there. Full
               # rate retained on the WiFi link above.
               collision_pointcloud: {source: collision_monitor/pointcloud, period: 1.0}
+              # Danger-zone polygons throttled to 1 Hz on VPN to match the cloud;
+              # state is tiny and sent unthrottled for prompt mode changes (#170).
+              collision_slowdown_polygon: {source: collision_monitor/slowdown_polygon, period: 1.0}
+              collision_stop_polygon: {source: collision_monitor/stop_polygon, period: 1.0}
+              collision_monitor_state: {source: collision_monitor_state}
+              # Cropped local-costmap window for operator SA over the constrained VPN
+              # link — throttled to every 2 s (unh_marine_navigation#38, #127). The
+              # footprint and path-follower viz are low-bandwidth, sent unthrottled.
+              local_costmap_windowed: {source: local_costmap/costmap_windowed, period: 2.0}
+              local_costmap_footprint: {source: local_costmap/published_footprint}
+              path_follower_visualization: {source: path_follower_visualization}
               odom: {source: odom}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg, queue_size: 100}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 1.0}

--- a/bizzyboat_project11/launch/nav_launch.py
+++ b/bizzyboat_project11/launch/nav_launch.py
@@ -5,6 +5,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -31,5 +32,19 @@ def generate_launch_description():
                 'use_namespace': 'true',
                 'use_composition': 'False',
             }.items()
+        ),
+
+        # Republish a cropped, smaller window of the local costmap for the
+        # operator (CAMP) over the lossy bridge — unh_marine_navigation#38,
+        # unh_marine_autonomy#127. Runs in the local_costmap namespace so it
+        # subscribes to <ns>/local_costmap/costmap and publishes
+        # <ns>/local_costmap/costmap_windowed. window_size is live-tunable.
+        Node(
+            package='marine_nav_utilities',
+            executable='costmap_window_node',
+            name='costmap_window',
+            namespace=[namespace, '/local_costmap'],
+            parameters=[{'window_size': 200.0}],
+            output='screen',
         ),
     ])

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>depthai_ros_driver</exec_depend>
   <depend>joint_state_publisher</depend>
   <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>marine_nav_utilities</exec_depend>
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>
   <exec_depend>mavros_msgs</exec_depend>


### PR DESCRIPTION
## What

Wires the new windowed local-costmap ([rolker/unh_marine_navigation#38](https://github.com/rolker/unh_marine_navigation/pull/39), merged) to the operator over the udp_bridge, and forwards a set of low-bandwidth nav-stack feedback topics so the operator has a usable SA picture on both links.

**Launch** (`bizzyboat_project11/launch/nav_launch.py`): runs `marine_nav_utilities/costmap_window_node` on the boat in the `<ns>/local_costmap` namespace (`window_size:=200.0`) → subscribes `<ns>/local_costmap/costmap`, publishes `<ns>/local_costmap/costmap_windowed`.

**udp_bridge** (`bizzyboat_project11/config/bizzyboat.yaml`):
- **Drop** raw `local_costmap` (`local_costmap/costmap`, ~78% loss — [#127](https://github.com/rolker/unh_marine_autonomy/issues/127)); **forward `local_costmap_windowed`** instead — **WiFi full rate, VPN `period: 2.0`**, both connections.
- **Add to VPN** (already on WiFi): `path_follower_visualization`, `local_costmap_footprint`.
- **Add to both** (were unbridged): `collision_monitor/slowdown_polygon`, `stop_polygon`, `collision_monitor_state` — reflex danger zones + state ([#170](https://github.com/rolker/unh_echoboats_project11/issues/170)); polygons throttled to 1 Hz on VPN.

**package.xml**: `exec_depend` on `marine_nav_utilities`.

## Why

The full local costmap (400 m @ 0.25 m = 2.56 MB/msg) was lost ~78% over the bridge. The windowed view (200 m @ 0.25 m = 640 kB) is self-contained per frame, so it tolerates drops with no delta-stitching and CAMP renders it via its existing OccupancyGrid layer.

## Validation

- Local: YAML parses; every `topics_list` entry has a source map on its connection (WiFi 44/44, VPN 34/34); raw `local_costmap` fully removed; launch compiles; package.xml well-formed.
- **Real validation is the pier test** (deploy merged `marine_nav_utilities` + this config to gabby, rebuild core, confirm CAMP shows the windowed costmap + path + zones, and measure WiFi vs VPN delivery).

## Deploy notes (for the pier test)

gabby needs the merged `marine_nav_utilities` (core layer) — propagate github→gitcloud, pull on gabby, rebuild core — plus this config.

Closes #187
Part of rolker/unh_marine_autonomy#127

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
