### PR TITLE
Bridge survey-line avoidance overlay + followed path to the operator

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -93,6 +93,8 @@
             - oak_segmentation_port_raw
             - odom
             - path_follower_visualization
+            - survey_obstacle_avoidance
+            - received_global_plan
             - plan
             - platforms
             - mavros_gps_status
@@ -140,6 +142,12 @@
               oak_segmentation_port_info: {source: sensors/cameras/oak_port/segmentation/camera_info}
               oak_segmentation_port_raw:    {source: sensors/cameras/oak_port/segmentation, period: -1.0, queue_size: 100}
               path_follower_visualization: {source: path_follower_visualization}
+              # Survey-line obstacle-avoidance overlay (unh_marine_navigation#30) —
+              # published only while deviating; small + intermittent, so unthrottled
+              # like the path-follower viz. CAMP auto-discovers the MarkerArray.
+              survey_obstacle_avoidance: {source: survey_obstacle_avoidance}
+              # Followed path for CAMP's platform path-line overlay (camp#55).
+              received_global_plan: {source: received_global_plan}
               deltat: {source: sensors/deltat/soundings}
               deltat_grid: {source: sensors/deltat/grid}
               battery: {source: /bizzy/mavros/battery}
@@ -168,6 +176,8 @@
             - local_costmap_windowed
             - local_costmap_footprint
             - path_follower_visualization
+            - survey_obstacle_avoidance
+            - received_global_plan
             - collision_pointcloud
             - collision_slowdown_polygon
             - collision_stop_polygon
@@ -215,6 +225,12 @@
               local_costmap_windowed: {source: local_costmap/costmap_windowed, period: 2.0}
               local_costmap_footprint: {source: local_costmap/published_footprint}
               path_follower_visualization: {source: path_follower_visualization}
+              # Survey-line obstacle-avoidance overlay (unh_marine_navigation#30) —
+              # intermittent + small, unthrottled like the path-follower viz above.
+              survey_obstacle_avoidance: {source: survey_obstacle_avoidance}
+              # Followed path for CAMP's platform path-line overlay (camp#55),
+              # throttled to 1 Hz on the constrained VPN/Starlink link.
+              received_global_plan: {source: received_global_plan, period: 1.0}
               odom: {source: odom}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg, queue_size: 100}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 1.0}

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -209,15 +209,16 @@
               heartbeat: {source: marine/heartbeat}
               heartbeat_nav: {source: marine/status/mission_manager}
               hover_viz: {source: hover_visualization}
-              # Reflex collision cloud (#170). Throttled to 1 Hz on the VPN
-              # link (period: 1.0) — VPN is the constrained OTH/Starlink budget
-              # path (1 MB/s cap); 1 Hz is enough for operator SA there. Full
-              # rate retained on the WiFi link above.
-              collision_pointcloud: {source: collision_monitor/pointcloud, period: 1.0}
-              # Danger-zone polygons throttled to 1 Hz on VPN to match the cloud;
-              # state is tiny and sent unthrottled for prompt mode changes (#170).
-              collision_slowdown_polygon: {source: collision_monitor/slowdown_polygon, period: 1.0}
-              collision_stop_polygon: {source: collision_monitor/stop_polygon, period: 1.0}
+              # Reflex collision cloud + danger-zone polygons + state (#170). Sent
+              # unthrottled on VPN too: each is small (cloud <2 KB/msg, polygons +
+              # state smaller) and is core OTH situational awareness — the operator's
+              # only view of what reflex CA sees and whether it's intervening. The
+              # 1 Hz throttle these previously carried was removed deliberately to
+              # prioritise SA overlays on the link; the heavy costmap window below
+              # keeps its throttle as the budget's one big consumer.
+              collision_pointcloud: {source: collision_monitor/pointcloud}
+              collision_slowdown_polygon: {source: collision_monitor/slowdown_polygon}
+              collision_stop_polygon: {source: collision_monitor/stop_polygon}
               collision_monitor_state: {source: collision_monitor_state}
               # Cropped local-costmap window for operator SA over the constrained VPN
               # link — throttled to every 2 s (unh_marine_navigation#38, #127). The
