### PR TITLE
Wire Garmin GCV-20 sidescan into BizzyBoat (launch wrapper + recording + mercat proxy service)

### DIFF
--- a/.agent/work-plans/issue-234/progress.md
+++ b/.agent/work-plans/issue-234/progress.md
@@ -17,8 +17,8 @@ issue: 234
 ### Findings
 - [x] (must-fix, Copilot) debug_raw passed as LaunchConfiguration (string) but node declares it bool -> node fails on startup; crash-loops now that sidescan is on-by-default — wrap in ParameterValue(value_type=bool) — `bizzyboat_project11/launch/sidescan_launch.py`
 - [x] (should-fix, Copilot) sound_speed_topic hard-coded /bizzy/...; add a namespace arg, derive the SV topic from it, pass namespace from core_launch — `sidescan_launch.py`, `core_launch.py`
-- [ ] (doc, Copilot) PR #236 body still says it vendors mercat/* scripts; they were de-vendored to marine_tools — update the PR description
-- [ ] (defensive, Copilot) install_proxy_service.ps1 passes all powershell flags to nssm as one string token; pass each as a separate token — NOTE: this file is in MERGED marine_tools (#21), needs a follow-up there, not in #236
+- [x] (doc, Copilot) PR #236 body still says it vendors mercat/* scripts; they were de-vendored to marine_tools — update the PR description
+- [x] (defensive, Copilot) install_proxy_service.ps1 NSSM single-string args -> tracked in marine_tools#22 (merged code, needs Windows verification)
 
 ### False positives
 - (Copilot x3) sidescan default 'true' / "on by default" comments contradict issue's opt-in — superseded by explicit user instruction to make sidescan on by default; code + comments are consistent and correct.

--- a/.agent/work-plans/issue-234/progress.md
+++ b/.agent/work-plans/issue-234/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 234
+---
+
+# Issue #234 — Wire Garmin GCV-20 sidescan into BizzyBoat (launch wrapper + recording)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-07 22:04 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #236 at `942606d`
+**Sources**: 2 Copilot reviews (@ `361c834`, @ `942606d`)
+**Cross-source confirmations**: 0
+**CI**: copilot check pass (no build gate — config/launch repo)
+
+### Findings
+- [ ] (must-fix, Copilot) debug_raw passed as LaunchConfiguration (string) but node declares it bool -> node fails on startup; crash-loops now that sidescan is on-by-default — wrap in ParameterValue(value_type=bool) — `bizzyboat_project11/launch/sidescan_launch.py`
+- [ ] (should-fix, Copilot) sound_speed_topic hard-coded /bizzy/...; add a namespace arg, derive the SV topic from it, pass namespace from core_launch — `sidescan_launch.py`, `core_launch.py`
+- [ ] (doc, Copilot) PR #236 body still says it vendors mercat/* scripts; they were de-vendored to marine_tools — update the PR description
+- [ ] (defensive, Copilot) install_proxy_service.ps1 passes all powershell flags to nssm as one string token; pass each as a separate token — NOTE: this file is in MERGED marine_tools (#21), needs a follow-up there, not in #236
+
+### False positives
+- (Copilot x3) sidescan default 'true' / "on by default" comments contradict issue's opt-in — superseded by explicit user instruction to make sidescan on by default; code + comments are consistent and correct.

--- a/.agent/work-plans/issue-234/progress.md
+++ b/.agent/work-plans/issue-234/progress.md
@@ -15,8 +15,8 @@ issue: 234
 **CI**: copilot check pass (no build gate — config/launch repo)
 
 ### Findings
-- [ ] (must-fix, Copilot) debug_raw passed as LaunchConfiguration (string) but node declares it bool -> node fails on startup; crash-loops now that sidescan is on-by-default — wrap in ParameterValue(value_type=bool) — `bizzyboat_project11/launch/sidescan_launch.py`
-- [ ] (should-fix, Copilot) sound_speed_topic hard-coded /bizzy/...; add a namespace arg, derive the SV topic from it, pass namespace from core_launch — `sidescan_launch.py`, `core_launch.py`
+- [x] (must-fix, Copilot) debug_raw passed as LaunchConfiguration (string) but node declares it bool -> node fails on startup; crash-loops now that sidescan is on-by-default — wrap in ParameterValue(value_type=bool) — `bizzyboat_project11/launch/sidescan_launch.py`
+- [x] (should-fix, Copilot) sound_speed_topic hard-coded /bizzy/...; add a namespace arg, derive the SV topic from it, pass namespace from core_launch — `sidescan_launch.py`, `core_launch.py`
 - [ ] (doc, Copilot) PR #236 body still says it vendors mercat/* scripts; they were de-vendored to marine_tools — update the PR description
 - [ ] (defensive, Copilot) install_proxy_service.ps1 passes all powershell flags to nssm as one string token; pass each as a separate token — NOTE: this file is in MERGED marine_tools (#21), needs a follow-up there, not in #236
 

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -391,6 +391,17 @@
       - /bizzy/odom
       - /bizzy/robot_description
       - /bizzy/sensors/deltat/soundings
+      # Garmin GCV-20 sidescan (only present when core_launch sidescan:=true).
+      # Decoded per-channel imagery + latched control/status. debug/raw_status
+      # carries the GCV :50050 status stream (incl. the unverified depth field);
+      # it is only published when the driver runs with debug_raw:=true, recorded
+      # here so the first wet run captures it for the offline depth decode.
+      - /bizzy/sensors/sidescan/garmin_sidescan/sonar_image_port
+      - /bizzy/sensors/sidescan/garmin_sidescan/sonar_image_starboard
+      - /bizzy/sensors/sidescan/garmin_sidescan/sonar_image_down
+      - /bizzy/sensors/sidescan/garmin_sidescan/state
+      - /bizzy/sensors/sidescan/garmin_sidescan/status
+      - /bizzy/sensors/sidescan/garmin_sidescan/debug/raw_status
       # Sound-speed for bathy correction in post-processing.
       - /bizzy/sensors/sound_speed/sound_speed
       # SBG INS for sonar motion compensation + georeferencing.

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -391,7 +391,7 @@
       - /bizzy/odom
       - /bizzy/robot_description
       - /bizzy/sensors/deltat/soundings
-      # Garmin GCV-20 sidescan (only present when core_launch sidescan:=true).
+      # Garmin GCV-20 sidescan (on by default; absent if core_launch sidescan:=false).
       # Decoded per-channel imagery + latched control/status. debug/raw_status
       # carries the GCV :50050 status stream (incl. the unverified depth field);
       # it is only published when the driver runs with debug_raw:=true, recorded

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -318,6 +318,7 @@ def generate_launch_description():
                         ])
                     ),
                     launch_arguments={
+                        'namespace': namespace,
                         'frame_prefix': frame_prefix,
                     }.items(),
                     condition=IfCondition(sidescan)

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -35,12 +35,13 @@ def generate_launch_description():
         'gcs_url', default_value=TextSubstitution(text='')
     )
 
