### PR TITLE
Enable controller-layer obstacle avoidance on BizzyBoat (FollowPath flip)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -91,3 +91,43 @@ collision_monitor:
       min_height: -2.0
       max_height: 2.0
       enabled: true
+
+# Controller-layer survey-line obstacle avoidance (rolker/unh_marine_navigation#59,
+# echoboats#206). Flip BizzyBoat's FollowPath controller from the bare crabbing
+# tracker to the AvoidanceController decorator, with crabbing as its inner. The
+# decorator reshapes the followed path around obstacles using the controller_server's
+# own in-process local costmap (fresh by construction — fixes the staleness/anchor
+# problems of the old BT-node avoider, rolker/unh_marine_navigation#57).
+#
+# Deep-merged over seafloor's nav2_params.base.yaml: this overrides FollowPath.plugin
+# and adds primary_controller + the avoidance tunables; the inner crabbing keeps
+# reading the base's FollowPath.default_speed / pid.* / visualization (same FollowPath
+# namespace), so the tracker itself is unchanged. BizzyBoat-only — other EchoBoats
+# stay crabbing-direct.
+#
+# REQUIRES marine_nav_avoidance_controller built in core_ws (PR
+# rolker/unh_marine_navigation#60). Without the plugin, controller_server cannot
+# load AvoidanceController and there is no FollowPath controller — deploy together.
+controller_server:
+  ros__parameters:
+    FollowPath:
+      plugin: "marine_nav_avoidance_controller::AvoidanceController"
+      primary_controller: "marine_nav_crabbing_path_follower::CrabbingPathFollower"
+      # Corridor-solver tunables (live via `ros2 param set <controller_server>
+      # FollowPath.<name>`). obstacle_avoidance_weight 1.0 == 1:1 with
+      # line_following_weight for a clearly visible bend (raised from the 0.02
+      # placeholder per the 2026-06-01 field finding); SIM/ON-WATER TUNE before
+      # trusting. anchor_behind_distance anchors the detour entry behind the boat
+      # so the tracker actually follows it (#59 fix).
+      max_deviation: 6.0
+      along_track_spacing: 2.0
+      lateral_resolution: 0.5
+      line_following_weight: 1.0
+      obstacle_avoidance_weight: 1.0
+      smoothness_weight: 2.0
+      chatter_damping_weight: 0.0
+      max_lateral_change: 1.0
+      anchor_behind_distance: 4.0
+      # avoid_speed 0.0 = no slowdown through the manoeuvre (controller default
+      # speed). Off for v1; enable + tune on the water if a slowdown is wanted.
+      avoid_speed: 0.0


### PR DESCRIPTION
Closes #206

Flip BizzyBoat's `FollowPath` controller (in `bizzyboat_project11/config/nav2_overlay.yaml`,
BizzyBoat-only) from the bare `CrabbingPathFollower` to the
`marine_nav_avoidance_controller::AvoidanceController` decorator, with crabbing as
its `primary_controller`. The decorator reshapes the followed path around obstacles
using the controller_server's own in-process local costmap — the deploy-side
activation of the obstacle-avoidance rearchitecture
(rolker/unh_marine_navigation#59) and the fix for the stale-avoidance symptom
(rolker/unh_marine_navigation#57).

Deep-merged over seafloor's `nav2_params.base.yaml`: overrides `FollowPath.plugin`
and adds `primary_controller` + the corridor tunables; the inner crabbing keeps
reading the base's `FollowPath.default_speed` / `pid.*` / `visualization`, so the
tracker is unchanged. Other EchoBoats stay crabbing-direct.

## ⚠️ Merge/deploy ordering

**Depends on [rolker/unh_marine_navigation#60](https://github.com/rolker/unh_marine_navigation/pull/60).**
Do not deploy before that PR is merged and `core_ws` is rebuilt on the boat —
without the plugin installed, `controller_server` cannot load `AvoidanceController`
and BizzyBoat will have no `FollowPath` controller. Draft until #60 lands + validated.

## Validation (before marking ready)

- [ ] #60 merged + `core_ws` rebuilt on the boat
- [ ] Stack relaunches healthy; `controller_server` loads `AvoidanceController`
- [ ] Sim: ahead path re-plans against a live/clearing costmap; boat rounds a stationary obstacle
- [ ] Progress-checker does not abort during a large deviation
- [ ] On-water validation before the June 15 survey

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
