### PR TITLE
Post-deployment fact-finding: 2026-06-08 first student-ops day

### DIFF
--- a/bizzyboat_project11/launch/sidescan_launch.py
+++ b/bizzyboat_project11/launch/sidescan_launch.py
@@ -84,6 +84,15 @@ def generate_launch_description():
                     parameters=[{
                         'gcv_ip': gcv_ip,
                         'iface_ip': iface_ip,
+                        # Force the GCV-20 decode path. This boat's GCV-20 is
+                        # mis-identified as gcv10 by 'auto': its imagery packets
+                        # carry the 0x11 value-width tag at offset 13, which
+                        # GEN_BY_TAG maps to gcv10, so the dark_layer extractor
+                        # finds no third "dark" layer (GCV-20 has only two) and
+                        # sonar_image_* stays empty. Verified on the 2026-06-08
+                        # wet test: /debug/raw flowed at ~255 Hz while all three
+                        # decoded channels were silent under auto-detect.
+                        'device': 'gcv20',
                         'frame_id': [frame_prefix, 'garmin_sidescan'],
                         # debug_raw is a bool node param; type the launch-arg
                         # string override so ROS 2 doesn't reject "true"/"false".

--- a/bizzyboat_project11/scripts/fcu_battery.sh
+++ b/bizzyboat_project11/scripts/fcu_battery.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# fcu_battery.sh — Print the FCU-reported battery voltage without the ROS stack.
+#
+# Talks MAVLink directly to the flight controller's serial port and reads one
+# SYS_STATUS message. Handy for a quick battery check before launch, or any time
+# MAVROS / the core stack is NOT running.
+#
+# Usage: ./fcu_battery.sh [device] [baud]
+#   device: FCU serial device   (default: /dev/fcu)
+#   baud:   serial baud rate     (default: 57600)
+# These defaults match core_launch.py's fcu_url (/dev/fcu:57600).
+#
+# IMPORTANT: the FCU serial port is single-owner. If MAVROS is running it holds
+# /dev/fcu, and this script will fail to open the port (or fight it). Only use
+# this when the ROS stack is down — otherwise read /bizzy/mavros/battery instead.
+#
+# Requires pymavlink. It lives in the workspace .venv, not system python, so we
+# auto-select an interpreter that can import it. Override with FCU_BATTERY_PYTHON.
+
+set -eo pipefail
+
+DEVICE="${1:-/dev/fcu}"
+BAUD="${2:-57600}"
+
+# --- pick a python interpreter that has pymavlink -------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+has_pymavlink() { "$1" -c 'import pymavlink' >/dev/null 2>&1; }
+
+PYTHON=""
+CANDIDATES=("$FCU_BATTERY_PYTHON" python3 python)
+# Walk up from the script looking for a .venv (workspace root holds it).
+dir="$SCRIPT_DIR"
+for _ in 1 2 3 4 5 6 7 8; do
+    CANDIDATES+=("$dir/.venv/bin/python")
+    dir="$(dirname "$dir")"
+    [ "$dir" = "/" ] && break
+done
+
+for cand in "${CANDIDATES[@]}"; do
+    [ -n "$cand" ] || continue
+    if command -v "$cand" >/dev/null 2>&1 && has_pymavlink "$cand"; then
+        PYTHON="$cand"
+        break
+    fi
+done
+
+if [ -z "$PYTHON" ]; then
+    echo "error: no python with pymavlink found." >&2
+    echo "       install it (pip install pymavlink) or set FCU_BATTERY_PYTHON=/path/to/python" >&2
+    exit 1
+fi
+
+if [ ! -e "$DEVICE" ]; then
+    echo "error: FCU device '$DEVICE' not found." >&2
+    exit 1
+fi
+
+# --- read one SYS_STATUS and print -----------------------------------------
+exec "$PYTHON" - "$DEVICE" "$BAUD" <<'EOF'
+import sys
+from pymavlink import mavutil
+
+device, baud = sys.argv[1], int(sys.argv[2])
+m = mavutil.mavlink_connection(device, baud=baud)
+
+if not m.wait_heartbeat(timeout=10):
+    sys.exit("error: no MAVLink heartbeat (is the FCU powered? is MAVROS holding the port?)")
+
+s = m.recv_match(type='SYS_STATUS', blocking=True, timeout=5)
+if s is None:
+    sys.exit("error: heartbeat seen but no SYS_STATUS within 5s")
+
+volts = s.voltage_battery / 1000.0            # mV -> V
+amps = "n/a" if s.current_battery == -1 else f"{s.current_battery / 100.0:.1f} A"
+remaining = "n/a" if s.battery_remaining == -1 else f"{s.battery_remaining}%"
+print(f"{volts:.2f} V  (current: {amps}, remaining: {remaining})")
+EOF

--- a/bizzyboat_project11/scripts/fcu_battery.sh
+++ b/bizzyboat_project11/scripts/fcu_battery.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 # fcu_battery.sh — Print the FCU-reported battery voltage without the ROS stack.
 #
-# Talks MAVLink directly to the flight controller's serial port and reads one
+# Talks MAVLink directly to the flight controller's serial port and reads a live
 # SYS_STATUS message. Handy for a quick battery check before launch, or any time
 # MAVROS / the core stack is NOT running.
+#
+# Stale-value guard: when nothing is reading /dev/fcu (exactly the case this
+# script is for), the FCU keeps streaming into the serial buffer, which fills
+# with OLD data and drops new bytes. A naive single read then returns a value
+# buffered minutes-to-hours ago. We flush the input buffer after the heartbeat
+# and keep the most recent SYS_STATUS from a short live window, so the printed
+# voltage is current. If the FCU is off there is nothing fresh to read and we
+# time out rather than report a stale number.
 #
 # Usage: ./fcu_battery.sh [device] [baud]
 #   device: FCU serial device   (default: /dev/fcu)
@@ -55,9 +63,9 @@ if [ ! -e "$DEVICE" ]; then
     exit 1
 fi
 
-# --- read one SYS_STATUS and print -----------------------------------------
+# --- read a live SYS_STATUS and print --------------------------------------
 exec "$PYTHON" - "$DEVICE" "$BAUD" <<'EOF'
-import sys
+import sys, time
 from pymavlink import mavutil
 
 device, baud = sys.argv[1], int(sys.argv[2])
@@ -66,9 +74,23 @@ m = mavutil.mavlink_connection(device, baud=baud)
 if not m.wait_heartbeat(timeout=10):
     sys.exit("error: no MAVLink heartbeat (is the FCU powered? is MAVROS holding the port?)")
 
-s = m.recv_match(type='SYS_STATUS', blocking=True, timeout=5)
+# Dump any stale backlog buffered while the port sat idle, then read only data
+# that arrives after the flush.
+try:
+    m.port.reset_input_buffer()
+except Exception:
+    pass
+
+# Keep the most recent SYS_STATUS from a short live window. Discards a possible
+# partial frame left by the flush; if nothing fresh arrives, s stays None.
+s = None
+deadline = time.monotonic() + 3.0
+while time.monotonic() < deadline:
+    msg = m.recv_match(type='SYS_STATUS', blocking=True, timeout=3)
+    if msg is not None:
+        s = msg
 if s is None:
-    sys.exit("error: heartbeat seen but no SYS_STATUS within 5s")
+    sys.exit("error: heartbeat seen but no live SYS_STATUS within 3s (FCU off, or port contended?)")
 
 volts = s.voltage_battery / 1000.0            # mV -> V
 amps = "n/a" if s.current_battery == -1 else f"{s.current_battery / 100.0:.1f} A"

--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: git@gitcloud:field/marine_tools.git
     version: jazzy
+  unh_marine_radar:
+    type: git
+    url: git@gitcloud:field/unh_marine_radar.git
+    version: jazzy

--- a/docs/logs/2026/2026-06-08_dev_logs.md
+++ b/docs/logs/2026/2026-06-08_dev_logs.md
@@ -56,6 +56,68 @@ placeholder — voltage only), so there's no state-of-charge / time-to-empty sig
 Gaps to consider: a **low-voltage failsafe** (deliberate action before brown-out)
 and a **lower-power "waiting for pickup" mode** than active station-keeping.
 
+*Battery-voltage trace (post-deployment, `/bizzy/mavros/battery`, ~24 V nominal;
+voltage-only — no current meter).* The day's bags on deadpool
+(`~/data/logs/bizzyboat/2026-06-08T*`):
+- Morning short tests (09:45, 10:06 EDT): ~24.0–24.2 V, healthy.
+- **Main session `2026-06-08T15-08-16+00-00` (11:08 → 15:11 EDT, ~4 h, 145k
+  samples @ ~10 Hz):**
+  - Min 0–30 (pre-launch, idle): voltage *rose* 24.66 → 24.94 V (pack resting,
+    no load). Session began at **24.7 V — already not fully topped**; the max
+    voltage seen all day was only 24.95 V.
+  - Min 30–200 (~3 h active ops): gradual plateau 24.9 → ~22.8 V, ≈ **−0.5 V/hr**,
+    with load-transient dips into the 22–23 V range under thrust.
+  - **Min ~200 onward (≈14:30 EDT) — end-of-discharge knee:** rate jumps to
+    **≈ −0.8 V per 10 min (−4.7 V/hr)**; mean 22.8 → 20.9 V in the last 40 min,
+    with **loaded dips to 19.5 V** under loiter station-keeping.
+
+*End-of-day sequence (time of death + recovery, from the bag timestamps):*
+- **15:10:48 EDT — the boat died.** Not just the battery topic: **46 of 55
+  recorded topics stop within ~30 ms of each other** (SBG IMU, mavros, GPS, odom,
+  `/tf`, costmap, collision monitor, cmd_vel — the whole onboard suite). That
+  simultaneous cutout, with the pack at 21.0 V steady (sagging to 19.5 V under
+  load), is an **undervoltage brown-out** — the FCU/companion computer hit its
+  cutoff and everything lost power at once. Not a comms drop or a manual bag stop
+  (those wouldn't kill the hardwired onboard sensors mid-stream).
+- **15:10–15:40 — dead boat, ~30 min recovery** (physical crane recovery; pack
+  resting open-circuit up toward ~22.2 V, no telemetry recorded).
+- **~15:41:19 EDT — charger plugged in.** The boat has no other power source and
+  had hit cutoff, so the systems spontaneously rebooting (next bag,
+  `2026-06-08T19-41-16+00-00`, starts here) can only mean external power applied:
+  the reboot time *is* the charger plug-in time. Corroborated by that bag's
+  voltage **climbing steadily 22.28 → 22.71 V (+3.5 V/hr)** over 7 min with no
+  load dips — too fast/linear for 30-min-late open-circuit relaxation, so it's
+  active charge current. That final bag captures the **first ~7 min of charging**.
+  (Charging continued off-record; pack at 25.8 V and still charging as of the
+  evening of 06-08.)
+- **Conclusion:** ~3 h usable plateau, then the knee. **Loitering is not free** —
+  station-keeping kept drawing at low SoC and drove loaded voltage into the
+  ~19.5–20 V danger zone in ~40 min. Below ~22.8 V *loaded*, expect ~30–40 min of
+  margin, not hours. Reinforces the low-voltage-failsafe + low-power-loiter gaps
+  above; a **resting-voltage-based SoC heuristic** (the ~1.5 V load↔rest gap is the
+  only state-of-charge proxy available without a current meter).
+
+*Why it started low — Friday baseline + suspected weekend drain.* The 06-08 pack
+went out **already undercharged**, which is half of why it hit the knee:
+- **Friday 06-05 (#228 run, `2026-06-05T17-31-10+00-00`, ~99 min):** started
+  **26.2 V, max 26.44 V** (the pack's true top-of-charge), gentle decline to
+  ~25.6 V under load, then idle-rested back to **~25.9 V** at end of run. Never
+  near the knee — lots of margin.
+- **Over the weekend the boat was meant to be shut down, but likely stayed on at a
+  low level.** Friday rested end **25.86 V** → Monday's first reading **24.01 V**
+  (09:45 EDT) = a **~1.85 V resting drop over ~66 h**. A genuinely-off 24 V pack
+  self-discharges ~0.05–0.1 V over 3 days; **15–30× that loss points to a
+  continuous parasitic draw.** Corroborating: Monday's pack **never exceeded
+  24.95 V all day** (vs Friday's 26.44 V) — even after a morning partial top-up it
+  couldn't get near full.
+- **No weekend telemetry exists** (recording was off Sat/Sun — no bags), so the
+  drain itself isn't directly logged. Definitive confirmation would be a
+  **field-host check** (not done here — won't SSH into field hosts): **gabby
+  uptime/syslog** or the **FCU dataflash (.bin) logs** — either spanning Sat–Sun
+  proves the boat stayed energized.
+- **Action:** verify a true hard-power-down at end of day; a partial "off" state
+  apparently still costs ~1.8 V over a weekend, compounding the next day's range.
+
 **2. Flaky `p11.lan` DNS — operator Teltonika RUTX11 WAN misconfigured as
 load-balance (root cause; mitigated).** Symptom: intermittent
 `Temporary failure in name resolution` for `*.p11.lan` from operator hosts;
@@ -133,8 +195,172 @@ commands (`uptime`) froze, while ICMP/TCP-SYN stayed responsive — a "kernel fi
 userspace starved" pattern on the modest RUTX11 CPU. Cleared after the operator
 power-cycled the router and disabled the WiFi WAN (removing the churn).
 
+**7. CAMP (updated #59 build) — operator-reported display regressions (tracked).**
+During student ops the operator reported two problems on the updated CAMP, both
+already filed:
+- **Y-flipped ("upside down") text on the map** —
+  [camp#76](https://github.com/rolker/camp/issues/76). Map text renders vertically
+  mirrored (looks like a scene→screen y-axis flip introduced by the port).
+- **Collision-avoidance zones no longer visible** —
+  [camp#77](https://github.com/rolker/camp/issues/77). The CA boxes that drew on
+  the previous CAMP aren't shown.
+
+Both read as parity gaps from the CAMP port (#59) — cf. the markers/overlay
+regression [camp#70](https://github.com/rolker/camp/issues/70) and the
+footprint+collision overlay unification
+[camp#74](https://github.com/rolker/camp/issues/74). **Operator-display only —
+boat-side nav / collision avoidance run onboard and are unaffected** (the missing
+boxes are a rendering gap, not CA being off). Tracked in their own issues; logged
+here for the day's record.
+
+**8. Garmin GCV sidescan did not work on-water — only the down beam transmits
+(root cause narrowed; OPEN).** (Operator report.) No side-scan imagery during
+student ops. Data on deadpool: two raw bags
+`~/data/logs/bizzy_sidescan/bag_2026-06-08T13.55.35_sidescan_raw` and `…14.49.00…`,
+both with `debug_raw` on — each ~50–52k decoded `…/garmin_sidescan/debug/raw`
+(UInt8MultiArray) over ~4 min, plus `state` (1) and `status` (~100). The raw GCV
+UDP payloads were received + recorded (GCV→proxy[mercat]→driver[gabby] delivered
+bytes — distinct from the earlier #229 gabby-NIC-link issue).
+
+*Post-deployment decode of the captured payloads (definitive).* Parsing every
+`debug/raw` payload by the GCV wire format (decode.py: beam-type @off8,
+channel @off12, generation tag @off13):
+- **100% of packets in BOTH runs are identical:** generation tag `0x12`
+  (**GCV-20** — matches the actual hardware), beam-type `0x0d` (**down-look /
+  water-column**), channel `2` (down). **~102k data packets, zero side-scan
+  (`0x0e`) packets — the side beams were never put on the wire at all.**
+- The driver's `status` line `pings(port/stbd/down)=0/0/N` is therefore *correct*:
+  port/stbd = 0 because the device emitted no side-scan packets; `down` counts up.
+- **This is a device-side problem, not a ROS-driver decode/channel-map bug.** The
+  GCV-20 channel defaults (port=0/stbd=1/down=2) are right; down decoded cleanly.
+
+*Two earlier blockers — the SV interlock is understood; the mis-detect is a
+separate, still-unexplained loose end (neither is the no-side-beams root cause):*
+- **SV interlock:** `require_sound_speed=True` + `sv=nan` (the main bag's
+  `/bizzy/sensors/sound_speed/sound_speed` published **0 msgs all session** — no
+  live SV source exists on BizzyBoat) initially refused transmit. Operator set
+  `require_sound_speed:=false`; transmit then ran — but still down-only. *(Durable
+  note: with no SV source, `require_sound_speed` must be false on this boat, or a
+  constant SV provided.)*
+- **GCV-10 mis-detect on first run (cause undetermined — incident unrecorded).**
+  The mis-detect happened **before raw recording was turned on**, so there are
+  **no bytes for the incident stream** — its offset-13 tag is genuinely unknown.
+  Two claims got compared and falsely conflicted: the boat-side agent *inferred*
+  the packets carried `0x11` (reasoning back from "driver reported gcv10"); the
+  deadpool decode of the two **post**-incident raw bags *measured* `0x12` on 100%
+  of packets (raw hex confirmed, every packet `eb 07 … 0d 01 03 09 02 12 …`).
+  These describe **different runs** — the inference is about the unrecorded
+  incident, the measurement about the later (recorded) runs — so they don't
+  actually contradict, and **neither proves what the incident carried.** What's
+  solid: once recording started, this unit emits `0x12` (real GCV-20 tag), and
+  forcing `device:=gcv20` is correct.
+  *Disambiguation without the lost bytes* — pin **which driver commit gabby ran
+  at incident time** vs the `069ec71` merge (Jun 7, "detect by tag byte, not
+  packet size"):
+  - pre-`069ec71` (size-based detect) → gcv10 came from a >1000 B packet; "`0x11`"
+    is just a wrong back-inference, nothing exotic.
+  - ≥ `069ec71` (tag-based) yet still logged gcv10 → it really read `0x11`, i.e.
+    this GCV-20 can emit `0x11` (the `0x12` mapping was only bench-validated) — a
+    real finding worth chasing.
+  Either way this concerns only the *down*-image echo extractor (`dark_layer` vs
+  `echo_layer`), **not** whether side beams exist — a separate loose end from the
+  no-side-beams root cause. *Actions: (1) check gabby's incident-time driver
+  commit; (2) keep raw recording on so a recurrence captures offset-13 directly.*
+
+**Why unresolved — the driver has no way to enable side-scan.** The transducer is
+confirmed side-scan capable (operator), so the hardware is ruled out — the single
+remaining cause is the **command path**. `commands.py` + the transmit path send
+only `TRANSMIT_ON` (5 channel-slot frames) + range/TVG/interference. There is **no
+SideVü / beam-mode-select command** — the driver assumes "transmit on ⇒ all
+beams," but this GCV-20 needs an explicit command to start emitting the side
+beams, which the driver doesn't send and we have no capture of.
+
+Resolution path (OPEN — resolved only once the driver can enable side-scan):
+- **Find the side-scan-enable command.** Put a real Garmin chartplotter on this
+  GCV-20, enable SideVü, and capture the control traffic — the driver already has
+  a debug capture for the chartplotter CDP config multicast
+  (`239.254.2.11:51000` → `~/debug/raw_config`; not recorded in today's raw-only
+  bags). That frame is the missing command; add it to `commands.py` and send it
+  alongside `TRANSMIT_ON`. (Cross-ref Dan Tauriello's GCV protocol notes — the
+  transmit/range/TVG frames came from there; a mode/beam-select frame may already
+  be documented or capturable the same way.)
+- **Tracking:** distinct from #229 (which was the gabby-NIC delivery gap; bytes now
+  arrive). This is "GCV-20 emits down-look only / driver lacks a SideVü-enable
+  command" — file as its own `garmin_sidescan` (marine_tools) issue.
+
+### Cross-cutting observation — bridge radios were never fully provisioned
+
+Findings #3 and #5 share one root: the WiFi-bridge radios were brought up just
+far enough to work and never finished. Both got static IPs at setup (2026-03-18),
+but —
+- the boat **OmniTIK kept its factory defconf DHCP client** (never removed), and
+- **both** radios had their **RouterBOOT left at the factory version** (never
+  `/system routerboard upgrade`d) under RouterOS 7.22.
+
+Each is minor alone; together they read as "configured quickly, not finished /
+hardened." And because there is **no committed device-config snapshot** (only
+addressing-level docs — see #3's snapshot gap), none of it was visible to review.
+Worth a one-time "finish + snapshot the bridge radios" pass (see follow-ups).
+
+### "Unreliable WiFi" was mostly DNS, not the radio link
+
+The day's perceived WiFi unreliability was largely **name-resolution flakiness**,
+not the WiFi bridge dropping. The bridge RF was healthy (SXTsq −43 dBm, CCQ
+95/100%, stable association), while DNS intermittently failed from the
+WiFi-WAN-flap-driven dnsmasq reloads (#2). Reaching the boat by name and having it
+intermittently not resolve presents exactly as "the WiFi keeps dropping."
+
+The **VPN-worked-all-day** observation is the discriminator: VPN and the WiFi
+bridge both traverse the operator router, so VPN's stability proves the router's
+**forwarding/data plane was fine the whole time** — the flaky parts were the *DNS*
+service and the *WiFi-WAN member*, neither of which the VPN path leans on (stable
+WireGuard endpoint, NETMAP/`/etc/hosts` addressing, and the tunnel almost
+certainly rode the stable wired `wan`). So "WiFi was unreliable" was really "name
+resolution was unreliable," misattributed to the radio; disabling the WiFi WAN
+(#2) should resolve it.
+
+Caveats: the DHCP spam (#3) was cosmetic (negligible load, not a driver of any of
+this); and the management-session freezes we saw are under-explained by these
+issues alone — a RUTX11 shouldn't wedge from this level of churn — so that remains
+a loose end, possibly aggravated by our own diagnostic load.
+
 ### Open / unresolved
 
+- **Bridge + boat-side went unreachable right after the OmniTIK firmware reboot
+  (in-session, cause TBD).** deadpool sweep: op router (`192.168.13.1`) + `p11.lan`
+  DNS UP, but SXTsq (`172.16.20.4`), OmniTIK (`172.16.20.3`), boat router
+  (`172.16.20.1`) and gabby (`192.168.20.5`) all DOWN. Candidates: (a) the OmniTIK
+  hadn't finished its post-firmware-upgrade reboot (bridge down; SXTsq
+  unresponsive while scanning for its AP — self-recovers), or (b) the op-side
+  SXTsq dropped again (recurring op-radio flakiness — needs power-cycle).
+  **Follow-up:** ping from the op router itself (directly cabled to the SXTsq on
+  port 4) also got 100% loss to both `.4` and `.3`, with router load normal
+  (0.12/0.33/0.31) — so the SXTsq is dead even to its wired neighbor, which a
+  merely-lost-AP station would not be. **But the boat router (`172.16.20.1`) CAN
+  ping the SXTsq (`.4`) over the air** — so the SXTsq, the OmniTIK, and the
+  wireless bridge are all UP. The break is therefore the **op-router ↔ SXTsq
+  *wired* hop** (op router port 4 / cable / SXTsq ether1), which severs the op
+  side from an otherwise-healthy bridge (hence everything past it is dark from the
+  op side, while the boat side reaches the SXTsq). Not a dead radio — do NOT
+  power-cycle the SXTsq; check the op-router↔SXTsq cable + port-4 link (link-down =
+  physical; link-up = L2/VLAN). VPN path to the boat unaffected. (Earlier "SXTsq
+  is down" read was wrong — corrected once the boat-side ping was tried.)
+  **Port-4 check** (`swconfig dev switch0 port 4 get link`): **`link:up
+  speed:10baseT full-duplex`** with 100% packet loss. Link up rules out a dead
+  port / VLAN issue (speed downshift is physical-layer); a healthy short run
+  negotiates 100M/1G, so **10baseT + total loss = a failing/marginal Ethernet
+  cable or connector** on the op-router↔SXTsq run (damaged pairs / bad crimp /
+  corrosion-water on a marine install). **Fix: reseat + inspect both ends, replace
+  the cable.** Likely the real source of the day's "op-WiFi flakiness" — the
+  radio/RF were healthy throughout; an intermittently-degrading wired hop on the
+  op end would drop the op-side bridge on and off and present exactly as flaky
+  WiFi.
+  **RESOLVED 2026-06-08:** swapped the cable → port 4 now negotiates `100baseT
+  full-duplex` and the op router pings `.4`/`.3` at 0% loss (~0.7 / ~1.1 ms) → the
+  op-side bridge is restored. Confirms the failing op-router↔SXTsq cable was the
+  cause — and the most likely root of the day's "op-WiFi flakiness" (the radio/RF
+  and DNS were separate/healthy). Follow-up: inspect / strain-relief / label the
+  bridge cabling; marine corrosion-water on RJ45 runs is a recurring risk.
 - **salmon → shore radio (`172.16.20.4`) reachability gap.** salmon gets 100%
   ping loss to the radio even though its routing is identical to deadpool's (both
   via gw `192.168.13.1`), salmon reaches the gateway and deadpool fine, and there

--- a/docs/logs/2026/2026-06-08_dev_logs.md
+++ b/docs/logs/2026/2026-06-08_dev_logs.md
@@ -1,0 +1,130 @@
+# 2026-06-08 — dev log (BizzyBoat — first student operations day)
+
+Deployment issue: https://github.com/rolker/unh_echoboats_project11/issues/239
+Host: deadpool
+Side: dev
+Started: 2026-06-08 (Summer Hydro — first day students operated the boat)
+
+## Summary
+
+> _Curated wrap-up section — for Roland to finalize._
+
+First day students operated BizzyBoat. The team **ran over the BenCloud VPN all
+day** to work around flakiness on the operator WiFi bridge / operator network;
+the day's networking issues caused **minor operational problems** rather than
+stoppages. Post-day analysis (dev-side, on deadpool) root-caused the WiFi/DNS
+flakiness to a **WAN-failover misconfiguration on the operator Teltonika RUTX11**
+(set to 50/50 load-balance with a flapping WiFi WAN, instead of failover) and
+cleaned up several adjacent items. One operational safety gap surfaced: the boat
+**ran out of power while loitering** (active station-keeping) waiting for the
+crane pickup window.
+
+## Lessons Learned
+
+> _Draft — for Roland to curate._
+
+- **A flaky WAN in an active load-balance poisons local DNS.** Each WiFi-WAN flap
+  forced a dnsmasq reload on the operator router, so even `*.p11.lan` names
+  intermittently failed to resolve — surfacing as "can't reach X" all over the
+  operator station. Failover (not load-balance) keeps the stable wired link
+  carrying DNS.
+- **`ping` is a misleading reachability test against Windows hosts** (mercat) —
+  ICMP is firewalled off by default while SSH/services are up. Test the service,
+  not the ping.
+- **Loitering is not free on a vectored boat with no battery swap.** Active hover
+  burns the energy budget with no field reset and no current telemetry to warn
+  you — a waiting-for-pickup loiter needs a low-power mode and/or a low-voltage
+  failsafe.
+
+## 2026-06-08
+
+### Operating posture
+
+- **Ran over BenCloud VPN all day** (operator ↔ boat) to sidestep WiFi-bridge
+  flakiness. Higher latency (~37 ms vs ~1 ms wired) but stable. (Operator report.)
+- First day with students at the controls; issues below caused minor friction,
+  not stoppages. (Operator report.)
+
+### Issues encountered / diagnoses
+
+**1. Boat ran out of power while loitering for crane pickup (operational; gap).**
+(Operator report.) The boat was holding station (active hover) awaiting the crane
+and depleted its battery. Compounding factors (from prior project knowledge):
+active hover on the vectored 240 draws continuously; **no field battery swap**
+(charge-in-place only); **no current meter** (`BatteryState.current` is a ~0.01 A
+placeholder — voltage only), so there's no state-of-charge / time-to-empty signal.
+Gaps to consider: a **low-voltage failsafe** (deliberate action before brown-out)
+and a **lower-power "waiting for pickup" mode** than active station-keeping.
+
+**2. Flaky `p11.lan` DNS — operator Teltonika RUTX11 WAN misconfigured as
+load-balance (root cause; mitigated).** Symptom: intermittent
+`Temporary failure in name resolution` for `*.p11.lan` from operator hosts;
+salmon/deadpool couldn't reach the radio/mercat *by name* on-and-off.
+- The op router (`192.168.13.1`) is the `p11.lan` DNS server (dnsmasq).
+- `mwan3 status`: stable wired `wan` up 9 h; **WiFi WAN `ifWan1` (`wlan1-2`) up
+  only ~2 min** (repeatedly flapping). Policy `balance_default` = **`ifWan1` 50% /
+  `wan` 50%** — i.e. active load-balance, not failover.
+- `logread`: each `ifWan1` ping-check failure (1.1.1.1 / 8.8.8.8) →
+  offline → `mwan3` reconfigure → **dnsmasq reload** (`reading
+  /tmp/resolv.conf.d/resolv.conf.auto`). During each reload, resolution
+  (including local `p11.lan`) briefly fails; between flaps, half of upstream
+  queries were also routed out the dying WiFi link.
+- **Mitigation applied (by operator): WiFi WAN disabled.** Removes the flap
+  source → no more dnsmasq reload churn. **Trade-off:** now single-WAN (wired
+  only) — no automatic failover. Follow-up: re-add WiFi as a *lower-metric
+  backup* (failover), and find why `wlan1-2` drops, before re-enabling.
+
+**3. `eth0.4` DHCP log spam on the operator router (cosmetic; fix boat-side).**
+dnsmasq logged `no address range available for DHCP request via eth0.4` every
+1–3 s. `uci show network`: `eth0.4` = `bizzy_wifi_bridge`, static
+`172.16.20.2/24` — the operator end of the WiFi bridge to the boat (VLAN 4 / LAN
+port 4; the old "mobile lab" moved to `br-lan` as `molab` 192.168.50.1). It is an
+all-static router-to-router segment with **no DHCP server by design**.
+`tcpdump -i eth0.4` on DHCP: DISCOVER from MAC **`c4:ad:34:90:72:48`**, hostname
+`"MikroTik"` — a sibling interface of the boat AP MAC `c4:ad:34:90:72:4C`
+(`SSID bizzy_bridge`), i.e. the **boat-side OmniTIK left on DHCP-client**. It
+never gets a lease and retries forever → the spam. **Fix (boat-side): static IP
+on the OmniTIK on `172.16.20.0/24`.** Do *not* add a DHCP pool to the operator
+router's `eth0.4`. Resolves the 2026-05-28 salmon-log "eth0.4 vs SXTsq
+VLAN-mismatch" hypothesis (not a VLAN mismatch).
+
+**4. mercat "unreachable" was a false alarm (no action).** mercat doesn't answer
+`ping` because Windows Firewall blocks inbound ICMP; it's reachable via SSH
+(ports 22/443 open, host-key matched). Pinging mercat is a misleading health
+check; test the service instead. (The earlier "salmon can't reach mercat" was the
+DNS flakiness above, not a mercat fault.)
+
+**5. Shore SXTsq Lite5 radio — stale RouterBOOT, upgraded (housekeeping).**
+`/system routerboard print` showed RouterBOOT `current-firmware: 6.45.9` under
+RouterOS `7.22` (pending `upgrade-firmware: 7.22` never applied). Upgraded
+(`/system routerboard upgrade`) + rebooted → now `7.22`/`7.22`. RF link itself is
+healthy: signal −43 dBm, SNR 69 dB, noise floor −112 dBm, tx/rx CCQ 95%/100%,
+stable association to `bizzy_bridge`. (A short uptime seen earlier was an operator
+power-cycle, not a self-reboot.)
+
+**6. Operator router stalls under churn (resolved by mitigation).** During the
+WAN-flap + DHCP-spam churn, SSH sessions to the op router wedged and even local
+commands (`uptime`) froze, while ICMP/TCP-SYN stayed responsive — a "kernel fine,
+userspace starved" pattern on the modest RUTX11 CPU. Cleared after the operator
+power-cycled the router and disabled the WiFi WAN (removing the churn).
+
+### Open / unresolved
+
+- **salmon → shore radio (`172.16.20.4`) reachability gap.** salmon gets 100%
+  ping loss to the radio even though its routing is identical to deadpool's (both
+  via gw `192.168.13.1`), salmon reaches the gateway and deadpool fine, and there
+  is no IP duplication (ARP MAC matches salmon's real NIC). deadpool reaches the
+  radio normally. Cause not yet found; deferred. (Investigated from deadpool only;
+  not root-caused.)
+
+### Follow-ups / action items
+
+- [ ] Re-add WAN **failover** on the op Teltonika the correct way: WiFi WAN as a
+      lower-metric backup behind wired `wan` (not 50/50 balance); diagnose
+      `wlan1-2` flapping first.
+- [ ] Boat-side: set the OmniTIK to a **static IP** on `172.16.20.0/24` (stop the
+      `eth0.4` DHCP spam).
+- [ ] Root-cause and close the **salmon → `172.16.20.4`** reachability gap.
+- [ ] Consider a **low-voltage failsafe** and a **low-power loiter mode** for
+      waiting-for-pickup, given no battery swap and no current telemetry.
+- [ ] Decide the standing **VPN-vs-WiFi operating posture** for student days.

--- a/docs/logs/2026/2026-06-08_dev_logs.md
+++ b/docs/logs/2026/2026-06-08_dev_logs.md
@@ -74,19 +74,37 @@ salmon/deadpool couldn't reach the radio/mercat *by name* on-and-off.
   only) — no automatic failover. Follow-up: re-add WiFi as a *lower-metric
   backup* (failover), and find why `wlan1-2` drops, before re-enabling.
 
-**3. `eth0.4` DHCP log spam on the operator router (cosmetic; fix boat-side).**
+**3. `eth0.4` DHCP log spam — boat OmniTIK left on a defconf DHCP client (root-caused + fixed).**
 dnsmasq logged `no address range available for DHCP request via eth0.4` every
 1–3 s. `uci show network`: `eth0.4` = `bizzy_wifi_bridge`, static
 `172.16.20.2/24` — the operator end of the WiFi bridge to the boat (VLAN 4 / LAN
 port 4; the old "mobile lab" moved to `br-lan` as `molab` 192.168.50.1). It is an
 all-static router-to-router segment with **no DHCP server by design**.
-`tcpdump -i eth0.4` on DHCP: DISCOVER from MAC **`c4:ad:34:90:72:48`**, hostname
-`"MikroTik"` — a sibling interface of the boat AP MAC `c4:ad:34:90:72:4C`
-(`SSID bizzy_bridge`), i.e. the **boat-side OmniTIK left on DHCP-client**. It
-never gets a lease and retries forever → the spam. **Fix (boat-side): static IP
-on the OmniTIK on `172.16.20.0/24`.** Do *not* add a DHCP pool to the operator
-router's `eth0.4`. Resolves the 2026-05-28 salmon-log "eth0.4 vs SXTsq
-VLAN-mismatch" hypothesis (not a VLAN mismatch).
+`tcpdump -i eth0.4`: DISCOVER from MAC `c4:ad:34:90:72:48`, hostname `"MikroTik"`
+— the boat-side OmniTIK. On the OmniTIK (`172.16.20.3`), `/ip dhcp-client print`
+showed a `;;; defconf` client on `bridge`, **`status=searching...`** — the
+factory-default DHCP client running *alongside* the device's correct static IP,
+broadcasting DISCOVER forever because nothing serves DHCP on the bridge.
+- **Fix applied 2026-06-08:** `/ip dhcp-client remove 0` on the OmniTIK — removes
+  the stray client; static `172.16.20.3` retained; spam stops at the source.
+  (RouterOS persists config immediately, so it survives the radio's daily
+  power-cycles.)
+- **Provenance — a setup-time leftover, not a regression.** Per
+  `ccomjhc_project11/documentation/bizzyboat_network_setup_2026-03-18.md`, the
+  OmniTIK was given static `172.16.20.3` (replacing factory `192.168.88.1`) and
+  set to `ap-bridge` at initial setup, but its factory **defconf DHCP client was
+  never removed**. The journal's `Disabled DHCP on the interface` line is under
+  the *Operator Router* section (the DHCP *server* on `eth0.4`) — not the OmniTIK
+  *client* — so the server side was handled while the client side was missed. It
+  has been spamming since 2026-03-18. Also resolves the 2026-05-28 salmon-log
+  "eth0.4 vs SXTsq VLAN-mismatch" hypothesis (not a VLAN mismatch).
+- **Snapshot gap:** this could not have been caught by our "config snapshot."
+  `ccomjhc_project11/configuration/bizzyboat_network.yaml` records the OmniTIK's
+  *intended* IP/role (`172.16.20.3`, ~line 105) but is a hand-maintained
+  topology/addressing description, **not a device config export**. There are **no
+  committed RouterOS `/export` (`.rsc`) backups** for any of the radios/routers in
+  either repo, so live device cruft like a leftover DHCP client is invisible to a
+  config review. See follow-up.
 
 **4. mercat "unreachable" was a false alarm (no action).** mercat doesn't answer
 `ping` because Windows Firewall blocks inbound ICMP; it's reachable via SSH
@@ -122,8 +140,14 @@ power-cycled the router and disabled the WiFi WAN (removing the churn).
 - [ ] Re-add WAN **failover** on the op Teltonika the correct way: WiFi WAN as a
       lower-metric backup behind wired `wan` (not 50/50 balance); diagnose
       `wlan1-2` flapping first.
-- [ ] Boat-side: set the OmniTIK to a **static IP** on `172.16.20.0/24` (stop the
-      `eth0.4` DHCP spam).
+- [x] **DONE 2026-06-08:** removed the stray defconf DHCP client on the OmniTIK
+      (`/ip dhcp-client remove 0`) — it already had static `172.16.20.3`; the
+      `eth0.4` spam stops at the source.
+- [ ] Capture/commit actual **device config exports** (RouterOS `/export`) for the
+      bridge radios + routers. The network is documented only at the addressing
+      level (`ccomjhc_project11/configuration/bizzyboat_network.yaml`); with no
+      device-config snapshot, latent cruft like a leftover defconf DHCP client is
+      invisible to review.
 - [ ] Root-cause and close the **salmon → `172.16.20.4`** reachability gap.
 - [ ] Consider a **low-voltage failsafe** and a **low-power loiter mode** for
       waiting-for-pickup, given no battery swap and no current telemetry.

--- a/docs/logs/2026/2026-06-08_dev_logs.md
+++ b/docs/logs/2026/2026-06-08_dev_logs.md
@@ -112,13 +112,20 @@ broadcasting DISCOVER forever because nothing serves DHCP on the bridge.
 check; test the service instead. (The earlier "salmon can't reach mercat" was the
 DNS flakiness above, not a mercat fault.)
 
-**5. Shore SXTsq Lite5 radio — stale RouterBOOT, upgraded (housekeeping).**
-`/system routerboard print` showed RouterBOOT `current-firmware: 6.45.9` under
-RouterOS `7.22` (pending `upgrade-firmware: 7.22` never applied). Upgraded
-(`/system routerboard upgrade`) + rebooted → now `7.22`/`7.22`. RF link itself is
+**5. Both WiFi-bridge radios had stale RouterBOOT — upgraded (housekeeping).**
+Both MikroTik bridge radios ran RouterOS `7.22` on an old RouterBOOT bootloader
+with the `7.22` firmware pending (`/system routerboard upgrade` never run):
+- **Shore SXTsq Lite5** (`172.16.20.4`): RouterBOOT `6.45.9` → `/system routerboard
+  upgrade` + reboot → confirmed `current-firmware: 7.22`.
+- **Boat OmniTIK 5 ac** (`172.16.20.3`): RouterBOOT `6.44.5` → `/system routerboard
+  upgrade` succeeded + reboot issued (2026-06-08); post-reboot `current-firmware`
+  verification pending reconnect. Rebooting the OmniTIK drops the whole WiFi
+  bridge, so it was done after ops.
+
+Housekeeping, not a cause of operational flakiness. The SXTsq's RF link is
 healthy: signal −43 dBm, SNR 69 dB, noise floor −112 dBm, tx/rx CCQ 95%/100%,
-stable association to `bizzy_bridge`. (A short uptime seen earlier was an operator
-power-cycle, not a self-reboot.)
+stable association to `bizzy_bridge`. (A short SXTsq uptime seen earlier was an
+operator power-cycle, not a self-reboot.)
 
 **6. Operator router stalls under churn (resolved by mitigation).** During the
 WAN-flap + DHCP-spam churn, SSH sessions to the op router wedged and even local


### PR DESCRIPTION
Post-deployment fact-finding for **2026-06-08 — the first student-operations
day** (boat run over VPN all day to work around WiFi flakiness). This is a
fact-finding record, not a full deployment-log wrap-up. Single log file:
`docs/logs/2026/2026-06-08_dev_logs.md`.

## Findings

**Power / loiter brown-out (finding #1).** Battery-voltage analysis from the
day's bags: the pack went out **undercharged** (24.7 V vs Friday's full 26.4 V),
delivered ~3 h of usable plateau, then hit the end-of-discharge knee at ~14:30.
The boat **browned out at 15:10:48 EDT** — 46 of 55 recorded topics cut within
~30 ms (undervoltage cutoff, not a comms drop). ~30 min recovery, charger plugged
in ~15:41. Friday baseline + a suspected **weekend parasitic drain**
(Fri 25.86 V → Mon 24.01 V over ~66 h, ~15–30× self-discharge) explain the low
start. Actions noted: low-voltage failsafe, low-power loiter mode, verified
end-of-day hard power-down. *(No current meter on this boat — voltage only.)*

**Network (findings #2–#7).** "Unreliable WiFi" was mostly **DNS**, not the radio:
the operator Teltonika's WAN was misconfigured as a 50/50 load-balance, churning
dnsmasq (mitigated by disabling the WiFi WAN). Separately, the op-router↔SXTsq
**Ethernet cable was dying** (port 4 at 10baseT + 100% loss → swapped → restored)
— the actual op-WiFi flakiness root cause. Plus `eth0.4` DHCP spam (boat OmniTIK
defconf DHCP client, removed) and both bridge radios on stale RouterBOOT
(upgraded to 7.22). mercat "unreachable" was a Windows-ICMP false alarm.

**Garmin sidescan (finding #8) — OPEN.** Decode of the captured raw payloads shows
the GCV-20 transmitted **down-look only** (100% channel 2 / beam `0x0d`, zero
side-scan `0x0e` packets across ~102k packets, both runs). The side beams were
never on the wire; the driver has **no SideVü-enable command**. Transducer
confirmed capable; channel-map and decode-generation ruled out. Tracked as a
driver enhancement: **rolker/marine_tools#23**. SV interlock (no SV source →
`require_sound_speed:=false`) and a GCV-10 mis-detect on an earlier *unrecorded*
run are noted as separate, non-causal loose ends.

## Notes

- Several follow-ups (low-power loiter mode, finish/snapshot the bridge radios,
  pin gabby's incident-time driver commit) are recorded in the log's Follow-ups
  section for separate tracking.
- Open thread not resolved here: salmon → `172.16.20.4` reachability gap.

Closes #239

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