-    # Garmin GCV-20 sidescan. Off by default: it depends on the mercat proxy
-    # being up (see sidescan_launch.py) and is a parallel effort, not part of
-    # every mission. Enable with sidescan:=true.
+    # Garmin GCV-20 sidescan. On by default so it comes up with the boat; the
+    # driver transmits nothing until commanded and is gated on a valid sound
+    # speed, so with the mercat proxy or GCV absent it simply retries (no harm).
+    # Disable with sidescan:=false.
     sidescan = LaunchConfiguration('sidescan')
     sidescan_arg = DeclareLaunchArgument(
-        'sidescan', default_value='false'
+        'sidescan', default_value='true'
     )
 
     return LaunchDescription([
@@ -307,7 +308,7 @@ def generate_launch_description():
                 ),
 
                 # Garmin GCV-20 sidescan (gabby driver -> mercat proxy -> GCV).
-                # Opt-in: requires the mercat proxy; enable with sidescan:=true.
+                # On by default; disable with sidescan:=false.
                 IncludeLaunchDescription(
                     PythonLaunchDescriptionSource(
                         PathJoinSubstitution([

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -2,6 +2,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
@@ -34,11 +35,20 @@ def generate_launch_description():
         'gcs_url', default_value=TextSubstitution(text='')
     )
 
+    # Garmin GCV-20 sidescan. Off by default: it depends on the mercat proxy
+    # being up (see sidescan_launch.py) and is a parallel effort, not part of
+    # every mission. Enable with sidescan:=true.
+    sidescan = LaunchConfiguration('sidescan')
+    sidescan_arg = DeclareLaunchArgument(
+        'sidescan', default_value='false'
+    )
+
     return LaunchDescription([
         namespace_arg,
         frame_prefix_arg,
         fcu_url_arg,
         gcs_url_arg,
+        sidescan_arg,
 
         GroupAction(
             actions=[
@@ -294,6 +304,22 @@ def generate_launch_description():
                     launch_arguments={
                         'frame_prefix': frame_prefix,
                     }.items()
+                ),
+
+                # Garmin GCV-20 sidescan (gabby driver -> mercat proxy -> GCV).
+                # Opt-in: requires the mercat proxy; enable with sidescan:=true.
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('bizzyboat_project11'),
+                            'launch',
+                            'sidescan_launch.py'
+                        ])
+                    ),
+                    launch_arguments={
+                        'frame_prefix': frame_prefix,
+                    }.items(),
+                    condition=IfCondition(sidescan)
                 ),
 
                 # ZDA serial bridge (SBG SbgUtcTime -> $GPZDA on

--- a/bizzyboat_project11/launch/sidescan_launch.py
+++ b/bizzyboat_project11/launch/sidescan_launch.py
@@ -27,9 +27,15 @@ from launch.substitutions import LaunchConfiguration
 from launch.substitutions import TextSubstitution
 from launch_ros.actions import Node
 from launch_ros.actions import PushRosNamespace
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    namespace_arg = DeclareLaunchArgument(
+        'namespace', default_value=TextSubstitution(text='bizzy')
+    )
+
     frame_prefix = LaunchConfiguration('frame_prefix')
     frame_prefix_arg = DeclareLaunchArgument(
         'frame_prefix', default_value='bizzy/'
@@ -53,7 +59,13 @@ def generate_launch_description():
                     '(set true for the first wet run to capture depth bytes)'
     )
 
+    # The sound-speed interlock topic follows the launch namespace (the AML SVS
+    # bridge publishes it under /<namespace>/sensors/sound_speed/), so it stays
+    # correct if core_launch runs under a non-default namespace.
+    sound_speed_topic = ['/', namespace, '/sensors/sound_speed/sound_speed']
+
     return LaunchDescription([
+        namespace_arg,
         frame_prefix_arg,
         gcv_ip_arg,
         iface_ip_arg,
@@ -73,13 +85,14 @@ def generate_launch_description():
                         'gcv_ip': gcv_ip,
                         'iface_ip': iface_ip,
                         'frame_id': [frame_prefix, 'garmin_sidescan'],
-                        'debug_raw': debug_raw,
+                        # debug_raw is a bool node param; type the launch-arg
+                        # string override so ROS 2 doesn't reject "true"/"false".
+                        'debug_raw': ParameterValue(debug_raw, value_type=bool),
                         # SAFE: never transmit on startup; only ping under a
                         # valid sound speed from the AML SVS bridge.
                         'transmit_on_startup': False,
                         'sound_speed_safety_enabled': True,
-                        'sound_speed_topic':
-                            '/bizzy/sensors/sound_speed/sound_speed',
+                        'sound_speed_topic': sound_speed_topic,
                     }],
                     respawn=True,
                     respawn_delay=2.0,

--- a/bizzyboat_project11/launch/sidescan_launch.py
+++ b/bizzyboat_project11/launch/sidescan_launch.py
@@ -1,0 +1,90 @@
+"""Garmin GCV-20 sidescan launch for BizzyBoat.
+
+The garmin_sidescan driver (rolker/marine_tools) runs on gabby, but the GCV-20
+lives on the Garmin Marine Network reachable only from mercat (Windows). On
+mercat, ``garmin_sidescan/tools/garmin_marine_network_proxy.ps1`` (in the
+marine_tools repo) relays the GCV's imagery multicast + TCP control onto gabby's
+LAN; install it as a Windows service with the sibling
+``tools/install_proxy_service.ps1``. The proxy defaults already match this boat
+(``--gcv-ip 172.16.3.0``, ``--listen-ip 192.168.20.8``, ``--relay-to
+192.168.20.5``). So on gabby the driver points at the proxy, not the GCV:
+
+* ``gcv_ip`` = 192.168.20.8  (mercat's bridge NIC = the relay's source address)
+* ``iface_ip`` = 192.168.20.5  (gabby's LAN NIC that the imagery is unicast to)
+
+Transmit is OFF at startup and interlocked on a valid sound speed
+(``/bizzy/sensors/sound_speed/sound_speed``, published by sound_speed_launch.py).
+TF frames for the channels come from ben_description (garmin_sidescan_*).
+
+For the first wet run, set ``debug_raw:=true`` to also record the raw GCV streams
+(needed for the offline depth-field decode that the imagery alone can't verify).
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+
+
+def generate_launch_description():
+    frame_prefix = LaunchConfiguration('frame_prefix')
+    frame_prefix_arg = DeclareLaunchArgument(
+        'frame_prefix', default_value='bizzy/'
+    )
+
+    # Point at the mercat proxy, not the GCV directly (see module docstring).
+    gcv_ip = LaunchConfiguration('gcv_ip')
+    gcv_ip_arg = DeclareLaunchArgument(
+        'gcv_ip', default_value=TextSubstitution(text='192.168.20.8')
+    )
+
+    iface_ip = LaunchConfiguration('iface_ip')
+    iface_ip_arg = DeclareLaunchArgument(
+        'iface_ip', default_value=TextSubstitution(text='192.168.20.5')
+    )
+
+    debug_raw = LaunchConfiguration('debug_raw')
+    debug_raw_arg = DeclareLaunchArgument(
+        'debug_raw', default_value='false',
+        description='Publish raw GCV UDP payloads for offline re-decode '
+                    '(set true for the first wet run to capture depth bytes)'
+    )
+
+    return LaunchDescription([
+        frame_prefix_arg,
+        gcv_ip_arg,
+        iface_ip_arg,
+        debug_raw_arg,
+
+        GroupAction(
+            actions=[
+                # Topics land at /<namespace>/sensors/sidescan/garmin_sidescan/...
+                # matching the /<ns>/sensors/<sensor>/... convention used by the
+                # SBG, deltat, sound_speed, and oak camera nodes.
+                PushRosNamespace('sensors/sidescan'),
+                Node(
+                    package='garmin_sidescan',
+                    executable='garmin_sidescan',
+                    name='garmin_sidescan',
+                    parameters=[{
+                        'gcv_ip': gcv_ip,
+                        'iface_ip': iface_ip,
+                        'frame_id': [frame_prefix, 'garmin_sidescan'],
+                        'debug_raw': debug_raw,
+                        # SAFE: never transmit on startup; only ping under a
+                        # valid sound speed from the AML SVS bridge.
+                        'transmit_on_startup': False,
+                        'sound_speed_safety_enabled': True,
+                        'sound_speed_topic':
+                            '/bizzy/sensors/sound_speed/sound_speed',
+                    }],
+                    respawn=True,
+                    respawn_delay=2.0,
+                    emulate_tty=True,
+                ),
+            ]
+        ),
+    ])


### PR DESCRIPTION
## Summary

Boat-side ROS wiring for the generic `garmin_sidescan` driver (rolker/marine_tools#17,
#21), following the `sound_speed_launch.py` wrapper pattern.

## ROS wiring (gabby)

- **`launch/sidescan_launch.py`** — runs the `garmin_sidescan` node under
  `sensors/sidescan` with `frame_id=<prefix>garmin_sidescan`, the **mercat-proxy**
  IPs (`gcv_ip=192.168.20.8`, `iface_ip=192.168.20.5`), and the sound-speed safety
  interlock derived from the launch `namespace`
  (`/<namespace>/sensors/sound_speed/sound_speed`). Transmit OFF at startup;
  `debug_raw` arg (typed bool) for the first wet run.
- **`core_launch.py`** — included behind a `sidescan` arg (**default true** — on by
  default; disable with `sidescan:=false`), passing `namespace` + `frame_prefix`.
- **`config/bizzyboat.yaml`** — `sonar_logger` records the 3 decoded image topics
  + `state`/`status` + `debug/raw_status`.

## mercat proxy (Windows)

GCV-20 is on the Garmin Marine Network reachable only from **mercat**; the driver
runs on **gabby**. The proxy bridges them. The proxy script **and** its NSSM
service installer live in **marine_tools** (`garmin_sidescan/tools/`), not vendored
here — the mercat agent has that repo cloned, so there's one source of truth and no
drift. `sidescan_launch.py`'s docstring points at them.

## Validation

- `sidescan_launch.py` / `core_launch.py` generate valid LaunchDescriptions;
  `bizzyboat.yaml` loads.
- PowerShell tooling lives in marine_tools and is exercised on mercat.

## Related

- TF frames: rolker/ben_description#14
- Driver + generic launch + proxy/installer: rolker/marine_tools#17, #21

Closes #234.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
