### PR TITLE
Field import: unh_echoboats_project11 battery monitoring (2026-06-09)

### DIFF
--- a/.agent/work-plans/issue-241/progress.md
+++ b/.agent/work-plans/issue-241/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 241
+---
+
+# Issue #241 — Field import: unh_echoboats_project11 battery monitoring (2026-06-09)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-09
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #242 at `5b9e8e3`
+**Sources**: 2 (Copilot @ `5b9e8e3`, import pre-review in issue #241 / PR #242 body)
+**Cross-source confirmations**: 1
+**CI**: no CI configured (copilot check success)
+
+### Findings
+- [ ] (cross-confirmed) `current_a` CSV column blank for FCU and `0`/NaN/misleading from MAVROS — no current meter on BizzyBoat; document or drop the column — `bizzyboat_project11/scripts/battery_logger.sh:18`
+- [ ] (bug, Copilot) `percentage` cleaned only for NaN; out-of-range (MAVROS emits -0.01 when battery_remaining==-1) → negative/garbage remaining_pct; blank values outside [0,1] before *100 — `bizzyboat_project11/scripts/mavros_battery.sh:86`
+- [ ] (nit, Copilot) grammar "An flock" → "A flock" in header comment — `bizzyboat_project11/scripts/battery_logger.sh:21`
+
+### False positives
+- None — all three Copilot comments valid.

--- a/bizzyboat_project11/scripts/battery_logger.sh
+++ b/bizzyboat_project11/scripts/battery_logger.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# battery_logger.sh — Append one battery sample to a daily CSV. Cron-driven.
+#
+# Designed to run every minute from cron and keep a continuous battery record
+# regardless of whether the ROS stack is up:
+#
+#   * /dev/fcu FREE  (stack down) -> read the FCU directly  (fcu_battery.sh)
+#   * /dev/fcu BUSY  (stack up)   -> read MAVROS's topic     (mavros_battery.sh)
+#   * neither yields a reading     -> log nothing (a gap in the series)
+#
+# The port-held check (`fuser`) is the gate: "stack up" == "something holds
+# /dev/fcu". Reading the FCU directly while MAVROS holds the port would steal
+# bytes from the live link, so we never do — we switch to the ROS topic instead.
+#
+# Output: ~/data/logs/bizzy_battery/battery_YYYY-MM-DD.csv
+#   columns: timestamp,voltage_v,current_a,remaining_pct,source
+#   timestamp is ISO-8601 with offset; source is "fcu" or "mavros".
+#
+# An flock guards against overlapping runs: an FCU-off read can block several
+# seconds waiting for a heartbeat, longer than nothing, so a slow run must not
+# pile up under the per-minute schedule.
+#
+# Usage: ./battery_logger.sh        (intended for cron; safe to run by hand)
+# Cron:  * * * * * /home/field/project11/layers/main/platforms_ws/src/unh_echoboats_project11/bizzyboat_project11/scripts/battery_logger.sh
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVICE="${BIZZY_FCU_DEVICE:-/dev/fcu}"
+LOG_DIR="${BIZZY_BATTERY_LOG_DIR:-$HOME/data/logs/bizzy_battery}"
+LOCK_FILE="${TMPDIR:-/tmp}/bizzy_battery_logger.lock"
+HEADER="timestamp,voltage_v,current_a,remaining_pct,source"
+
+# --- never overlap ----------------------------------------------------------
+exec 9>"$LOCK_FILE"
+flock -n 9 || exit 0   # a previous run is still going; skip this tick
+
+# --- pick a source based on who holds the port ------------------------------
+# fuser -s: exit 0 if any process has the device open, 1 if none. We treat a
+# held port as "stack up -> read MAVROS". A missing device (FCU unplugged) is
+# neither held nor readable directly, so we still fall to the FCU branch, which
+# reports the device-missing case and yields no sample (-> gap), as intended.
+if fuser -s "$DEVICE" 2>/dev/null; then
+    SOURCE="mavros"
+    CSV="$("$SCRIPT_DIR/mavros_battery.sh" --csv 2>/dev/null)" || CSV=""
+else
+    SOURCE="fcu"
+    CSV="$("$SCRIPT_DIR/fcu_battery.sh" --csv "$DEVICE" 2>/dev/null)" || CSV=""
+fi
+
+# --- log nothing if we got nothing ------------------------------------------
+# Require a non-empty leading voltage field; an empty/garbled read is a gap.
+VOLT_FIELD="${CSV%%,*}"
+if [ -z "$CSV" ] || [ -z "$VOLT_FIELD" ]; then
+    exit 0
+fi
+
+# --- append (creating the dated file with a header) -------------------------
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/battery_$(date +%F).csv"
+if [ ! -s "$LOG_FILE" ]; then
+    printf '%s\n' "$HEADER" >>"$LOG_FILE"
+fi
+printf '%s,%s,%s\n' "$(date -Is)" "$CSV" "$SOURCE" >>"$LOG_FILE"

--- a/bizzyboat_project11/scripts/battery_logger.sh
+++ b/bizzyboat_project11/scripts/battery_logger.sh
@@ -15,8 +15,11 @@
 # Output: ~/data/logs/bizzy_battery/battery_YYYY-MM-DD.csv
 #   columns: timestamp,voltage_v,current_a,remaining_pct,source
 #   timestamp is ISO-8601 with offset; source is "fcu" or "mavros".
+#   NOTE: BizzyBoat has NO current sensor — current_a is not a real measurement.
+#   It is blank from the FCU (reports -1/unknown) and may be blank, 0, or NaN
+#   from MAVROS. Do not treat current_a as valid; voltage_v is the real signal.
 #
-# An flock guards against overlapping runs: an FCU-off read can block several
+# A flock guards against overlapping runs: an FCU-off read can block several
 # seconds waiting for a heartbeat, longer than nothing, so a slow run must not
 # pile up under the per-minute schedule.
 #

--- a/bizzyboat_project11/scripts/fcu_battery.sh
+++ b/bizzyboat_project11/scripts/fcu_battery.sh
@@ -13,7 +13,10 @@
 # voltage is current. If the FCU is off there is nothing fresh to read and we
 # time out rather than report a stale number.
 #
-# Usage: ./fcu_battery.sh [device] [baud]
+# Usage: ./fcu_battery.sh [--csv] [device] [baud]
+#   --csv:  emit machine-readable "volts,amps,remaining" (empty fields when the
+#           FCU reports a value as unavailable) instead of the human line. Used
+#           by battery_logger.sh. No trailing units; remaining has no % sign.
 #   device: FCU serial device   (default: /dev/fcu)
 #   baud:   serial baud rate     (default: 57600)
 # These defaults match core_launch.py's fcu_url (/dev/fcu:57600).
@@ -26,6 +29,12 @@
 # auto-select an interpreter that can import it. Override with FCU_BATTERY_PYTHON.
 
 set -eo pipefail
+
+FORMAT="human"
+if [ "${1:-}" = "--csv" ]; then
+    FORMAT="csv"
+    shift
+fi
 
 DEVICE="${1:-/dev/fcu}"
 BAUD="${2:-57600}"
@@ -64,11 +73,12 @@ if [ ! -e "$DEVICE" ]; then
 fi
 
 # --- read a live SYS_STATUS and print --------------------------------------
-exec "$PYTHON" - "$DEVICE" "$BAUD" <<'EOF'
+exec "$PYTHON" - "$DEVICE" "$BAUD" "$FORMAT" <<'EOF'
 import sys, time
 from pymavlink import mavutil
 
 device, baud = sys.argv[1], int(sys.argv[2])
+fmt = sys.argv[3] if len(sys.argv) > 3 else "human"
 m = mavutil.mavlink_connection(device, baud=baud)
 
 if not m.wait_heartbeat(timeout=10):
@@ -93,7 +103,13 @@ if s is None:
     sys.exit("error: heartbeat seen but no live SYS_STATUS within 3s (FCU off, or port contended?)")
 
 volts = s.voltage_battery / 1000.0            # mV -> V
-amps = "n/a" if s.current_battery == -1 else f"{s.current_battery / 100.0:.1f} A"
-remaining = "n/a" if s.battery_remaining == -1 else f"{s.battery_remaining}%"
-print(f"{volts:.2f} V  (current: {amps}, remaining: {remaining})")
+if fmt == "csv":
+    # Empty (not "n/a") when unavailable, so the CSV column is cleanly blank.
+    amps = "" if s.current_battery == -1 else f"{s.current_battery / 100.0:.1f}"
+    remaining = "" if s.battery_remaining == -1 else f"{s.battery_remaining}"
+    print(f"{volts:.2f},{amps},{remaining}")
+else:
+    amps = "n/a" if s.current_battery == -1 else f"{s.current_battery / 100.0:.1f} A"
+    remaining = "n/a" if s.battery_remaining == -1 else f"{s.battery_remaining}%"
+    print(f"{volts:.2f} V  (current: {amps}, remaining: {remaining})")
 EOF

--- a/bizzyboat_project11/scripts/mavros_battery.sh
+++ b/bizzyboat_project11/scripts/mavros_battery.sh
@@ -82,7 +82,14 @@ VOLTS="$(printf '%.2f' "$V")"
 AMPS=""
 [ -n "$A" ] && AMPS="$(printf '%.1f' "$A")"
 REMAIN=""
-[ -n "$PCT_RAW" ] && REMAIN="$(awk -v p="$PCT_RAW" 'BEGIN{printf "%d", p*100 + 0.5}')"
+# BatteryState percentage is 0..1, but MAVROS emits -0.01 when the MAVLink
+# battery_remaining field is -1 (unknown), and other publishers may report
+# similar out-of-range sentinels. Such a value would otherwise convert to a
+# negative or >100 "remaining" — treat anything outside [0,1] as unavailable
+# (blank) rather than emit a misleading percent.
+if [ -n "$PCT_RAW" ]; then
+    REMAIN="$(awk -v p="$PCT_RAW" 'BEGIN{ if (p < 0 || p > 1) exit 1; printf "%d", p*100 + 0.5 }')" || REMAIN=""
+fi
 
 if [ "$FORMAT" = "csv" ]; then
     printf '%s,%s,%s\n' "$VOLTS" "$AMPS" "$REMAIN"

--- a/bizzyboat_project11/scripts/mavros_battery.sh
+++ b/bizzyboat_project11/scripts/mavros_battery.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# mavros_battery.sh — Print the battery state from the RUNNING ROS stack.
+#
+# Companion to fcu_battery.sh. Use this when MAVROS is up and holding /dev/fcu:
+# the FCU serial port is single-owner, so a direct read would fight MAVROS for
+# bytes. Instead we read MAVROS's published /bizzy/mavros/battery topic.
+# battery_logger.sh picks between the two automatically based on whether the
+# port is held (see that script).
+#
+# QoS note: MAVROS publishes battery with sensor-data QoS (BEST_EFFORT). A
+# default RELIABLE subscriber silently matches nothing under that publisher, so
+# we subscribe with --qos-profile sensor_data. Under rmw_zenoh a fresh process
+# also pays a discovery/connection cost to reach the local zenoh router, so the
+# read is bounded by both ros2's --timeout and an outer `timeout` backstop; if
+# no sample arrives in time we print nothing and exit non-zero.
+#
+# Usage: ./mavros_battery.sh [--csv] [topic]
+#   --csv:  emit "volts,amps,remaining" (empty fields when unmeasured/NaN),
+#           matching fcu_battery.sh --csv. remaining is percent (0-100).
+#   topic:  battery topic (default: /bizzy/mavros/battery)
+#
+# Env: sources the same ROS env the operator launch scripts use, so it works
+# from a bare cron environment. Override the topic via the positional arg.
+
+set -o pipefail
+
+FORMAT="human"
+if [ "${1:-}" = "--csv" ]; then
+    FORMAT="csv"
+    shift
+fi
+TOPIC="${1:-/bizzy/mavros/battery}"
+
+# --- ROS env (matches start_tmux_project11.bash) ---------------------------
+# Source before `set -e`/strict mode: ROS setup scripts reference unbound vars
+# and can return non-zero benignly. site_ws is optional — guard it so a missing
+# overlay doesn't break the base-ROS read (sensor_msgs lives in base ROS).
+source /opt/ros/jazzy/setup.bash >/dev/null 2>&1 || true
+SITE_SETUP=/home/field/project11/layers/main/site_ws/install/setup.bash
+[ -f "$SITE_SETUP" ] && { source "$SITE_SETUP" >/dev/null 2>&1 || true; }
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+
+if ! command -v ros2 >/dev/null 2>&1; then
+    echo "error: ros2 not on PATH after sourcing ROS env" >&2
+    exit 1
+fi
+
+# --- grab one sample --------------------------------------------------------
+# Outer `timeout` is a hard backstop in case discovery wedges past ros2's own
+# --timeout (which only counts once subscribed). One full-message echo, then
+# parse the fields we want — cheaper than one discovery round per field.
+MSG="$(timeout 12 ros2 topic echo --once --timeout 8 \
+        --qos-profile sensor_data --no-arr "$TOPIC" 2>/dev/null)"
+ECHO_RC=$?
+# ros2 prints "WARNING: topic ... does not appear to be published yet" to
+# STDOUT (not stderr) and exits non-zero when there's no publisher. Drop such
+# notices and trust the exit code, so a no-publisher state can never be parsed
+# as a message.
+MSG="$(grep -v '^WARNING:' <<<"$MSG")"
+
+if [ "$ECHO_RC" -ne 0 ] || [ -z "$MSG" ]; then
+    echo "error: no battery sample from $TOPIC (stack down, or topic not publishing?)" >&2
+    exit 1
+fi
+
+# Extract top-level fields. --no-arr drops the cell_voltage arrays, so these
+# anchored matches are unambiguous. NaN -> empty.
+parse() { awk -v key="$1:" '$1==key {print $2; exit}' <<<"$MSG"; }
+clean() { case "$1" in ''|nan|.nan|NaN) echo "" ;; *) echo "$1" ;; esac; }
+
+V="$(clean "$(parse voltage)")"
+A="$(clean "$(parse current)")"
+PCT_RAW="$(clean "$(parse percentage)")"   # BatteryState percentage is 0..1
+
+if [ -z "$V" ]; then
+    echo "error: battery sample had no usable voltage" >&2
+    exit 1
+fi
+
+# Normalize: voltage 2dp, percentage 0..1 -> whole percent.
+VOLTS="$(printf '%.2f' "$V")"
+AMPS=""
+[ -n "$A" ] && AMPS="$(printf '%.1f' "$A")"
+REMAIN=""
+[ -n "$PCT_RAW" ] && REMAIN="$(awk -v p="$PCT_RAW" 'BEGIN{printf "%d", p*100 + 0.5}')"
+
+if [ "$FORMAT" = "csv" ]; then
+    printf '%s,%s,%s\n' "$VOLTS" "$AMPS" "$REMAIN"
+else
+    a_disp="${AMPS:-n/a}"; [ -n "$AMPS" ] && a_disp="$AMPS A"
+    r_disp="${REMAIN:-n/a}"; [ -n "$REMAIN" ] && r_disp="$REMAIN%"
+    printf '%s V  (current: %s, remaining: %s)  [mavros]\n' "$VOLTS" "$a_disp" "$r_disp"
+fi


