### PR TITLE
Deployment 2026-05-29 wrap-up: graded sea-surface costmap (#197)

### DIFF
--- a/.agents/deployment.yaml
+++ b/.agents/deployment.yaml
@@ -42,7 +42,10 @@ log_dir: docs/logs
 # `git bug pull / push` are top-level, hence no `bug` repetition.
 
 issue_sync:
-  field_pull: "git bug pull gitcloud"
+  # field_pull runs ON the field host, where the field share is the clone's
+  # `origin` (not a separately-named `gitcloud` remote) — so pull from origin.
+  # (dev_push below runs on dev, where `gitcloud` IS a named remote.)
+  field_pull: "git bug pull origin"
   field_list_open: "git bug bug --label deployment --status open"
   field_show: "git bug bug show {id}"
   # dev_push runs bridge-pull first so newly-created GitHub issues are

--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -30,6 +30,12 @@ local_costmap:
         aft:
           segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
           camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
+          # Pixel-space mask for on-boat structures (GPS antenna at bottom-
+          # centre of aft FOV). Flat int list of [x_min, y_min, x_max, y_max]
+          # tuples in segmentation-output pixel coordinates (downsampled to
+          # 128x96 as of 2026-05-29). Tunable live via
+          # `ros2 param set ... sea_surface_layer.aft.image_mask_rects`.
+          image_mask_rects: [40, 65, 90, 96]
         maximum_range: 150.0
         # Republish the lethal mask for the global-costmap SeaSurfaceRelayLayer
         # (configured in echoboat_project11's nav2_params.base.yaml — see

--- a/docs/logs/2026/2026-05-29_dev_logs.md
+++ b/docs/logs/2026/2026-05-29_dev_logs.md
@@ -57,4 +57,16 @@ Running list of skill-improvement observations from this run (feeds [ros2_agent_
 
 **2026-05-29 14:08 -04:00** — Boat in the water for a while (operator-reported). Troubleshooting the **segmentation → costmap** path (the #197 core: segments not registering on the costmap as expected).
 
-**2026-05-29 16:13 -04:00** — Boat recovered (operator-reported). End of on-water session. Seg→costmap troubleshooting outcome TBD (to capture before wrap-up).
+**2026-05-29 16:13 -04:00** — Boat recovered (operator-reported). End of on-water session.
+
+### Outcome — seg→costmap (summary; full narrative in [gabby log](2026-05-29_gabby_logs.md))
+
+The graded sea-surface costmap was debugged extensively on-water. Buoys initially didn't mark; sensitivity dials (`obstacle_prob_min` 0.35→0.20) had no effect, and diagnostics confirmed the graded layer **was** loaded and running today's HEAD — so not a stale build. Three distinct bugs were found and fixed live (all in `unh_marine_perception`, imported as [#26](https://github.com/rolker/unh_marine_perception/issues/26) / PR [#27](https://github.com/rolker/unh_marine_perception/pull/27)):
+
+1. **Close obstacles → zero marks** — at close range few cells round to the exact contact-pixel row. Fix: per-column contact backstop (`792255d`). Verified: close buoys marked.
+2. **GPS antenna false marks** (exposed by fix 1) — per-source `image_mask_rects` + aft mask `[40,65,90,96]` (`e4c0657` + `nav2_overlay.yaml`, in this PR). Verified: "no more gps trail."
+3. **Side-FOV detections missing / misplaced** — 16:9 preview → 4:3 NN was cropped/stretched with isotropic intrinsics. Fix: explicit stretch + anisotropic `camera_info` (`93b1e81`). Verified live (fy/fx = 1.333).
+
+Reflex collision avoidance confirmed working (unchanged — reads the reflex pointcloud, not the costmap). The "global route bends around marks" must-verify went untested.
+
+**Still open (deferred to bag-replay analysis):** forward red obstacle not marking (speck-hides-contact in the `contact_row` scan), close-range sailboat barely marking, goto re-commanding latch (sibling of hover #46 / trackline #35), and runtime params not durable across nav2 relaunch (need YAML defaults). 20-min forensic bag: `~/data/logs/bizzy_images/bag_2026-05-29T15.56.42_ffmpeg_seg/`.

--- a/docs/logs/2026/2026-05-29_dev_logs.md
+++ b/docs/logs/2026/2026-05-29_dev_logs.md
@@ -5,6 +5,18 @@ Host: deadpool
 Side: dev
 Started: 2026-05-29 12:32 -04:00
 
+## Summary
+
+Meant to validate the graded sea-surface costmap (perception #22); in practice the costmap **never marked reliably**, so the objective isn't met and investigation continues offline with the new `sea_surface_tuner` ([unh_marine_perception#26](https://github.com/rolker/unh_marine_perception/issues/26)). The break is **downstream**: targets (moorings, lobster pots, a moored sailboat) were clearly red in segmentation **and** reliably caught by the reflex path, but the costmap projection didn't mark them. Three **exploratory** changes were tried on the water (close-range contact backstop, aft GPS-antenna image mask, anisotropic `camera_info`) — none validated. Re-issued hovers worked; the reflex only **slows** the boat (an apparent "go-around" was incidental drift, not routing); and CAMP froze once on salmon.
+
+## Lessons Learned
+
+- **The break can be downstream of good perception.** Targets were clearly red in segmentation and caught by the reflex pointcloud, yet never reached the costmap — diagnose the projection/accumulation path (`project_observations_inverse` / `contact_row`), not segmentation or `obstacle_prob_min`.
+- **Reflex CA is a slow/stop floor, not avoidance routing.** An incidental drift-and-resume is not "it went around." Deliberative route-bending remains unproven.
+- **On-water changes are experiments until validated offline.** Ship them as candidates; validate by bag replay; don't bank them as fixes.
+- **"Frozen" needs disambiguation and timing care** — interaction is often *when you notice* a freeze, not its cause.
+- **Lazy publishers don't emit without a subscriber** — suspect this when a topic is empty downstream but fine at the source (the windowed-costmap `period: -1` workaround).
+
 ## 2026-05-29
 
 ### Pre-flight
@@ -45,28 +57,53 @@ Weather window is this afternoon ahead of the ~4–5 pm rain onset; conditions d
 
 Running list of skill-improvement observations from this run (feeds [ros2_agent_workspace#504](https://github.com/rolker/ros2_agent_workspace/issues/504) / a v2 PR). Append as the deployment proceeds.
 
-1. **Timestamp format is defined but not operationalized.** Rule 6 states the format `date '+%Y-%m-%d %H:%M %:z'` only as a "don't pipe through sed" aside. It never says (a) *stamp every log entry* with it, nor (b) *stamp time-sensitive fetched data with its retrieval time*. This run initially omitted the weather-forecast retrieval timestamp (operator caught it). Skill fix: promote the format to a named convention and require it on every entry + on forecast fetches. (Same root cause as #504's fabrication finding — the format exists, the *obligation to apply it* doesn't.)
+1. **Timestamp format is defined but not operationalized — and agents diverged on it.** Rule 6 states the format `date '+%Y-%m-%d %H:%M %:z'` only as a "don't pipe through sed" aside. It never says (a) *stamp every log entry* with it, nor (b) *stamp time-sensitive fetched data with its retrieval time*. This run initially omitted the weather-forecast retrieval timestamp (operator caught it). **Worse, agents used inconsistent formats**: dev/salmon `YYYY-MM-DD HH:MM -04:00` vs gabby ISO `YYYY-MM-DDThh:mm-04:00` — operator reports the format was a point of confusion. Skill fix: **pin ONE canonical entry-timestamp format** as a named convention and require it on every entry + on forecast fetches. (Same root cause as #504's fabrication finding — the format exists, the *obligation + the single canonical form* don't.)
 2. **Pre-flight format underspecified.** The convention in practice (2026-05-28 dev log) is inline `L 04:01 EDT (08:01 UTC) 0.11 m`; this run rendered Markdown tables instead. Both readable, but divergent across agents. Pin a concrete pre-flight line format in `deployment_mode.md` with an example so it's reproducible.
 3. **NWS two-hop latency** (re-confirms #504 item): `/points/<lat,lon>` → `/gridpoints/<id>/forecast` is sequential, so weather can't join the parallel NOAA batch. Now that Judd Gregg resolves to **GYX 62,28**, add an optional `weather.gridpoint: "GYX,62,28"` field to `.agents/deployment.yaml` (+ template + knowledge doc) to skip the first hop.
 4. **Exit banner** (#504 item): emitted manually this run (`[deployment-mode] ✅ ACTIVATED for #197 …`). Worked well — codify as a required final skill step (activated / not-activated + reason).
 5. **NWS forecast issue time not captured.** For a time-sensitive forecast, also record the API's own `generatedAt`/`updateTime` alongside wall-clock retrieval for full reproducibility (optional).
+6. **Auto-log operator observations with a timestamp — don't wait to be asked.** The operator can't pause mid-op to say "log this with a timestamp"; the burden is on the agent to capture each operator observation immediately as a quote + `date '+...'` timestamp. Concrete miss this deployment: the operator's **aggressive-maneuver / roll-on-accel-and-turn** observation was never logged, so at wrap-up there was no timestamp to anchor the bag analysis — we had to scan the whole in-water window for candidate roll events. Skill fix: make "capture operator observations verbatim + timestamped, proactively" an explicit deployment-mode instruction (strengthens urgency-contract rules 5 + 10).
 
 ### Session
 
 **2026-05-29 13:00 -04:00** — Agents set on **gabby** (boat-side Linux/ROS) and **salmon** (operator station). Control checks completed earlier (operator-reported; exact time not captured). Launching the boat now.
 
+**2026-05-29 13:05:24 -04:00** — **Launch** (crane-edge / settled-in), from the `bag_to_sqlite` nav extract (`~/data/logs/analysis/2026-05-29_nav.db`, GPS-altitude crane-edge detection). Boat in the water.
+
 **2026-05-29 14:08 -04:00** — Boat in the water for a while (operator-reported). Troubleshooting the **segmentation → costmap** path (the #197 core: segments not registering on the costmap as expected).
 
-**2026-05-29 16:13 -04:00** — Boat recovered (operator-reported). End of on-water session.
+**2026-05-29 16:08:15 -04:00** — **Recovery** (crane-edge / lift-start), same nav extract. In-water ≈ 3h03m. (Operator reported "recovered" at 16:13.)
 
 ### Outcome — seg→costmap (summary; full narrative in [gabby log](2026-05-29_gabby_logs.md))
 
-The graded sea-surface costmap was debugged extensively on-water. Buoys initially didn't mark; sensitivity dials (`obstacle_prob_min` 0.35→0.20) had no effect, and diagnostics confirmed the graded layer **was** loaded and running today's HEAD — so not a stale build. Three distinct bugs were found and fixed live (all in `unh_marine_perception`, imported as [#26](https://github.com/rolker/unh_marine_perception/issues/26) / PR [#27](https://github.com/rolker/unh_marine_perception/pull/27)):
+The graded sea-surface costmap was debugged extensively on-water. Buoys initially didn't mark; sensitivity dials (`obstacle_prob_min` 0.35→0.20) had no effect, and diagnostics confirmed the graded layer **was** loaded and running today's HEAD — so not a stale build. Three **exploratory changes** were tried on the water — **not validated fixes** (the costmap never marked reliably end-to-end; see Post-deployment). All in `unh_marine_perception`, imported as the baseline in [#26](https://github.com/rolker/unh_marine_perception/issues/26) / PR [#27](https://github.com/rolker/unh_marine_perception/pull/27):
 
-1. **Close obstacles → zero marks** — at close range few cells round to the exact contact-pixel row. Fix: per-column contact backstop (`792255d`). Verified: close buoys marked.
-2. **GPS antenna false marks** (exposed by fix 1) — per-source `image_mask_rects` + aft mask `[40,65,90,96]` (`e4c0657` + `nav2_overlay.yaml`, in this PR). Verified: "no more gps trail."
-3. **Side-FOV detections missing / misplaced** — 16:9 preview → 4:3 NN was cropped/stretched with isotropic intrinsics. Fix: explicit stretch + anisotropic `camera_info` (`93b1e81`). Verified live (fy/fx = 1.333).
+1. **Close obstacles → zero marks** — at close range few cells round to the exact contact-pixel row. Change: per-column contact backstop (`792255d`). In the moment: close buoys appeared to mark.
+2. **GPS antenna false marks** (exposed by fix 1) — per-source `image_mask_rects` + aft mask `[40,65,90,96]` (`e4c0657` + `nav2_overlay.yaml`, in this PR). In the moment: operator confirmed "no more gps trail."
+3. **Side-FOV detections missing / misplaced** — 16:9 preview → 4:3 NN was cropped/stretched with isotropic intrinsics. Change: explicit stretch + anisotropic `camera_info` (`93b1e81`). Intrinsics confirmed changed (fy/fx = 1.333); marking unreliable overall.
 
-Reflex collision avoidance confirmed working (unchanged — reads the reflex pointcloud, not the costmap). The "global route bends around marks" must-verify went untested.
+Reflex collision avoidance: the reflex **slowed** the boat, which **drifted clear** and resumed — incidental drift, **not** routing (it reads the reflex pointcloud, not the costmap). The "global route bends around marks" must-verify went untested.
 
 **Still open (deferred to bag-replay analysis):** forward red obstacle not marking (speck-hides-contact in the `contact_row` scan), close-range sailboat barely marking, goto re-commanding latch (sibling of hover #46 / trackline #35), and runtime params not durable across nav2 relaunch (need YAML defaults). 20-min forensic bag: `~/data/logs/bizzy_images/bag_2026-05-29T15.56.42_ffmpeg_seg/`.
+
+## Post-deployment (dev-side wrap-up 2026-05-29)
+
+### Data extraction
+Standard `bag_analysis bag_to_sqlite` extract from the launch (12:48 EDT) + recovery (15:22 EDT) session bags → `~/data/logs/analysis/2026-05-29_nav.db`. Scripts: `2026-05-29_pitch_roll.py`, `turning.py`, `2026-05-29_launch_recovery.py`.
+
+- **Launch / recovery (crane-edge):** launched **13:05:24 EDT**, recovered **16:08:15 EDT**; in-water **≈ 3h03m**.
+- **Reflex vs costmap:** the test method was to deliberately hover near / approach moorings + lobster-pot buoys to check costmap marking, which triggered the reflex frequently (output throttled to ~0 with forward commanded, incl. underway at ~0.8–1.0 m/s; one 49 s stop at 15:42:45). The **reflex path detected and stopped** for the same close obstacles the **costmap failed to mark** — same segmentation input, only the costmap projection failed → narrows the gap to `project_observations_inverse`.
+- **Turning:** GUIDED yaw p99 0.58, **max 1.01 rad/s** (hitting the raised 1.0 cap); turn radius @ 1.52 m/s cruise: old 0.5-clamp 3.0 m → 1.0-cap 1.5 m; vectored-thrust pivot (peak yaw at low speed/high throttle).
+- **Pitch/roll:** predominantly **roll** (p99 9.2°, max 31.1°) vs pitch (p99 3.8°, max 10.4°). Worst event **15:36:47**: from near-stop, hard pivot + accel to join a line → yaw stepped to 1.0 rad/s and reversed, hull rolled **±30°** before settling. Root: unsmoothed cmd_vel (velocity_smoother disabled in #170) → impulsive thruster slew.
+
+### Follow-up dispositions
+| Finding | Disposition |
+|---|---|
+| Costmap projection break (segmentation + reflex good, costmap doesn't mark) | folded into [unh_marine_perception#26](https://github.com/rolker/unh_marine_perception/issues/26) (interactive `sea_surface_tuner` investigation; PR [#27](https://github.com/rolker/unh_marine_perception/pull/27) = exploratory baseline) |
+| `goto` re-command latch (+ hover/trackline family) | [unh_marine_navigation#50](https://github.com/rolker/unh_marine_navigation/issues/50) — BT-review umbrella (goto a listed symptom) |
+| CAMP recurring lockup | 3rd-occurrence comment on [camp#52](https://github.com/rolker/camp/issues/52) (capture-first watchdog issue) |
+| Sonar/QINSy not seeing M3 data | **deferred to the class** (students, as part of survey prep) — not tracked |
+| `deployment.yaml` `field_pull` remote drift (gitcloud→origin) | fixed in this PR (`6d72bdd`) |
+| Aggressive maneuver / ±30° roll → re-enable velocity_smoother | [seafloor_echoboat_project11#36](https://github.com/rolker/seafloor_echoboat_project11/issues/36) |
+| Runtime nav2 params not durable across relaunch | closing step of #26 (persist *validated* params to YAML once the investigation settles) |
+| `/start-deployment` v2 (timestamp format, auto-log operator observations) | [ros2_agent_workspace#504](https://github.com/rolker/ros2_agent_workspace/issues/504) (see trial notes above) |

--- a/docs/logs/2026/2026-05-29_dev_logs.md
+++ b/docs/logs/2026/2026-05-29_dev_logs.md
@@ -1,0 +1,60 @@
+# 2026-05-29 — dev log (BizzyBoat deployment #197)
+
+Deployment issue: https://github.com/rolker/unh_echoboats_project11/issues/197
+Host: deadpool
+Side: dev
+Started: 2026-05-29 12:32 -04:00
+
+## 2026-05-29
+
+### Pre-flight
+
+Retrieved 2026-05-29 12:37 -04:00 from NOAA Tides & Currents + NWS (Judd Gregg pier / Newcastle, NH defaults). EDT = UTC−4. Tide/current predictions are static for the day; the **NWS forecast is time-sensitive** — retrieval stamp above is when it was pulled.
+
+**Tides** — NOAA Fort Point, NH (station 8423898), heights in metres above MLLW:
+
+| Type | Local (EDT) | UTC | Height (m) |
+|------|-------------|-----|-----------|
+| L | 04:47 | 08:47 | 0.072 |
+| H | 11:03 | 15:03 | 2.502 |
+| L | 16:49 | 20:49 | 0.387 |
+| H | 23:05 | 30 03:05 | 2.839 |
+
+**Currents** — NOAA Clark Island, Portsmouth Harbor main channel (station ACT0731, Bin 1, 15 ft; mean flood dir 270°, mean ebb dir 085°):
+
+| Event | Local (EDT) | UTC | Speed (kn) |
+|-------|-------------|-----|-----------|
+| slack | 00:26 | 04:26 | 0 |
+| ebb | 04:15 | 08:15 | 2.26 |
+| slack | 06:59 | 10:59 | 0 |
+| flood | 10:44 | 14:44 | 1.38 |
+| slack | 13:00 | 17:00 | 0 |
+| ebb | 15:40 | 19:40 | 1.89 |
+| slack | 19:01 | 23:01 | 0 |
+| flood | 21:12 | 30 01:12 | 1.49 |
+
+**Weather** — NWS Gray, ME (GYX), gridpoint 62,28:
+
+- **This afternoon**: Mostly sunny, high near 63 °F. SE wind 5–10 mph (≈4–9 kn). Slight chance of rain showers 4–5 pm, then a chance of rain; PoP 40%, <0.1 in.
+- **Tonight**: Rain before 11 pm, then rain + slight chance of thunderstorms. Low ~46 °F. SE wind 10–20 mph (≈9–17 kn), gusts to 45 mph (≈39 kn). PoP 90%, 0.75–1 in.
+- **Saturday**: Rain before 1 pm, chance of showers to 5 pm. High ~54 °F. NE wind 10–25 mph (≈9–22 kn), gusts to 45 mph (≈39 kn). PoP 100%.
+
+Weather window is this afternoon ahead of the ~4–5 pm rain onset; conditions deteriorate sharply tonight (gusts to 45 mph) and Saturday.
+
+### [start-deployment trial] notes — v2 candidates
+
+Running list of skill-improvement observations from this run (feeds [ros2_agent_workspace#504](https://github.com/rolker/ros2_agent_workspace/issues/504) / a v2 PR). Append as the deployment proceeds.
+
+1. **Timestamp format is defined but not operationalized.** Rule 6 states the format `date '+%Y-%m-%d %H:%M %:z'` only as a "don't pipe through sed" aside. It never says (a) *stamp every log entry* with it, nor (b) *stamp time-sensitive fetched data with its retrieval time*. This run initially omitted the weather-forecast retrieval timestamp (operator caught it). Skill fix: promote the format to a named convention and require it on every entry + on forecast fetches. (Same root cause as #504's fabrication finding — the format exists, the *obligation to apply it* doesn't.)
+2. **Pre-flight format underspecified.** The convention in practice (2026-05-28 dev log) is inline `L 04:01 EDT (08:01 UTC) 0.11 m`; this run rendered Markdown tables instead. Both readable, but divergent across agents. Pin a concrete pre-flight line format in `deployment_mode.md` with an example so it's reproducible.
+3. **NWS two-hop latency** (re-confirms #504 item): `/points/<lat,lon>` → `/gridpoints/<id>/forecast` is sequential, so weather can't join the parallel NOAA batch. Now that Judd Gregg resolves to **GYX 62,28**, add an optional `weather.gridpoint: "GYX,62,28"` field to `.agents/deployment.yaml` (+ template + knowledge doc) to skip the first hop.
+4. **Exit banner** (#504 item): emitted manually this run (`[deployment-mode] ✅ ACTIVATED for #197 …`). Worked well — codify as a required final skill step (activated / not-activated + reason).
+5. **NWS forecast issue time not captured.** For a time-sensitive forecast, also record the API's own `generatedAt`/`updateTime` alongside wall-clock retrieval for full reproducibility (optional).
+
+### Session
+
+**2026-05-29 13:00 -04:00** — Agents set on **gabby** (boat-side Linux/ROS) and **salmon** (operator station). Control checks completed earlier (operator-reported; exact time not captured). Launching the boat now.
+
+**2026-05-29 14:08 -04:00** — Boat in the water for a while (operator-reported). Troubleshooting the **segmentation → costmap** path (the #197 core: segments not registering on the costmap as expected).
+
+**2026-05-29 16:13 -04:00** — Boat recovered (operator-reported). End of on-water session. Seg→costmap troubleshooting outcome TBD (to capture before wrap-up).

--- a/docs/logs/2026/2026-05-29_dev_logs.md
+++ b/docs/logs/2026/2026-05-29_dev_logs.md
@@ -1,6 +1,6 @@
 # 2026-05-29 — dev log (BizzyBoat deployment #197)
 
-Deployment issue: https://github.com/rolker/unh_echoboats_project11/issues/197
+**Deployment**: [#197](https://github.com/rolker/unh_echoboats_project11/issues/197)
 Host: deadpool
 Side: dev
 Started: 2026-05-29 12:32 -04:00
@@ -30,7 +30,7 @@ Retrieved 2026-05-29 12:37 -04:00 from NOAA Tides & Currents + NWS (Judd Gregg p
 | L | 04:47 | 08:47 | 0.072 |
 | H | 11:03 | 15:03 | 2.502 |
 | L | 16:49 | 20:49 | 0.387 |
-| H | 23:05 | 30 03:05 | 2.839 |
+| H | 23:05 | 03:05 (+1d) | 2.839 |
 
 **Currents** — NOAA Clark Island, Portsmouth Harbor main channel (station ACT0731, Bin 1, 15 ft; mean flood dir 270°, mean ebb dir 085°):
 
@@ -43,7 +43,7 @@ Retrieved 2026-05-29 12:37 -04:00 from NOAA Tides & Currents + NWS (Judd Gregg p
 | slack | 13:00 | 17:00 | 0 |
 | ebb | 15:40 | 19:40 | 1.89 |
 | slack | 19:01 | 23:01 | 0 |
-| flood | 21:12 | 30 01:12 | 1.49 |
+| flood | 21:12 | 01:12 (+1d) | 1.49 |
 
 **Weather** — NWS Gray, ME (GYX), gridpoint 62,28:
 

--- a/docs/logs/2026/2026-05-29_gabby_logs.md
+++ b/docs/logs/2026/2026-05-29_gabby_logs.md
@@ -1,0 +1,496 @@
+# 2026-05-29 — gabby log (BizzyBoat deployment)
+
+**Mode**: field (gitcloud origin)
+**Deployment**: git-bug `5617368` — *Deployment 2026-05-29: validate graded
+sea-surface costmap (perception #22)*
+**Host**: gabby
+**Side**: field
+**Started**: 2026-05-29 12:42 -04:00
+**Dev-side wrap-up TODO**: stamp this log's path under the deployment issue
+body's `## Logs` section (field-side is read-only, per memory + skill 4b).
+The dev log link is already present in the issue body; this gabby log needs
+to be added there from a dev session.
+
+## 1. Build freshness vs today's merges
+
+**2026-05-29T12:42-04:00** — Stack is up. Checked install timestamps against
+today's merges:
+
+- **Perception #22 (graded sea-surface costmap)** — merged 11:42 EDT,
+  `sensors_ws/install/sea_surface_segmentation` rebuilt 12:13 EDT.
+  `libsea_surface_layer.so` is fresh. ✅
+- **Navigation #46 / #48 hover fixes + #35 trackline re-send
+  (`unh_marine_navigation`)** — merged 11:51 EDT,
+  `core_ws/install/marine_nav_*` last built **Apr 8**. Source is on
+  `jazzy` HEAD locally but **not in the install**. ❌
+
+Implication: costmap focus is ready; hover/trackline checks will show old
+behavior until `core_ws` is rebuilt. Flagged to operator.
+
+## 2. core_ws rebuild
+
+**2026-05-29T12:5x-04:00** — Operator requested rebuild. Ran
+`colcon build --symlink-install --packages-select marine_nav_interfaces
+marine_nav_utilities marine_nav_tasks marine_nav_behaviors
+marine_nav_behavior_tree marine_nav_bt_task_navigator
+marine_nav_crabbing_path_follower` from `core_ws`. All 7 finished in
+8.25s, exit 0. `--allow-overriding` warning expected (rebuild into
+existing install).
+
+Install now has #46/#48/#35; running nodes still on old code until the
+autonomy/BT launch group is relaunched.
+
+**2026-05-29T12:5x-04:00** — Operator restarted the whole stack. Running
+nodes now reflect today's `jazzy` HEAD for both perception #22 and
+nav #46/#48/#35.
+
+## 3. Windowed costmap not visible at operator station
+
+**2026-05-29T13:xx-04:00** — Operator reported no windowed costmap on the
+operator side. Initial hypothesis (mine) was the known zenoh
+transient_local discovery race on `costmap_window` /
+`local_costmap/costmap_windowed`. **Actual cause**: udp_bridge subscribe
+entry for the local costmap had `period: -1`, which disables forwarding.
+Operator caught and fixed it. Costmap now visible on operator side.
+
+Note for follow-up: worth a quick check whether the `-1` was a stale
+test value or intentionally there from a prior debugging session — if
+it's lurking in committed config, others will hit it.
+
+## 4. In the water
+
+**2026-05-29T13:xx-04:00** — Boat in the water. First on-water command:
+goto hover. Boat executed it successfully (went to the commanded
+location and held).
+
+Partial confirmation that the basic hover path is alive on today's
+nav build. Still untested on-water:
+- `#46` end-of-task hover landing at current location (not the first
+  hover spot) — requires a task/mission ending into a hover
+- Re-commanded hover re-targeting while already hovering — requires
+  issuing a second hover from within a hover
+- `#48` marker appearing on first hover without CAMP restart — need
+  operator-side confirmation
+
+## 5. Sea-surface layer tuning — buoys not marking on costmap
+
+**Symptom**: buoys not appearing on the costmap. Direction: increase
+sensitivity. Primary dial is `obstacle_prob_min` (default 0.35; lower
+= more sensitive).
+
+Defaults: `obstacle_prob_min=0.35`, `lethal_threshold=1.0`,
+`max_evidence_step=0.85`, `free_threshold=0.0`, `clear_floor=-2.0`,
+`obstacle_clamp=5.0`, `decay_half_life_s=30.0`.
+
+| Time | Param | Old → New | Result | Notes |
+|---|---|---|---|---|
+| 13:23 | `obstacle_prob_min` | 0.35 → 0.25 | No buoys marking | First attempt |
+| 13:26 | `obstacle_prob_min` | 0.25 → 0.20 | No buoys marking | Going further |
+
+**2026-05-29T13:28-04:00** — Operator confirms buoy IS showing red in
+segmentation image, but still not marking on costmap. Perception input
+is good; chain is breaking downstream. Two sensitivity drops with zero
+effect (not even soft cost) is consistent with the param not landing
+on the right node, or the new graded layer not actually loaded.
+
+**2026-05-29T13:28-04:00** — Diagnostic from gabby:
+- `ros2 node list` shows `/bizzy/local_costmap/local_costmap`,
+  `/bizzy/local_costmap/costmap_window`, `/bizzy/global_costmap/global_costmap`.
+- Plugin list on `/bizzy/local_costmap/local_costmap`:
+  `['chart_layer', 'sea_surface_layer', 'inflation_layer']` — new graded
+  layer IS loaded.
+- **`obstacle_prob_min` reads back as `0.35`** despite operator's two
+  `param set` commands (0.25, then 0.20). Set commands silently no-op'd.
+- rmw_zenoh QoS errors visible in param-service output ("Received
+  liveliness token with invalid qos keyexpr"; "service's implementation
+  is invalid") — plausible mechanism for the set going nowhere.
+
+**2026-05-29T13:3x-04:00** — Source review of
+`sea_surface_segmentation/src/sea_surface_layer.cpp`:
+
+- `obstacle_prob_min` declared at `onInitialize` (line 107) → published
+  on costmap node as `sea_surface_layer.obstacle_prob_min`.
+- Dynamic param callback registered (line 239), validation in `(0, 1)`,
+  atomic update under `costmap_mutex_` (line 706).
+- `bufferPoints` reads `obstacle_prob_min_` per-frame (line 416) and
+  passes it into `segments_projection` (line 453).
+
+Wiring is correct. Layer would honor a dynamic update if it received one.
+The fact that `ros2 param get` reads 0.35 after two `set` calls means
+the set RPC never reached the callback — most likely rmw_zenoh's
+param-service is silently dropping it (the QoS errors we saw on `get`
+support this).
+
+Mitigation: edit YAML default, relaunch nav2 group. Defer zenoh
+param-service RCA to wrap-up.
+
+**2026-05-29T13:5x-04:00** — Param later started landing (operator
+confirmed). But tuning still produced no visible costmap change. Deeper
+review of `project_observations_inverse` in `segments_projection.hpp`:
+- `obstacle_prob_min` only gates which RGB pixels qualify
+  (`px[0] >= obstacle_prob_min * 255`).
+- Positive evidence is only pushed for **waterline contact pixels** —
+  the lowest obstacle-ish pixel in each image column whose pixel
+  directly below is NOT obstacle-ish. Body pixels above contact are
+  silently skipped ("leave unobserved").
+- So even with the dial at 0.20, if cells project to the buoy body
+  rather than the contact row, nothing marks.
+
+**TF / runtime verification on the running stack**:
+- controller_server log (PID 52707, started 12:48): SeaSurfaceLayer
+  initialized cleanly, buffer 1600x1600, no projection-failed warnings,
+  no "Could not transform" / extrapolation errors. TF is fine.
+- Control loop occasionally missing 5.0 Hz target (saw 3.84, 3.03 Hz) —
+  noted, not pinned to the layer specifically.
+- Loaded `.so` is `/home/field/project11/layers/main/sensors_ws/build/
+  sea_surface_segmentation/libsea_surface_layer.so`, mtime 12:13:00,
+  contains today's `project_observations_inverse` symbol and
+  `obstacle_prob_min` strings. **Running code IS today's HEAD.**
+  (Path is the build dir because `--symlink-install` symlinks install
+  to build — same file.)
+- Ruled out "wrong .so loaded" / "param not landing" / "TF broken" /
+  "layer not initialized" classes of failure.
+
+Remaining likely causes: (a) cells projecting to buoy body not
+waterline contact (geometry); (b) segmentation lacking a clean
+waterline transition at the buoy; (c) layer's segmentsCallback not
+firing (subscription quietly broken — to be checked via
+`/bizzy/sea_surface/lethal_grid` topic activity).
+
+## 6. Topic flow verified — close-buoy blind spot confirmed
+
+**2026-05-29T14:0x-04:00** — `ros2 topic hz` is unreliable under
+rmw_zenoh (returns silence even on live topics). `ros2 topic echo
+--once` confirmed both `/bizzy/sensors/cameras/oak_forward/segmentation`
+(live `rgb8` images) and `/bizzy/sea_surface/lethal_grid` (recent
+header stamp) ARE flowing. Layer is publishing.
+
+Operator: "I see far targets, just not close ones." This matches the
+contact-only marking rule's geometric weakness exactly: at close range
+the cell-grid step is coarser than the angular tolerance to the
+contact pixel row, so few or zero cells round to exact equality with
+`contact_row[u]`. Far targets work because the angular tolerance is
+wide.
+
+## 7. Hot fix — per-column contact backstop
+
+**2026-05-29T14:0x-04:00** — Implemented operator-requested fix in
+`unh_marine_perception/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp`,
+`project_observations_inverse`:
+
+After the cell loop, a second pass iterates the `contact_row` vector.
+For each column with a detected contact pixel, back-project (col,
+contact_row[col]) directly to z=plane_z and push one observation at
+the contact's true world position (same range / grazing gates as the
+cell loop). This guarantees ≥1 mark per detected contact column,
+regardless of cell-grid alignment with the contact pixel row. No
+radial false shadow — we mark only the contact's actual back-projection,
+not the body's z=0 backprojection beyond the obstacle.
+
+~40-line addition. Rebuild kicked off; operator will relaunch nav2
+group when build completes. Commit + unit-test coverage deferred to
+wrap-up (urgency contract).
+
+## 8. Post-hot-fix observations
+
+**2026-05-29T14:1x-04:00** — Operator relaunched. Reports: buoys
+marking (including close ones — hot fix working), but two new issues:
+
+1. **On-boat structures marking** — GPS antenna in aft camera frame
+   producing false marks near the boat. Geometric reality: the
+   column-iteration backstop back-projects each detected contact
+   pixel to z=0, and a non-waterline on-boat object's bottom edge
+   z=0 backprojection lands near the boat. Previously hidden by
+   cell-loop discretization, now exposed.
+2. **Buoys not persisting** — marks appear then disappear quickly.
+
+Math: with defaults (`obstacle_clamp=5`, `max_evidence_step=0.85`,
+~5 Hz / camera), a cell can drop from LETHAL to below `lethal_threshold=1.0`
+in ~1 second of water-classified observations. That's why marks
+vanish under boat motion.
+
+### Tuning attempt — persistence
+
+| Time | Param | Old → New | Result | Notes |
+|---|---|---|---|---|
+| 14:22 | `decay_half_life_s` | 30.0 → 120.0 | applied, awaiting observation | Slow natural decay 4x |
+| 14:22 | `obstacle_clamp` | 5.0 → 10.0 | applied, awaiting observation | Double headroom vs water clearing |
+| 14:32 | `max_evidence_step` | 0.85 → 2.0 | **too noisy — reverted** | Slamming evidence amplifies false positives along with real ones |
+| 14:33 | `max_evidence_step` | 2.0 → 0.85 | reverted to default | Bump was net-worse for this scene |
+
+## 10. Per-source image mask hot fix
+
+**2026-05-29T14:4x-04:00** — Captured a frame from
+`/bizzy/sensors/cameras/oak_aft/segmentation` (128x96 px, rgb8). GPS
+antenna visible as dark blob at bottom-centre (rows ~75-92, cols ~50-78).
+
+Added a per-source `image_mask_rects` parameter to the layer:
+- Flat int array of `[x_min, y_min, x_max, y_max]` tuples (pixel coords).
+- Runtime-tunable via `ros2 param set <node> sea_surface_layer.<src>.image_mask_rects '[...]'`.
+- Pixels inside any masked rect are set to (0,0,0) before projection —
+  black fails both the red-dominant obstacle gate and the green-dominant
+  water gate, so masked pixels contribute zero observations (no positive,
+  no clearing).
+- ~70 lines across `Source` struct, `onInitialize`, `segmentsCallback`,
+  `onParametersSet`, and a new `parseMaskRects` helper.
+
+Pre-populated YAML mask for aft camera in
+`unh_echoboats_project11/bizzyboat_project11/config/nav2_overlay.yaml`:
+```yaml
+aft:
+  ...
+  image_mask_rects: [40, 65, 90, 96]
+```
+Generous bottom-centre rect covering the GPS antenna. Operator can
+adjust live without relaunch via param set.
+
+Rebuilt sensors_ws/sea_surface_segmentation 14:45:55. Operator needs
+to relaunch nav2 group to pick up the new .so AND the YAML change.
+
+**2026-05-29T14:5x-04:00** — Operator confirmed after relaunch: "no
+more gps trail." Mask hot fix working as designed. The
+`[40, 65, 90, 96]` aft rect cleanly suppresses the GPS antenna without
+visibly impacting buoy detection in the rest of the aft FOV.
+
+### Tuning re-set after relaunch + second persistence pass
+
+| Time | Param | Old → New | Result | Notes |
+|---|---|---|---|---|
+| 15:01 | `max_evidence_step` | 0.85 → 0.4 | applied | Slower water clearing (and slower marking) |
+| 15:01 | `obstacle_clamp` | 5.0 → 20.0 | applied | 4x original headroom |
+| 15:01 | `decay_half_life_s` | 30.0 → 120.0 | applied | Re-set; relaunch wiped earlier 120 |
+
+**Important caveat**: relaunches wipe all runtime-set params back to
+YAML defaults. The earlier persistence tuning got reset by the mask
+hot-fix relaunch. For a durable change after the run, the operator
+wants to commit the values into the nav2 YAML, not just live tuning.
+
+## 11. Camera-info / NN aspect-ratio fix
+
+**2026-05-29T15:1x-04:00** — Operator identified a deeper bug: camera
+preview is 1280x720 (16:9), but the NN input shape is 512x384 (4:3)
+and segmentation output is 128x96 (4:3). The current pipeline either
+center-crops or stretches the preview without the camera_info modelling
+which one. Side-FOV detections were either missing or geometrically wrong.
+
+Fix per operator direction: keep 1280x720 preview (full sensor coverage),
+explicitly STRETCH to NN input, update camera_info anisotropically.
+
+Code change in
+`unh_marine_perception/sea_surface_segmentation/src/sea_surface_segmentation.cpp`:
+
+1. Added `image_manip->initialConfig.setKeepAspectRatio(false)` before
+   the existing `setResize(512, 384)` — explicit stretch, not DepthAI
+   default's aspect-preserving crop.
+2. Rebuilt `segmentation_camera_info_` anisotropically:
+   - Call `calibrationToCameraInfo(handler, CAM_A, preview_w, preview_h)`
+     to get correct preview-resolution intrinsics from DepthAI's
+     calibration handler.
+   - Scale `fx`, `cx` by `seg_w / preview_w` (≈ 0.1 at 1280→128).
+   - Scale `fy`, `cy` by `seg_h / preview_h` (≈ 0.133 at 720→96).
+   - Set `width=128, height=96`.
+   - Distortion coefficients left unchanged (small residual; aspect-ratio
+     error dominates).
+
+~40 lines. Rebuilt 15:1x. The sea_surface_layer's cameraInfoCallback
+picks up the new intrinsics on the next CameraInfo message, so the
+nav2 stack does NOT need to relaunch. **Operator needs to relaunch
+the sensors_ws launch group** (the one with sea_surface_segmentation-4
+through -7) for the camera nodes to pick up the new code.
+
+**2026-05-29T15:2x-04:00** — Operator relaunched sensors. Verified new
+camera_info for `oak_aft`:
+- `fx = 76.81` (unchanged)
+- `fy = 102.37` (was 76.78)
+- Ratio fy/fx = 1.333 = 4/3, matching the squish from 16:9 preview
+  to 4:3 NN input.
+
+Initial "not seeing them yet" while layer presumably waited for fresh
+camera_info; "they are back" confirmed once layer picked up new
+intrinsics. Aspect-ratio fix verified live.
+
+**2026-05-29T15:2x-04:00** — Operator confirmed "the stretch worked"
+and asked to re-set persistence tuning. Verified: sensors-only
+relaunch did NOT wipe the nav2 layer params (`max_evidence_step=0.4`,
+`obstacle_clamp=20.0`, `decay_half_life_s=120.0` all still set as of
+14:33 / 15:01). Re-applied as requested; no-op since values matched.
+
+**2026-05-29T15:2x-04:00** — Verified GPS mask post-stretch. Fresh aft
+segmentation frame shows the GPS antenna now as a red (obstacle-class)
+blob at ~cols 50-66, rows 70-87. Two notes:
+
+- The GPS is narrower than before (~15 px wide vs prior ~25 px) — the
+  predicted result of the horizontal stretch (compression 0.1× width
+  ratio vs the prior keep-aspect-ratio's effective ~0.133×).
+- It is now red-classified by the NN (was dark/black before), so the
+  mask is actively suppressing strong (not subtle) false marks.
+
+Current mask `[40, 65, 90, 96]` cleanly contains the GPS with generous
+margin (50-wide window vs ~15-wide signature). No adjustment needed;
+margin protects against boat pitch shifts. Could tighten to e.g.
+`[45, 68, 70, 90]` to recover ~3% more usable aft-camera real estate,
+deferred — not worth the risk during live ops.
+
+## 12. Goto re-commanding not taking effect
+
+**2026-05-29T15:3x-04:00** — Operator observation: a goto command
+issued while a goto is already in progress does NOT take effect. The
+boat continues toward the original target.
+
+This is the same class of "latched task" bug that PR #47 / issue #46
+fixed for **hover** (re-commanded hover re-targets) and PR #35
+addressed for **tracklines** (resending a different trackline switches
+without `clear + resend`). Goto appears to still latch.
+
+Plausibly: the BT decorator that fires on task-update-time for hover
+(#46) and trackline (#35) may not be wired for goto, OR goto uses a
+different task-change path that wasn't updated alongside #46/#35.
+
+**Defer to wrap-up.** Not a live-ops blocker (operator can use
+`clear + resend` workaround). Worth a follow-up issue against
+`unh_marine_navigation` covering goto with the same fix pattern as
+hover/trackline.
+
+## 13. Forward red obstacle not marking — speck-hides-contact hypothesis
+
+**2026-05-29T15:4x-04:00** — Operator: clear red obstacle in forward
+segmentation isn't showing on costmap. Captured fresh frame — small
+red blob at cols ~68-78, rows ~50-58, well separated from main shore
+band; should back-project to ~16 m ahead.
+
+State verification:
+- Forward camera_info anisotropic (`fx=76.53, fy=102.00, cy=47.83`)
+- controller_server PID 64138 started 14:46:41 → has the mask code
+- `/bizzy/sea_surface/lethal_grid` actively publishing: 1600x1600 grid,
+  **1454 lethal cells, 15910 non-zero** at check time. Layer is alive
+  and marking lots — but not THIS obstacle.
+- No new "projection failed" warnings since the post-mask relaunch.
+
+Hypothesis: `project_observations_inverse` builds `contact_row[col]`
+by scanning bottom-up and taking the LOWEST obstacle-ish pixel with
+water directly below. Per-frame segmentation noise (tiny red specks
+in the water region) wins the scan in columns that also contain the
+real far obstacle — the speck back-projects to ~3-5 m, the real
+obstacle at rows 50-58 never gets a contact recorded.
+
+| Time | Param | Old → New | Result | Notes |
+|---|---|---|---|---|
+| 15:49 | `obstacle_prob_min` | 0.35 → 0.50 | **no observable improvement** — operator: "still not seeing much" | Specks must already be strongly classified, not weak; raise didn't filter them out. Kept at 0.5 (not reverted). |
+
+## 14. 20-minute bag recording for offline review
+
+**2026-05-29T15:5x-04:00** — Operator asked to record 20 min of video
+for offline forensics on the forward-obstacle-not-marking issue. Used
+the project's existing recorder script
+`unh_echoboats_project11/bizzyboat_project11/scripts/record_camera_topics.sh`
+(not a custom Python recorder — the project script bags ALL four
+cameras' ffmpeg streams + segmentation + camera_info + TF +
+local_costmap, which is what we need for end-to-end replay).
+
+Command:
+```bash
+.../bizzyboat_project11/scripts/record_camera_topics.sh 1200
+```
+
+Output will land at `~/data/logs/bizzy_images/bag_<timestamp>_ffmpeg_seg/`
+(mcap, zstd_fast). Will complete ~16:09.
+
+Completed at 16:16 (script exited cleanly):
+`~/data/logs/bizzy_images/bag_2026-05-29T15.56.42_ffmpeg_seg/`
+
+Replay use cases:
+- Reproduce the contact_row scan against the same frames offline; confirm
+  whether speck pixels are winning over real obstacles per-column.
+- A/B `obstacle_prob_min`, mask shapes, and any minimum-region-size
+  filter on the recorded segmentation.
+- Cross-check `/bizzy/local_costmap/costmap` against the segmentation
+  frame-by-frame to see exactly where the layer marks vs. expects.
+
+## 16. Boat recovered
+
+**2026-05-29T16:13-04:00** — Operator: boat recovered. End of on-water
+phase. The 20-min bag recording (started ~15:50) ran past the
+recovery, so it captures the recovery transition as well.
+
+Outstanding question from §15 (sailboat appearance in segmentation)
+goes unanswered live; can be inspected offline from the bag.
+
+## 15. Sailboat barely marking at close range
+
+**2026-05-29T16:0x-04:00** — Operator observation: a sailboat is hardly
+registering on the costmap at close range. Class-significant — close
+sailboats are exactly the kind of obstacle the layer needs to mark
+reliably.
+
+Possible mechanisms (pending confirmation of how the sailboat appears
+in segmentation):
+- Same speck-hides-contact mechanism as §13 — but for a sailboat the
+  hull spans many columns, so more chances for false-speck dominance
+  per column.
+- Hull/sail color not red-dominant in segmentation — white sails appear
+  near (255,255,255) which passes the new `R >= obstacle_prob_min*255`
+  gate but doesn't pass the green-water gate either; ends up as sky /
+  ambiguous and contributes no observation. With current
+  `obstacle_prob_min=0.5`, a hull with R=200 would just barely pass.
+- NN classification softness at close range — large objects can degrade
+  segmentation confidence.
+
+Captured in the 20-min bag for offline A/B. Pending operator answer on
+what the sailboat looks like in the live segmentation image to direct
+the next tuning move.
+
+## Open follow-ups for wrap-up
+
+This section consolidates the items deferred during live ops; the dev-side
+wrap-up log expands them into Summary / Lessons.
+
+- **goto re-commanding latched task bug** (see §12): goto sibling of
+  hover #46 / trackline #35 fixes — file issue against
+  `unh_marine_navigation` with the same decorator pattern.
+- **Forward obstacle not marking via costmap path** (see §13, §14):
+  bag-replay analysis required. Likely needs a minimum-region-size
+  filter in `project_observations_inverse`'s contact_row scan, OR
+  spatial smoothing in the layer's accumulator.
+- **GPS / close-aft-buoy mask overlap** (see §10 follow-up): the GPS
+  is physically at the same angular elevation as 5-9 m aft buoys; the
+  mask blinds both. Long-term: smaller / more-aggressive cropping
+  + buoy detection by motion (GPS is fixed in camera frame).
+- **Anisotropic distortion not corrected** (see §11): the stretch from
+  16:9 preview to 4:3 NN input changes effective distortion model;
+  per-pixel distortion correction is now slightly off. Layer
+  projection is fine for small distortion; revisit if precision matters.
+- **Runtime params not durable across nav2 relaunch**: every tuning
+  result (decay_half_life_s=120, obstacle_clamp=20, max_evidence_step=0.4,
+  obstacle_prob_min=0.5) needs YAML defaults updated in
+  `seafloor_echoboat_project11/echoboat_project11/config/nav2_params.base.yaml`
+  and/or `unh_echoboats_project11/bizzyboat_project11/config/nav2_overlay.yaml`.
+- **Per-source `image_mask_rects` runtime tunability**: add similar
+  param to `SeaSurfaceRelayLayer` (global_costmap) for consistency,
+  or document why it's local-only.
+- **Hot fix in `segments_projection.hpp` (per-column contact backstop)
+  + per-source mask + anisotropic camera_info + explicit-stretch**:
+  all uncommitted; needs commits + unit tests + PRs against
+  `unh_marine_perception`.
+
+## 9. Reflex collision avoidance worked ✓
+
+**2026-05-29T14:3x-04:00** — Operator: "the collision avoidance worked,
+made it go around an obstacle." Clarified by operator that this was
+the **reflex `collision_monitor` path** (segments_to_pointcloud_reflex
+→ collision_monitor → halt/slowdown/redirect), NOT the
+costmap → global planner path. Reflex is independent of the graded
+sea-surface layer (see memory: CA reads the reflex pointcloud, not
+the costmap).
+
+So what was validated here is the issue's "Reflex still stops"
+must-verify item (under unchanged behavior) — the new graded costmap
+didn't regress the existing reflex CA. The "Global route bends around
+marks" item is still untested.
+
+Open follow-up:
+- Buoy persistence improving with the persistence tuning but still
+  position-jitter-limited (per operator). Next options are
+  `max_evidence_step` bump and/or `inflation_radius` increase if needed.
+- GPS-in-aft-camera noise still present; recommend disabling aft source
+  or adding `minimum_range` param post-deployment.
+

--- a/docs/logs/2026/2026-05-29_salmon_logs.md
+++ b/docs/logs/2026/2026-05-29_salmon_logs.md
@@ -1,0 +1,58 @@
+# BizzyBoat deployment log — salmon — 2026-05-29
+
+**Host**: salmon
+**Operator**: Roland + Claude Code Agent (Claude Opus 4.7, 1M context)
+**Mode**: field (gitcloud origin)
+**Side**: field
+**Deployment**: git-bug `5617368` — "Deployment 2026-05-29: validate graded sea-surface costmap (perception #22)" (opened 2026-05-29T11:47-04:00, last edited 2026-05-29T12:32-04:00).
+**Started**: 2026-05-29 12:45 -04:00
+
+## `/start-deployment` first-activation on salmon
+
+- Config: `.agents/deployment.yaml` discovered at `unh_echoboats_project11/.agents/`.
+- Side detection: `field_mode.sh` resolved field mode (origin `git@gitcloud:field/unh_echoboats_project11.git`). Clean.
+- `issue_sync.field_pull` (`git bug pull gitcloud`) **failed again** — same drift as 2026-05-28 salmon log noted. The remote in this repo is `origin`, not `gitcloud`. Worked around with `git bug pull origin` (15 objects, 4 bug refs updated). The deployment.yaml hotfix to switch the config commands from `gitcloud` → `origin` still hasn't landed.
+- `field_list_open` returned single open deployment issue (`5617368`). Clean.
+- Three-state detection → **activate first time** for salmon (issue present, no prior `2026-05-29_salmon_logs.md`).
+- Tree state: on `jazzy`, in sync with `origin/jazzy`, clean.
+- Issue title in canonical form; `## Logs` section present in body. No edits attempted (field side is read-only on the issue).
+- **TODO for next dev-side `/start-deployment` run**: stamp `[salmon log](docs/logs/2026/2026-05-29_salmon_logs.md)` under the deployment issue's `## Logs` section (only `dev log` is currently linked there).
+
+## Pre-launch checks
+
+### 2026-05-29 12:57 -04:00 — operator-bridge data sanity from salmon
+- 62 topics visible from salmon. Segmentation `/compressed` from all 4 cameras (aft / forward / port / starboard) + camera_info present.
+- Initial probe showed only `/bizzy/local_costmap/published_footprint` — no costmap occupancy, no plan, no `sea_surface_*`. Flagged the costmap absence (operator-bridge gap, not a stack-down condition — boat-side autonomy nodes are not visible to salmon by design).
+- Operator added the costmap to the operator bridge; costmap now flowing to salmon. Plan / `sea_surface_*` not (re)checked post-fix.
+
+### 2026-05-29 15:19 -04:00 — CAMP (operator app) frozen on salmon
+- Operator report: "camp seems frozen" / "camp is frozen". **Agent misread as "costmap" for several turns** before operator clarified ("it's not the topics, it's camp, the application that is frozen"). Probes below were therefore on the wrong target.
+- Misdirected ROS probes (kept for record): `hz` on `/bizzy/local_costmap/costmap_windowed` over 5s → 0 msgs; then `published_footprint` also 0 msgs over 4s. Both topics exist; neither flowing during the window. **Not the user's symptom** — CAMP is an operator-side application on salmon, not a ROS topic. Whether the local_costmap node is actually wedged is unconfirmed and unrelated to the operator's report.
+- Mitigation: operator asked diagnose-vs-restart; agent recommended restart (low confidence on diagnosing an unfamiliar GUI freeze from outside; restart is faster than any external probe).
+- Follow-up if CAMP refreezes: check `journalctl --user`, its stderr, and whether the process is CPU-pegged.
+
+### 2026-05-29 16:30 -04:00 — CAMP freeze post-mortem (post-restart analysis)
+- CAMP identity: `CCOMAutonomousMissionPlanner`, built at `layers/main/ui_ws/install/camp/`. Launched as ROS 2 node `__node:=camp __ns:=/operator`. Prior PID 138488 (from the 12:14:42 launch), current PID 156187 (restarted 15:22:34).
+- Per-node log `~/.ros/log/CCOMAutonomousMissionPlanner_138488_*.log` was misleadingly sparse (7 lines, 790 bytes). Real output went to `~/.ros/log/2026-05-29-12-14-42-213786-salmon-138470/launch.log` (the combined launch log).
+- Death certificate: `process has died [pid 138488, exit code -9, cmd ...]` at epoch 1780082549.96 = **15:22:29 EDT**. Exit code -9 = **SIGKILL** → operator force-killed; a clean shutdown signal wouldn't take. Consistent with "frozen / unresponsive".
+- Last activity before SIGKILL:
+  - 15:07:23 — last `QGeoCoordinate` update (still alive).
+  - **15:15:43** — last log line was `Message Filter dropping message: frame 'bizzy/base_link' at time 1780082142.038 for reason 'the timestamp on the message is earlier than all the data in the transform cache'`. ~4 min gap before operator noticed at 15:19.
+  - Same `bizzy/base_link` TF cache miss reappeared on the restarted instance at 15:23:52 (line 1 of its log) → not a one-shot, this is an ongoing TF / clock state.
+- Other suggestive signals from the session:
+  - 15:02:59 — `[ERROR] [rmw_zenoh_cpp]: SubscriberCallback triggered over 0/bizzy/marine/heartbeat/...` (Zenoh-side anomaly on heartbeat).
+  - Post-restart at 15:22:35/45 — Zenoh: `Scouting delay elapsed before start conditions are met` and `Didn't receive DeclareFinal for interest ... Timeout(10s)`. Discovery/interest layer unhappy.
+- Negative findings (ruling out): no OOM kill (dmesg clean), no `journalctl --user` entries for CAMP. Not a kernel-side or systemd-side event.
+- Working hypothesis (not proven): TF cache miss on `bizzy/base_link` (likely clock skew salmon ↔ gabby, or a transient TF publisher reset) caused a Qt-thread-bound TF wait or message-filter callback to stall; flaky Zenoh discovery state may have compounded. The GUI thread wedged → SIGKILL required.
+- Suggested follow-up when quiet: `ros2 run tf2_ros tf2_echo bizzy/map bizzy/base_link` for stability; `ros2 topic hz /bizzy/tf` to look at fan-in cadence; compare salmon vs gabby `chronyc tracking` for clock drift.
+
+## Wrap-up
+
+### 2026-05-29 16:32 -04:00 — boat recovered, session wrap
+- Operator: "boat has been recovered, let's wrap up."
+- `/wrap-up-deployment` skill not yet built (tracked under workspace #495) — hand-rolled close: committing + pushing this log only. Not closing the deployment issue.
+- Open items to carry into wrap-up / next deployment:
+  - **Costmap verification gap**: never confirmed end-to-end that the graded sea-surface costmap (perception #22) actually marked dim buoys on the costmap. Operator-side bridge work + CAMP freeze ate the window. The fix is shipped + the bridge is updated, but the deployment's "must-verify" checklist on issue 5617368 is still unchecked.
+  - **CAMP freeze cause**: hypothesis (TF cache miss on `bizzy/base_link` + Zenoh discovery flakiness) is unproven. Suggested probes documented above for a quieter window.
+  - **deployment.yaml drift**: `issue_sync.field_pull` still says `gitcloud` when the repo's remote is `origin`. Worked around (again) this session — same as 2026-05-28. Worth a v2 hotfix to the config.
+  - **Issue body `## Logs` section**: still only links the dev log. Next dev-side `/start-deployment` should stamp `salmon log` and any `gabby log` that exists.


### PR DESCRIPTION
Wrap-up for **Deployment 2026-05-29: validate graded sea-surface costmap (perception #22)**.

Bundles the deployment's durable records + two small field-surfaced config fixes into one PR (per the per-deployment bundling convention):

- **dev log** (`2026-05-29_dev_logs.md`) — Summary + Lessons + pre-flight + session timeline (incl. crane-edge launch **13:05:24** / recovery **16:08:15**) + Post-deployment data extraction + `/start-deployment` trial notes.
- **gabby + salmon field logs** — merged from gitcloud (original SHAs preserved; no cherry-pick, so origin/gitcloud stay reconcilable).
- **nav2_overlay.yaml** — aft-camera `image_mask_rects` GPS-antenna mask (field-verified "no more gps trail"; consumes the perception `image_mask_rects` param from #26 / PR #27 — see merge-ordering note).
- **deployment.yaml** — `issue_sync.field_pull` fix (`gitcloud`→`origin`; the field share is the clone's `origin` — recurred 2026-05-28/29).

### Deployment outcome
The graded costmap **never marked reliably** — objective not met; investigation continues. Three exploratory perception changes were tried on the water (contact backstop, GPS image-mask, anisotropic camera_info) — **not validated**. The break is downstream: targets were clear in segmentation and caught by the reflex, but the costmap projection didn't mark them. Reflex CA only *slows* the boat (apparent "go-around" = incidental drift, not routing). Worst handling event: **±30° roll** on an accel+pivot to join a line (15:36:47) — unsmoothed cmd_vel.

### Follow-up dispositions (all filed)
| Finding | Where |
|---|---|
| Costmap projection break | rolker/unh_marine_perception#26 (interactive `sea_surface_tuner`; PR #27 = exploratory baseline, parked) |
| `goto` latch + hover/trackline family | rolker/unh_marine_navigation#50 (BT-review umbrella) |
| CAMP recurring lockup | rolker/camp#52 (3rd-occurrence comment) |
| Sonar/QINSy not seeing M3 data | deferred to the class (students, survey prep) |
| Aggressive maneuver / ±30° roll | rolker/seafloor_echoboat_project11#36 (re-enable velocity_smoother) |
| Durable nav2 params | closing step of #26 |
| /start-deployment v2 | rolker/ros2_agent_workspace#504 |

### Merge-ordering note
`nav2_overlay.yaml` sets `image_mask_rects`, a param declared in perception PR #27 (parked). If this PR merges ahead of #27, the deployed perception layer just ignores the unset-but-declared param (harmless); the mask takes effect once #27 lands.

Closes #197

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
