### PR TITLE
Add M3 multibeam transducer frame (base_link → m3) to BizzyBoat URDF

### DIFF
--- a/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
+++ b/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
@@ -235,4 +235,13 @@
   <xacro:deltat_sonar parent="bizzy/base_link" name="deltat"
     x="-0.23" y="0.0" z="-0.18"/>
 
+  <!-- ========== Kongsberg M3 Multibeam ========== -->
+  <!-- Loaner unit sharing the DeltaT cavity (x); transducer-face z from the
+       #77 install log ([MEAS] rough). Frame consumed by cube_bathymetry's
+       TF lookup; kongsberg_em_bridge must stamp frame_id "bizzy/m3" (set its
+       frame_id param in the launch). Offsets + orientation to be confirmed by
+       a patch test. -->
+  <xacro:m3_multibeam parent="bizzy/base_link" name="m3"
+    x="-0.23" y="0.0" z="-0.145"/>
+
 </robot>

--- a/bizzyboat_project11/urdf/sensors/sonar.xacro
+++ b/bizzyboat_project11/urdf/sensors/sonar.xacro
@@ -24,4 +24,32 @@
 
   </xacro:macro>
 
+  <!-- Kongsberg M3 multibeam sonar macro.
+       Normally mounted below the hull looking down: roll=pi maps base_link
+       {x-fwd, y-port, z-up} to the sonar frame {x-fwd, y-starboard, z-down},
+       matching the Kongsberg "normally mounted looking down" convention
+       (EM Datagram Formats 850-160692 Note 1) and the
+       marine_acoustic_msgs/SonarDetections frame produced by kongsberg_em_bridge.
+       No yaw (unlike the DeltaT). Orientation is the nominal convention; a
+       patch test confirms/refines it (and resolves handedness). -->
+  <xacro:macro name="m3_multibeam" params="parent name x y z roll:=3.14159 yaw:=0">
+
+    <link name="bizzy/${name}">
+      <visual>
+        <geometry>
+          <box size="0.12 0.10 0.08"/>
+        </geometry>
+        <origin xyz="0 0 0"/>
+        <material name="sonar_gray"/>
+      </visual>
+    </link>
+
+    <joint name="base_to_${name}" type="fixed">
+      <parent link="${parent}"/>
+      <child link="bizzy/${name}"/>
+      <origin xyz="${x} ${y} ${z}" rpy="${roll} 0 ${yaw}"/>
+    </joint>
+
+  </xacro:macro>
+
 </robot>


### PR DESCRIPTION
## Summary

Adds the **M3 multibeam transducer frame** (`bizzy/base_link → bizzy/m3`) to the
BizzyBoat URDF. The M3 is a loaner that was never added to the description, so the
TF tree had no `m3` frame — and `cube_bathymetry` georeferences soundings via a TF
lookup to the map frame, so without it nothing georeferences. This was the one
blocker on the live-coverage-in-CAMP path.

## Change

- New `m3_multibeam` xacro macro in `urdf/sensors/sonar.xacro` (mirrors
  `deltat_sonar`, but **no yaw** — the M3 frame follows the standard downward-MBES
  convention, unlike the DeltaT).
- Instantiates `bizzy/m3` in `bizzyboat.urdf.xacro` at the #77 install offsets:
  `x=-0.23` (shares the DeltaT cavity), `y=0.0`, `z=-0.145` (transducer face),
  `rpy=(π,0,0)`.

`roll=π` maps base_link `{x-fwd, y-port, z-up}` → sonar `{x-fwd, y-starboard,
z-down}`, matching the Kongsberg "normally mounted looking down" convention (EM
Datagram Formats 850-160692 Note 1) and the `marine_acoustic_msgs/SonarDetections`
frame that `kongsberg_em_bridge` (rolker/marine_tools#14) produces.

## Validation

`bizzyboat_project11` builds; full `bizzyboat.urdf.xacro` processes with the new
frame:

```
<joint name="base_to_m3" type="fixed">
  <parent link="bizzy/base_link"/>
  <child link="bizzy/m3"/>
  <origin rpy="3.14159 0 0" xyz="-0.23 0.0 -0.145"/>
```

## Notes / follow-ups

- `kongsberg_em_bridge` must stamp `frame_id = bizzy/m3` — set its `frame_id`
  param when wiring it into `perception_launch.py` (next step on the coverage path).
- Offsets are `[MEAS]` rough and the orientation is the nominal convention; a
  **patch test** confirms/refines both. The driver's angle convention is fixed from
  spec, so the patch test validates this URDF, not a driver sign.

Closes #221. Part of #77.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
