### PR TITLE
manifest: move marine_tools from core to sensors layer

### DIFF
--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -23,7 +23,3 @@ repositories:
     type: git
     url: git@gitcloud:field/unh_marine_autonomy.git
     version: jazzy
-  marine_tools:
-    type: git
-    url: git@gitcloud:field/marine_tools.git
-    version: jazzy

--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: git@gitcloud:field/ros2_network_monitor.git
     version: jazzy
+  marine_tools:
+    type: git
+    url: git@gitcloud:field/marine_tools.git
+    version: jazzy


### PR DESCRIPTION
Moves `marine_tools` from the **core** layer to the **sensors** layer in the boat
manifest (`config/repos/core.repos` → `config/repos/sensors.repos`).

`marine_tools` is a sensors-layer package — it's `sensors` in the dev
(`unh_marine_autonomy`) and operator (`ccomjhc_project11`) manifests and is checked
out in `sensors_ws/src/marine_tools` on dev. The boat manifest had it in `core`,
which would clone it into `core_ws/src` and build it a layer too low (core cannot
depend on sensors/ui). This aligns all three manifests.

Same gitcloud URL and version; only the layer file changes.

Closes #231. Found during the manifest audit for rolker/unh_marine_autonomy#137.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
