### PR TITLE
docs(logs): backfill 06-04 + 06-05 salmon logs from operator bag sidecars

### DIFF
--- a/docs/logs/2026/2026-06-04_salmon_logs.md
+++ b/docs/logs/2026/2026-06-04_salmon_logs.md
@@ -18,7 +18,7 @@ deficiency on survey paths. Root-caused dev-side to cross-track PID over-command
 yaw 3–4× hull capability → undamped overshoot closing into 360° loops on
 planner-generated paths. Tracked at
 [unh_marine_navigation#66](https://github.com/rolker/unh_marine_navigation/issues/66)
-(top roadmap priority; not location-specific — will travel to Lake Massabesic).
+(top roadmap priority; not location-specific — expected to reproduce elsewhere).
 
 **2026-06-04 10:38:46 EDT** — Pilot: "way over corrected for avoid obstacle."
 Obstacle-avoidance over-correction (avoider-in-loop weave). Data point for

--- a/docs/logs/2026/2026-06-04_salmon_logs.md
+++ b/docs/logs/2026/2026-06-04_salmon_logs.md
@@ -1,0 +1,46 @@
+# 2026-06-04 — salmon log (BizzyBoat outing, backfilled)
+
+Host: salmon
+Side: field (operator station)
+
+> **Backfilled 2026-06-07 (echoboats#174).** No live agent log was written on
+> this day. This record is reconstructed from the durable operator-log sidecar
+> `~/data/logs/operator/2026-06-04/operator_log.jsonl` (Pilot entries) plus the
+> dev-side bag analysis already captured in
+> [`2026-06-03_dev_logs.md`](2026-06-03_dev_logs.md). Times are EDT, converted
+> from the entry `ts_ns`. Bags: main `bizzyboat/2026-06-04T13-43-04+00-00`;
+> operator `operator/2026-06-04/`.
+
+## Timeline (operator notes)
+
+**2026-06-04 10:25:53 EDT** — Pilot: "not following line properly." Line-following
+deficiency on survey paths. Root-caused dev-side to cross-track PID over-commanding
+yaw 3–4× hull capability → undamped overshoot closing into 360° loops on
+planner-generated paths. Tracked at
+[unh_marine_navigation#66](https://github.com/rolker/unh_marine_navigation/issues/66)
+(top roadmap priority; not location-specific — will travel to Lake Massabesic).
+
+**2026-06-04 10:38:46 EDT** — Pilot: "way over corrected for avoid obstacle."
+Obstacle-avoidance over-correction (avoider-in-loop weave). Data point for
+[unh_marine_navigation#63](https://github.com/rolker/unh_marine_navigation/issues/63).
+
+**2026-06-04 13:33:01 EDT** — Pilot: "Velocity smoother was disabled." Operator
+disabled the cmd_vel velocity_smoother mid-run to test its effect on the weave —
+"didn't seem to help." Dev-side verification (analysis `~/data/logs/analysis/2026-06-04/`):
+while in-loop, `cmd_vel_smoothed` yaw ≈ `cmd_vel_nav` yaw (median diff 0.000 rad/s)
+— the smoother is near-transparent on yaw, so the weave originates upstream
+(controller/avoider), not the smoother. NB: the ±1.0 rad/s yaw clamp lives *in*
+the smoother, so bypassing it removed the clamp (raw nav yaw ±2.4 reached the
+command), tending to make the weave sharper. Posted to nav#63. Confirms the
+smoother (re-enabled seafloor#36) is not the weave source.
+
+## Issues encountered
+
+- Line-following 360° loops → nav#66 (root-caused, top priority).
+- Obstacle-avoidance over-correction weave → nav#63 (smoother ruled out as source).
+
+## Notes
+
+The full cmd_vel-chain analysis for this outing lives in the 2026-06-03 dev log
+(written when the bags were pulled and analyzed). This salmon backfill captures
+the operator-voice timeline that was otherwise only in the bag sidecar.

--- a/docs/logs/2026/2026-06-05_salmon_logs.md
+++ b/docs/logs/2026/2026-06-05_salmon_logs.md
@@ -1,0 +1,56 @@
+# 2026-06-05 — salmon log (BizzyBoat outing, backfilled)
+
+Host: salmon
+Side: field (operator station)
+
+> **Backfilled 2026-06-07 (echoboats#174).** No live agent log was written on
+> this day. This record is reconstructed from the durable operator-log sidecar
+> `~/data/logs/operator/2026-06-05/operator_log.jsonl` (Pilot entries). Times are
+> EDT, converted from the entry `ts_ns`. Bags: operator `operator/2026-06-05/`
+> (incl. screenshooter `operator_2026-06-05.mp4`, 333 frames).
+
+## Timeline (operator notes)
+
+**2026-06-05 11:32:04 EDT** — Pilot: "Boat is in the water."
+
+**2026-06-05 12:57:14 EDT** — Pilot: "Twice I noticed the boat drift away from the
+hover. I did not figure out why the first time, but the second time, I noticed
+whitecaps were triggering the e stop making it drift." **Whitecaps are
+false-triggering the collision-monitor e-stop**, dropping the hover and letting
+the boat drift. Sea-surface perception **false positive** — the complementary
+failure mode to the 2026-06-03 lobster-pot false *negative* (buoy absent from the
+costmap; only the e-stop sensor caught it). Filed
+[unh_marine_perception#31](https://github.com/rolker/unh_marine_perception/issues/31)
+(cross-links perception#26; also flags the hover + reflex-e-stop interaction as a
+nav-side question — a reflex stop during active hover drifts instead of
+re-acquiring station).
+
+**2026-06-05 13:33:04 EDT** — Pilot: "so, gabby's ethernet port did not activate
+when the garmin was plugged into them, but mercat's did so going try testing via
+mercat." **Garmin GCV-10 sidescan: gabby NIC did not link; mercat did** — testing
+moved to mercat. gabby is the intended Linux/ROS host for the sidescan driver, so
+this blocks the on-boat integration path. Likely a gabby-side NIC
+config/negotiation/cabling issue, not a Garmin fault. Filed
+[unh_echoboats_project11#229](https://github.com/rolker/unh_echoboats_project11/issues/229).
+
+**2026-06-05 14:31:20 EDT** — Pilot: "camp locked up." CAMP **hang/lockup**
+(distinct from the 2026-06-03 trackline-removal crash, camp#65, which
+auto-respawned). Added as a dated occurrence to the intermittent-GUI-hang
+investigation [camp#52](https://github.com/rolker/camp/issues/52) (see also
+echoboats#166). No backtrace / Qt-heartbeat capture taken at the time.
+
+**2026-06-05 14:46:35 EDT** — Pilot: "boat recovered." End of on-water ops.
+
+## Issues encountered
+
+- Whitecaps false-trigger the e-stop → hover drift → perception#31 (NEW).
+- Garmin sidescan: gabby NIC no link → echoboats#229 (NEW).
+- CAMP lockup → camp#52 / echoboats#166 (new occurrence; no capture).
+
+## Carry-forward
+
+- perception#31 is the highest-signal new finding — a sea-surface perception
+  false-positive found on water and recorded nowhere but the bag. Pairs with the
+  06-03 false-negative; both feed the pre-class shakedown (echoboats#228).
+- The Garmin NIC blocker (echoboats#229) sits on the parallel sidescan driver
+  effort, not the June survey path.


### PR DESCRIPTION
## What

Backfills two missing deployment logs from the durable operator-log bag
sidecars on salmon:

- `docs/logs/2026/2026-06-04_salmon_logs.md`
- `docs/logs/2026/2026-06-05_salmon_logs.md`

Both 2026-06-04 and 2026-06-05 were real on-water outings (06-05 alone has 333
screenshooter frames + bags) but had **no committed deployment log on any host**.
The only surviving record was `~/data/logs/operator/<day>/operator_log.jsonl` —
the per-entry durable sidecar from the 2026-06-03 operator-log durability fix
(`rqt_operator_tools` 24fa965). Each log is reconstructed from the Pilot entries,
framed explicitly as a backfill, with `ts_ns` converted to EDT.

## Why it matters

06-05 surfaced findings recorded **nowhere but the bag**:

- **Whitecaps false-trigger the collision-monitor e-stop → boat drifts off hover**
  — a sea-surface perception false positive, complementary to the 2026-06-03
  lobster-pot false negative. Filed rolker/unh_marine_perception#31.
- **Garmin GCV-10 sidescan: gabby NIC won't link** (mercat does) — blocks the
  on-boat sidescan driver path. Filed #229.
- **CAMP lockup** — new occurrence added to rolker/camp#52 (hang investigation).

06-04 cross-references the line-following / velocity-smoother work already
analyzed dev-side (nav#66, nav#63).

## Provenance / accuracy

These are reconstructions, not live agent logs — each file says so in a header
note and cites the exact sidecar path and bag names. No claims beyond the Pilot's
own words plus already-committed dev-side analysis.

Part of #174.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
