### PR TITLE
Wire M3 (bridge + cube bathymetry) into BizzyBoat perception launch

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -34,6 +34,15 @@
     map_frame: bizzy/map
     cell_size: 0.5
 
+# M3 -> SonarDetections -> soundings: the CUBE error model's pose comes from TF
+# (roll/pitch from level_frame, heave from tide_frame) + /odom (SOG); odom is
+# remapped to /bizzy/odom in perception_launch.py.
+/**/detections_to_pointcloud:
+  ros__parameters:
+    base_link_frame: bizzy/base_link
+    level_frame: bizzy/base_link_north_up
+    tide_frame: bizzy/map_tide
+
 /**/mru_transform:
   ros__parameters:
     sensors:

--- a/bizzyboat_project11/launch/perception_launch.py
+++ b/bizzyboat_project11/launch/perception_launch.py
@@ -95,6 +95,46 @@ def generate_launch_description():
                     ]
                 ),
 
+                # M3 multibeam + cube bathymetry.
+                # Unlike the DeltaT (which publishes `soundings` directly), the
+                # M3 chain is three nodes: kongsberg_em_bridge decodes the M3's
+                # UDP Kongsberg .all stream to SonarDetections, then
+                # detections_to_pointcloud -> cube_bathymetry_node grid it. The
+                # bridge stamps `bizzy/m3` (the URDF transducer frame, #221).
+                GroupAction(
+                    actions=[
+                        PushRosNamespace('sensors/m3'),
+                        Node(
+                            package='kongsberg_em_bridge',
+                            executable='kongsberg_em_bridge',
+                            name='kongsberg_em_bridge',
+                            parameters=[{
+                                'bind_port': 20002,
+                                'frame_id': 'bizzy/m3',
+                            }],
+                            emulate_tty=True
+                        ),
+                        IncludeLaunchDescription(
+                            PythonLaunchDescriptionSource(
+                                PathJoinSubstitution([
+                                    FindPackageShare('cube_bathymetry'),
+                                    'launch',
+                                    'detections_to_pointcloud_launch.py'
+                                ])
+                            )
+                        ),
+                        IncludeLaunchDescription(
+                            PythonLaunchDescriptionSource(
+                                PathJoinSubstitution([
+                                    FindPackageShare('cube_bathymetry'),
+                                    'launch',
+                                    'cube_bathymetry_launch.py'
+                                ])
+                            )
+                        ),
+                    ]
+                ),
+
                 # Cameras
                 GroupAction(
                     actions=[

--- a/bizzyboat_project11/launch/perception_launch.py
+++ b/bizzyboat_project11/launch/perception_launch.py
@@ -114,6 +114,10 @@ def generate_launch_description():
                             }],
                             emulate_tty=True
                         ),
+                        # detections_to_pointcloud reads "odom" for speed-over-
+                        # ground; it lives outside this sensors/m3 namespace.
+                        # (Its TF frame params are set in bizzyboat.yaml.)
+                        SetRemap(src='odom', dst='/bizzy/odom'),
                         IncludeLaunchDescription(
                             PythonLaunchDescriptionSource(
                                 PathJoinSubstitution([


### PR DESCRIPTION
## Summary

Wires the M3 multibeam into `bizzyboat_project11/launch/perception_launch.py` so
live coverage reaches CAMP. Adds a `sensors/m3` group (mirroring the DeltaT group).

The DeltaT publishes `soundings` directly, so its group is just driver +
`cube_bathymetry_node`. The M3 chain is **three nodes**:

```
kongsberg_em_bridge (UDP Kongsberg .all -> SonarDetections, frame bizzy/m3)
  -> detections_to_pointcloud (-> PointCloud2 soundings)
  -> cube_bathymetry_node (-> grid_map_msgs/GridMap "grid")
```

CAMP's `grid_manager` auto-discovers any `grid_map_msgs/GridMap` topic, so the
`/bizzy/sensors/m3/grid` output renders as a coverage layer with no CAMP-side
config.

## Validation

`generate_launch_description()` builds cleanly (6 top-level entities).
Full end-to-end (replay bags -> chain -> CAMP) is the next step.

## Dependencies / notes

- #221 — the `bizzy/m3` URDF frame (the bridge stamps `frame_id=bizzy/m3`,
  `cube_bathymetry_node` looks it up via TF).
- rolker/marine_tools#14 — the `kongsberg_em_bridge` package.
- `detections_to_pointcloud` gets its nav (for TPU) from `bizzyboat.yaml` via the
  group's `SetParametersFromFile`.

Closes #225. Part of #77.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
