### PR TITLE
BizzyBoat: consolidate 4 SeaSurfaceLayer → 1 multi-source + publish lethal grid (#191)

### DIFF
--- a/.agent/work-plans/issue-191/progress.md
+++ b/.agent/work-plans/issue-191/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 191
+---
+
+# Issue #191 — BizzyBoat: consolidate 4 SeaSurfaceLayer instances → 1 multi-source
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 11:22 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #193 at `5cf0676`
+**Sources**: 1 (Copilot R1 @ `5cf0676`; no prior local timeline — yaml-only PR, opened today)
+**Cross-source confirmations**: 0
+**CI**: copilot-pull-request-reviewer = success; no other checks configured. R1 generated 0 comments.
+
+### Findings
+- _None_ — Copilot's review of the yaml-only diff is clean against the current head; the schema matches what [rolker/unh_marine_perception#20](https://github.com/rolker/unh_marine_perception/pull/20) introduces (`observation_sources`, per-source `<name>.segmentation_topic`/`camera_info_topic`, `published_topic`). No human reviewers have posted yet (draft).
+
+### False positives
+- None.
+
+### Follow-ups
+- Hold as draft until [rolker/unh_marine_perception#20](https://github.com/rolker/unh_marine_perception/pull/20) merges and the workspace rebuilds — the producer-side schema doesn't exist until then; loading this yaml against the current `unh_marine_perception:jazzy` would error.
+- Mark ready-for-review after #20 merges; expect one round of Copilot at human-review time.
+- **Out-of-band verification** (the original #19 AC, load-bearing pre-water): replay 2026-05-26 bag episode #21 (the small-buoy resume) through the new build. Confirms multi-source fusion + the producer→relay end-to-end actually delivers the persistence claim. This blocks the deployment, not the merge.

--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -9,37 +9,33 @@ local_costmap:
     ros__parameters:
       # 4-OAK sea_surface segmentation rig. Deep-merge replaces lists wholesale, so this
       # list restates the base's chart_layer + inflation_layer (they are NOT dropped) and
-      # adds the four sea_surface layers between them.
-      plugins: ["chart_layer",
-                "sea_surface_layer_forward",
-                "sea_surface_layer_port",
-                "sea_surface_layer_starboard",
-                "sea_surface_layer_aft",
-                "inflation_layer"]
-      sea_surface_layer_forward:
+      # adds the single multi-source sea_surface layer between them. The four cameras
+      # all feed one shared persistent log-odds buffer (see rolker/unh_marine_perception#19),
+      # so an obstacle in the FOV overlap accumulates evidence from every camera that
+      # sees it and survives the handoff between camera views.
+      plugins: ["chart_layer", "sea_surface_layer", "inflation_layer"]
+      sea_surface_layer:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
         enabled: true
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation/camera_info
+        observation_sources: ["forward", "port", "starboard", "aft"]
+        forward:
+          segmentation_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation
+          camera_info_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation/camera_info
+        port:
+          segmentation_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation
+          camera_info_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation/camera_info
+        starboard:
+          segmentation_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation
+          camera_info_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation/camera_info
+        aft:
+          segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
+          camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
         maximum_range: 150.0
-      sea_surface_layer_port:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: true
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation/camera_info
-        maximum_range: 150.0
-      sea_surface_layer_starboard:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: true
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation/camera_info
-        maximum_range: 150.0
-      sea_surface_layer_aft:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: true
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
-        maximum_range: 150.0
+        # Republish the lethal mask for the global-costmap SeaSurfaceRelayLayer
+        # (configured in echoboat_project11's nav2_params.base.yaml — see
+        # rolker/seafloor_echoboat_project11#35) so Smac plans around buoys too.
+        # Empty-string would disable the publication.
+        published_topic: <robot_namespace>/sea_surface/lethal_grid
 
 collision_monitor:
   ros__parameters:


### PR DESCRIPTION
## Summary

- Migrates `bizzyboat_project11/config/nav2_overlay.yaml` from 4 per-camera
  `SeaSurfaceLayer` instances → 1 multi-source `SeaSurfaceLayer` with
  `observation_sources: [forward, port, starboard, aft]`. All four cameras
  feed a single persistent log-odds buffer in `<robot>/map_tide`; obstacles
  in the FOV overlap accumulate evidence from every camera that sees them
  and survive handoffs between camera views.
- Adds `published_topic: <robot_namespace>/sea_surface/lethal_grid` so the
  new `SeaSurfaceRelayLayer` in the global costmap (configured in the
  seafloor base via [rolker/seafloor_echoboat_project11#35](https://github.com/rolker/seafloor_echoboat_project11/pull/35))
  stamps the same lethal cells without re-running the projection.

## Dependencies

- [rolker/unh_marine_perception#20](https://github.com/rolker/unh_marine_perception/pull/20)
  — introduces the `observation_sources` / `published_topic` config schema.
  **Must merge + workspace rebuild before this PR's config takes effect.**
- [rolker/seafloor_echoboat_project11#35](https://github.com/rolker/seafloor_echoboat_project11/pull/35)
  — adds the global-costmap relay consumer side. Independent ordering: this
  PR's `published_topic` is harmless without the consumer.

## Notes

- Per-source `maximum_range` is currently the shared top-level value
  (`maximum_range: 150.0`). Per-camera override (`<source>.maximum_range`)
  remains a possible future addition if multi-camera height/optics asymmetry
  shows up in field data.
- The new `min_grazing_angle_deg` projection cutoff (also from #20) is left
  at the default `0` (filter off). Operator can dial it in on water against
  the actual bag noise curve — at camera height 1.5 m, `2°→43 m`, `5°→17 m`,
  `10°→8.5 m` horizontal reach. Live-tunable via `ros2 param set`.

## Test plan

- [x] yaml parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Workspace builds with #20 + #35 + this PR (pending those merges).
- [ ] `ros2 launch bizzyboat_bringup` loads the single multi-source layer
      without errors; 4 segmentation + 4 camera_info subscriptions established.
- [ ] Bag replay (2026-05-26, episode #21 — the small-buoy resume): obstacle
      mark in one camera's FOV survives into the next camera's FOV; lethal
      cells appear in `global_costmap` via the relay.
- [ ] Sim-verify before deployment per the original #19 acceptance criteria.

Closes #191. Part of the rolker/unh_marine_perception#19 finalization.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
