### PR TITLE
Fix Hover Marker rviz type so rosbag2 can record /izzy/hover_visualization

### DIFF
--- a/izzyboat_project11/config/izzyboat.rviz
+++ b/izzyboat_project11/config/izzyboat.rviz
@@ -378,7 +378,7 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
-    - Class: rviz_default_plugins/Marker
+    - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: Hover Marker
       Namespaces:


### PR DESCRIPTION
## Summary

Same fix as ben_project11#27, applied to the Izzy config. Prevents `ros2 bag record` from rejecting `/izzy/hover_visualization`:

```
[ROSBAG2_TRANSPORT]: Topic '/izzy/hover_visualization' has more than one type associated. Only topics with one type are supported
```

The hover behavior publisher (`behavior_server`) emits `visualization_msgs/msg/MarkerArray`, but the **"Hover Marker"** display in `izzyboat_project11/config/izzyboat.rviz` was class `rviz_default_plugins/Marker`. The `Marker` subscription added a second type to the topic name, and rosbag2 enforces type-uniqueness across all endpoints, so it rejected the topic.

## Change

`izzyboat_project11/config/izzyboat.rviz`: "Hover Marker" display `rviz_default_plugins/Marker` → `rviz_default_plugins/MarkerArray`.

## Notes

- CAMP needs no change — its marker subscription is type-adaptive and mirrors the graph; with rviz corrected, `MarkerArray` is the only type and CAMP adapts automatically.
- bizzy is unaffected — there is no `bizzyboat.rviz` (bizzy is CAMP-driven); only `izzyboat.rviz` carried the display.
- Distinct from `unh_marine_navigation` #42/#48 (publisher churn, already fixed).

## Verification

- [x] Confirmed `izzyboat.rviz` is the only echoboats rviz config with a hover-marker display, and line 381 was the sole `Marker`-class display on that topic.
- [ ] Post-merge: launch Izzy, confirm `ros2 topic info /izzy/hover_visualization -v` reports a single `MarkerArray` type and `ros2 bag record` captures it cleanly.

Closes #243

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
