### PR TITLE
logger: record operator command inputs boat-side (closes #209)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -357,6 +357,13 @@
       - /bizzy/collision_monitor/stop_polygon
       - /bizzy/local_costmap/published_footprint
       - /bizzy/marine/response
+      # Operator command INPUTS — record the raw command bus + manual helm
+      # boat-side so the boat bag is self-contained for "what was commanded,
+      # by whom, when" (incl. manual takeovers). Previously these lived only
+      # in the operator-station bag; the #205 wrap-up needed that bag to
+      # confirm command intent + takeover timing (#209). Both low-rate.
+      - /bizzy/marine/command
+      - /bizzy/piloting_mode/manual/helm
       - /marine/platforms
       - /rosout
       - /tf


### PR DESCRIPTION
Adds the two raw operator command-input topics to the boat-side recorder (`bizzyboat.yaml` `/**/logger` allowlist):

- `/bizzy/marine/command` — operator goto/hover/mission/standby bus
- `/bizzy/piloting_mode/manual/helm` — manual teleop + takeover events

The boat bag already captured command *results* (`marine/response`, mission-manager status, action status); it was missing the *inputs*, which lived only in the operator-station bag. The #205 wrap-up depended on that operator bag to confirm command intent and takeover timing — recording both boat-side makes the boat (the system of record) self-contained. Both low-rate (trivial size).

## Before merge
- [ ] Verify both topics resolve on gabby (bridged from operator, exact names) so the recorder actually captures them.
- [ ] Decide IzzyBoat: `izzyboat_project11/config/izzyboat.yaml` has the same gap — same fix here, or separate? (raised in #209)

Closes #209.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