### PR DESCRIPTION
Imports field commit `391dbb3` from `gitcloud/jazzy`. Closes #241.

## What

Battery-monitoring tooling for BizzyBoat (follow-on to `fcu_battery.sh` from #240):

- `mavros_battery.sh` (new): reads `/bizzy/mavros/battery` with
  `--qos-profile sensor_data` (matches MAVROS's BEST_EFFORT publisher) for when
  MAVROS holds the single-owner `/dev/fcu` port.
- `battery_logger.sh` (new): cron-driven; `flock` (no overlap) + `fuser`-based
  source select (port free → FCU, busy → MAVROS); appends to a daily CSV; logs
  nothing on a gap.
- `fcu_battery.sh`: add `--csv` mode (`volts,amps,remaining`).

## Import method

Branched from `origin/jazzy` and **merged** `gitcloud/jazzy` (merge base `6db622d`,
already on origin). `gitcloud/jazzy` lacks the #239 doc commits, so a
branch-from-remote PR would have spuriously reverted
`docs/logs/2026/2026-06-08_dev_logs.md` (−387). Merging keeps the dev log intact,
limits the diff to `391dbb3`'s net changes, and preserves the field SHA so
gitcloud fast-forwards after this merges. Net diff: 3 scripts, +178 −5.

## Pre-review

- `mavros_battery.sh` QoS handling is correct (sensor_data / BEST_EFFORT).
- **No current meter on BizzyBoat**: the CSV `current_a` column is empty for FCU
  (`-1` handled) but MAVROS may emit `0`/NaN — the column can be empty/misleading.
  Worth dropping or documenting that current is not instrumented on this hull.
- Hardcoded field-host path `/home/field/project11/.../site_ws` (guarded with
  `[ -f ]`).
- Cron install is gabby-only and not version-controlled (per the commit message).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
