### PR TITLE
Add Garmin GCV-20 sidescan TF frames to BizzyBoat URDF

### DIFF
--- a/.agent/work-plans/issue-237/progress.md
+++ b/.agent/work-plans/issue-237/progress.md
@@ -1,0 +1,31 @@
+---
+issue: 237
+---
+
+# Issue #237 — Add Garmin GCV-20 sidescan TF frames to BizzyBoat URDF
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-09 10:00 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #238 at `de97700`
+**Sources**: 1 (Copilot @ `de97700`; no local review timeline existed for #237)
+**Cross-source confirmations**: 0
+**CI**: all-pass (only the Copilot reviewer check runs on this repo)
+
+### Findings
+- [ ] (valid, Copilot) Documentation inaccuracy — `bizzyboat.urdf.xacro:252` comment claims
+  the driver stamps per-channel images with `bizzy/garmin_sidescan`, but
+  `garmin_sidescan/node.py:757` builds `frame_id = f'{base}_{suffix}'`, yielding
+  `bizzy/garmin_sidescan_down/_port/_starboard`. Also contradicts this PR's own
+  `sidescan.xacro` header (lines 6-9), which is correct. — `bizzyboat_project11/urdf/bizzyboat.urdf.xacro`
+- [ ] (style, Copilot) Channel joints use `${radians(...)}` and order `<origin>` before
+  `<parent>`/`<child>`; sibling sensor macros (`camera_oak.xacro`, `sonar.xacro`) use `pi`
+  math (`${-pi/2}`) and `parent`/`child`/`origin` order. Consistency-only; functionally inert.
+  — `bizzyboat_project11/urdf/sensors/sidescan.xacro` (joints at lines 34/42/50)
+
+### False positives
+- (Copilot) Rationale "avoid relying on `radians()` being available in xacro" — `radians()`
+  IS a xacro built-in (file builds, CI green), so that justification is wrong. The underlying
+  style-consistency finding still stands and is retained above; only Copilot's reason is invalid.

--- a/bizzyboat_project11/launch/sidescan_launch.py
+++ b/bizzyboat_project11/launch/sidescan_launch.py
@@ -14,7 +14,9 @@ LAN; install it as a Windows service with the sibling
 
 Transmit is OFF at startup and interlocked on a valid sound speed
 (``/bizzy/sensors/sound_speed/sound_speed``, published by sound_speed_launch.py).
-TF frames for the channels come from ben_description (garmin_sidescan_*).
+TF frames for the channels (bizzy/garmin_sidescan, _down/_port/_starboard) come
+from BizzyBoat's URDF (urdf/sensors/sidescan.xacro), published by
+robot_state_publisher.
 
 For the first wet run, set ``debug_raw:=true`` to also record the raw GCV streams
 (needed for the offline depth-field decode that the imagery alone can't verify).

--- a/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
+++ b/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
@@ -8,6 +8,7 @@
   <xacro:include filename="$(find bizzyboat_project11)/urdf/sensors/camera_oak.xacro"/>
   <xacro:include filename="$(find bizzyboat_project11)/urdf/sensors/gnss.xacro"/>
   <xacro:include filename="$(find bizzyboat_project11)/urdf/sensors/sonar.xacro"/>
+  <xacro:include filename="$(find bizzyboat_project11)/urdf/sensors/sidescan.xacro"/>
 
   <!-- ========== Hull ========== -->
   <!-- base_link origin: center screw hole in hull floor, near CofG.
@@ -243,5 +244,15 @@
        a patch test. -->
   <xacro:m3_multibeam parent="bizzy/base_link" name="m3"
     x="-0.23" y="0.0" z="-0.145"/>
+
+  <!-- ========== Garmin GCV-20 Sidescan ========== -->
+  <!-- Centered, ~0.15 m forward of base_link, flush against the hull underside.
+       z = -0.30 is the flat hull bottom (hull depth 0.30 below the deck/base_link
+       plane per scripts/generate_hull_mesh.py). The garmin_sidescan driver stamps
+       its per-channel images with frame_id "bizzy/garmin_sidescan" (see
+       launch/sidescan_launch.py); this macro supplies the matching TF frames.
+       Offsets are approximate — confirm by measurement. -->
+  <xacro:garmin_sidescan parent="bizzy/base_link" name="garmin_sidescan"
+    x="0.15" y="0.0" z="-0.30"/>
 
 </robot>

--- a/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
+++ b/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
@@ -249,8 +249,10 @@
   <!-- Centered, ~0.15 m forward of base_link, flush against the hull underside.
        z = -0.30 is the flat hull bottom (hull depth 0.30 below the deck/base_link
        plane per scripts/generate_hull_mesh.py). The garmin_sidescan driver stamps
-       its per-channel images with frame_id "bizzy/garmin_sidescan" (see
-       launch/sidescan_launch.py); this macro supplies the matching TF frames.
+       each channel image with a per-channel frame_id — the base frame_id param
+       ("bizzy/garmin_sidescan", set in launch/sidescan_launch.py) plus a channel
+       suffix, giving "bizzy/garmin_sidescan_down/_port/_starboard"; this macro
+       supplies the matching TF frames.
        Offsets are approximate — confirm by measurement. -->
   <xacro:garmin_sidescan parent="bizzy/base_link" name="garmin_sidescan"
     x="0.15" y="0.0" z="-0.30"/>

--- a/bizzyboat_project11/urdf/sensors/sidescan.xacro
+++ b/bizzyboat_project11/urdf/sensors/sidescan.xacro
@@ -31,25 +31,25 @@
     <!-- Down-look (water-column) beam: +Z down. -->
     <link name="bizzy/${name}_down"/>
     <joint name="${name}_to_${name}_down" type="fixed">
-      <origin xyz="0 0 0" rpy="${radians(180)} 0 0"/>
       <parent link="bizzy/${name}"/>
       <child link="bizzy/${name}_down"/>
+      <origin xyz="0 0 0" rpy="${pi} 0 0"/>
     </joint>
 
     <!-- Port side-scan beam: +Z to port (+Y). -->
     <link name="bizzy/${name}_port"/>
     <joint name="${name}_to_${name}_port" type="fixed">
-      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <parent link="bizzy/${name}"/>
       <child link="bizzy/${name}_port"/>
+      <origin xyz="0 0 0" rpy="${-pi/2} 0 0"/>
     </joint>
 
     <!-- Starboard side-scan beam: +Z to starboard (-Y). -->
     <link name="bizzy/${name}_starboard"/>
     <joint name="${name}_to_${name}_starboard" type="fixed">
-      <origin xyz="0 0 0" rpy="${radians(90)} 0 0"/>
       <parent link="bizzy/${name}"/>
       <child link="bizzy/${name}_starboard"/>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
     </joint>
 
   </xacro:macro>

--- a/bizzyboat_project11/urdf/sensors/sidescan.xacro
+++ b/bizzyboat_project11/urdf/sensors/sidescan.xacro
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- Garmin GCV-20 sidescan sonar — TF frames only (no visual/collision).
+
+       The garmin_sidescan driver (rolker/marine_tools) publishes one
+       RawSonarImage per channel, each stamped with its own frame_id
+       (bizzy/<name>_port / _starboard / _down). Mounting and per-beam
+       orientation live here in TF, never in the driver params.
+
+       Per-channel range axis is the frame's local +Z (rviz_sonar_image places a
+       fixed beam's samples along +Z when rx/tx steering = 0):
+         _down       +Z points down   (matches the M3/DeltaT transducer convention)
+         _port       +Z points to port (+Y)
+         _starboard  +Z points to starboard (-Y)
+
+       PLACEHOLDER: side-scan grazing tilt is 0 (port/starboard beams horizontal).
+       Real side-scan fires a few tens of degrees below horizontal — refine the
+       _port/_starboard pitch once the install is measured/calibrated. -->
+  <xacro:macro name="garmin_sidescan" params="parent name x:=0 y:=0 z:=0">
+
+    <!-- Mount frame, aligned with base_link (X fwd, Y port, Z up). -->
+    <link name="bizzy/${name}"/>
+
+    <joint name="base_to_${name}" type="fixed">
+      <parent link="${parent}"/>
+      <child link="bizzy/${name}"/>
+      <origin xyz="${x} ${y} ${z}" rpy="0 0 0"/>
+    </joint>
+
+    <!-- Down-look (water-column) beam: +Z down. -->
+    <link name="bizzy/${name}_down"/>
+    <joint name="${name}_to_${name}_down" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(180)} 0 0"/>
+      <parent link="bizzy/${name}"/>
+      <child link="bizzy/${name}_down"/>
+    </joint>
+
+    <!-- Port side-scan beam: +Z to port (+Y). -->
+    <link name="bizzy/${name}_port"/>
+    <joint name="${name}_to_${name}_port" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
+      <parent link="bizzy/${name}"/>
+      <child link="bizzy/${name}_port"/>
+    </joint>
+
+    <!-- Starboard side-scan beam: +Z to starboard (-Y). -->
+    <link name="bizzy/${name}_starboard"/>
+    <joint name="${name}_to_${name}_starboard" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(90)} 0 0"/>
+      <parent link="bizzy/${name}"/>
+      <child link="bizzy/${name}_starboard"/>
+    </joint>
+
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
## Summary

