### PR TITLE
[seafloor#43] BizzyBoat CA-safety overlay tuning (240)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -109,6 +109,28 @@ collision_monitor:
       max_height: 2.0
       enabled: true
 
+# Marine CA safety node (rolker/unh_marine_navigation#64) — DEFAULT helm gate on
+# BizzyBoat (use_ca_safety:=true), replacing the Collision Monitor block above
+# (kept as the use_ca_safety:=false fallback). Per-rig tuning: the reflex cloud
+# feed + zone geometry mirroring the Collision Monitor it supersedes (20 m
+# slowdown box / 5 m x 4 m stop), now speed-scaled. Base wiring (frames, cmd_vel
+# topics, odom, viz topics) is in seafloor's nav2_params.base.yaml.
+# NB: reverse-yaw passthrough stays OFF (cancel_yaw_during_reverse: true) until
+# the sim yaw-sign-in-reverse test passes — see #64.
+ca_safety:
+  ros__parameters:
+    pointcloud_topic: "collision_monitor/pointcloud"
+    slowdown_min_length: 5.0
+    slowdown_max_length: 20.0
+    slowdown_width: 6.0
+    ttc_time_constant: 4.0
+    stop_length: 5.0
+    stop_width: 4.0
+    reverse_speed: 0.5
+    reverse_distance: 3.0
+    reverse_duration: 4.0
+    cancel_yaw_during_reverse: true
+
 # Controller-layer survey-line obstacle avoidance (rolker/unh_marine_navigation#59,
 # echoboats#206). Flip BizzyBoat's FollowPath controller from the bare crabbing
 # tracker to the AvoidanceController decorator, with crabbing as its inner. The

--- a/bizzyboat_project11/launch/nav_launch.py
+++ b/bizzyboat_project11/launch/nav_launch.py
@@ -15,8 +15,18 @@ def generate_launch_description():
         'namespace', default_value=TextSubstitution(text='bizzy')
     )
 
+    # Field revert hatch: use_ca_safety:=false falls back to the nav2 Collision
+    # Monitor (default true = the new CA safety node helm gate, #64).
+    use_ca_safety = LaunchConfiguration('use_ca_safety')
+    use_ca_safety_arg = DeclareLaunchArgument(
+        'use_ca_safety', default_value='true',
+        description='Use the CA safety node helm gate (default); false reverts '
+        'to the nav2 Collision Monitor.'
+    )
+
     return LaunchDescription([
         namespace_arg,
+        use_ca_safety_arg,
 
         # Nav2
         IncludeLaunchDescription(
@@ -31,6 +41,7 @@ def generate_launch_description():
                 'namespace': namespace,
                 'use_namespace': 'true',
                 'use_composition': 'false',
+                'use_ca_safety': use_ca_safety,
                 # BizzyBoat is an EchoBoat 240; supply its sensor-rig + reflex
                 # overlay on top of the generic base + 240 hull params (seafloor#3).
                 'model': '240',


### PR DESCRIPTION
Enable the marine **CA safety node** as BizzyBoat's helm gate by adding the 240 `ca_safety` overlay tuning (companion to rolker/seafloor_echoboat_project11#43; node from rolker/unh_marine_navigation#64).

## Change (`bizzyboat_project11/config/nav2_overlay.yaml`)
- Add the `ca_safety` param block (240 sensor rig): reflex pointcloud feed (`collision_monitor/pointcloud`) + zone geometry mirroring the Collision Monitor it replaces — 20 m slowdown box, 5 m × 4 m stop — now speed-scaled.
- `cancel_yaw_during_reverse: true` (straight reverse brake); reverse-yaw-passthrough stays **off** until the sim yaw-sign-in-reverse test passes (#64).
- The Collision Monitor block is kept as the `use_ca_safety:=false` fallback.

Generic launch plumbing + base wiring: rolker/seafloor_echoboat_project11#43. Runtime dep `marine_nav_ca_safety`: rolker/unh_marine_navigation#64.

Relates to rolker/seafloor_echoboat_project11#43, rolker/unh_marine_navigation#64. Origin: #205.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