@@ -228,9 +229,10 @@
               # Survey-line obstacle-avoidance overlay (unh_marine_navigation#30) —
               # intermittent + small, unthrottled like the path-follower viz above.
               survey_obstacle_avoidance: {source: survey_obstacle_avoidance}
-              # Followed path for CAMP's platform path-line overlay (camp#55),
-              # throttled to 1 Hz on the constrained VPN/Starlink link.
-              received_global_plan: {source: received_global_plan, period: 1.0}
+              # Followed path for CAMP's platform path-line overlay (camp#55).
+              # Republishes only on path change (stable on-line; bursts only while
+              # avoiding), so unthrottled like the overlay it pairs with.
+              received_global_plan: {source: received_global_plan}
               odom: {source: odom}
               oak_forward_ffmpeg: {source: sensors/cameras/oak_forward/image_raw/ffmpeg, queue_size: 100}
               oak_segmentation_forward:      {source: sensors/cameras/oak_forward/segmentation/compressed, period: 1.0}


### PR DESCRIPTION
## Summary

Forward two topics over the bizzyboat `udp_bridge` so the survey-line
obstacle-avoidance operator feedback reaches CAMP **over-the-horizon**, not just
on the boat's local DDS network. Added to both the **WiFi** and **VPN** connection
blocks (each `topics_list` + `topics` dict).

| Topic | Type | Why | Rate |
|---|---|---|---|
| `survey_obstacle_avoidance` | `visualization_msgs/MarkerArray` | The avoidance overlay (nominal line, adjusted path, "avoiding" band, flag) from rolker/unh_marine_navigation#30 / PR #51. CAMP auto-discovers MarkerArrays. | Unthrottled both links (matches `path_follower_visualization`; only published while deviating) |
| `received_global_plan` | `nav_msgs/Path` | The followed path for CAMP's platform path-line overlay, consumed after the rolker/camp#55 subscription fix. | Full-rate WiFi; `period: 1.0` on VPN |

## Why it's needed

The bridge forwards an explicit allow-list, not the whole DDS graph.
`path_follower_visualization` was already forwarded, but
`survey_obstacle_avoidance` is new and `received_global_plan` was never bridged
(the bridged `plan` is a different source). Without this change the overlay and
path-line only render when the operator shares the boat's network.

## VPN throttle review (operator-SA topics)

All viz/marker/path topics already reach the VPN block (none are WiFi-only). On
review, removed the VPN `period` throttle from the small, SA-critical topics so
they run full-rate over-the-horizon — OTH is exactly when the operator depends on
them most, and each is cheap:

- `received_global_plan` (this PR) — republishes only on path change.
- `collision_pointcloud` + `collision_slowdown_polygon` + `collision_stop_polygon`
  (previously 1 Hz, #170) — small (<2 KB/msg); the operator's only OTH view of what
  reflex CA sees and when it intervenes.

`local_costmap_windowed` **keeps** its 0.5 Hz throttle — it is the group's one big
consumer, and the 1 MB/s VPN cap is an allocation budget (unthrottling it would
starve the camera overlays), not just a total.

## Related

- rolker/unh_marine_navigation#30 / PR #51 — the node that publishes `survey_obstacle_avoidance`.
- rolker/camp#55 — the CAMP-side fix that consumes `received_global_plan`.
- Distinct from #183 (reflex Collision-Monitor overlay/annunciator).

## Test plan

- [x] `bizzyboat.yaml` parses (`yaml.safe_load`); both topics present in `topics_list` + `topics` for WiFi and VPN
- [ ] On a deployment: confirm `/bizzy/survey_obstacle_avoidance` and `/bizzy/received_global_plan` appear at the operator station and render in CAMP

Closes #199

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`