Adds the Garmin GCV-20 sidescan TF frames to **BizzyBoat's own URDF**, where the
`garmin_sidescan` driver runs and stamps `bizzy/garmin_sidescan*` frame_ids.

These frames had been added in error to `ben_description` (BEN's URDF) in
[rolker/ben_description#14](https://github.com/rolker/ben_description/pull/14).
BizzyBoat neither includes nor depends on `ben_description`, and BEN's
`robot_state_publisher` doesn't run on bizzy — so the driver's frame_ids never
resolved in bizzy's TF tree. This puts the frames where they belong.

## Changes

- **New** `urdf/sensors/sidescan.xacro` — `garmin_sidescan` macro following
  bizzy's URDF conventions (`bizzy/` prefix, `parent` param, TF-only links, no
  `ben_`/`namespace` styling). Mount frame + `_down`/`_port`/`_starboard` channel
  frames; range axis = each frame's local +Z (`_down` down, `_port` +Y,
  `_starboard` -Y). Side-scan grazing tilt is a 0 placeholder to calibrate.
- **`bizzyboat.urdf.xacro`** — include + instantiate, anchored to `bizzy/base_link`:
  centered, 0.15 m forward, against the hull underside (`z=-0.30`, the flat hull
  bottom per `scripts/generate_hull_mesh.py`). Offsets approximate — confirm by
  measurement.
- **`sidescan_launch.py`** — fix the stale comment that pointed at ben_description.

## Verification

`xacro bizzyboat.urdf.xacro` parses cleanly; output contains
`bizzy/garmin_sidescan`, `_down`, `_port`, `_starboard` with the mount joint
parented to `bizzy/base_link`.

## Companion

Revert of the misplaced frames in BEN: rolker/ben_description#15.

Closes #237.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
