### PR TITLE
bizzyboat: enable cross-track slew limiter at 3.0 m/s (nav#66 first cut)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -171,3 +171,14 @@ controller_server:
       # avoid_speed 0.0 = no slowdown through the manoeuvre (controller default
       # speed). Off for v1; enable + tune on the water if a slowdown is wanted.
       avoid_speed: 0.0
+      # Inner-crabbing cross-track slew limiter (rolker/unh_marine_navigation#66
+      # first cut, PR #75; enabled per #253). Caps how fast the cross-track error
+      # fed to the PID may change, so replan/reshape reference steps — the #250
+      # zig-zag trigger — ramp in instead of slamming the helm. Node default is
+      # 0.0 = disabled; 3.0 m/s sits above genuine lateral drift (~boat speed)
+      # but well below an instantaneous replan step. NB the limiter also ramps
+      # re-acquisition from a large offset (mission start far off the line, big
+      # avoidance excursion) at this same rate — don't set it low. Live-tunable:
+      # `ros2 param set /bizzy/controller_server FollowPath.cross_track_error_slew_rate 0.0`
+      # is the instant revert hatch.
+      cross_track_error_slew_rate: 3.0


### PR DESCRIPTION
## Summary

Enables the **cross-track slew limiter** (rolker/unh_marine_navigation#66 first cut, merged there as PR rolker/unh_marine_navigation#75) on BizzyBoat by setting `FollowPath.cross_track_error_slew_rate: 3.0` in `bizzyboat_project11/config/nav2_overlay.yaml`.

Part of #253 (does **not** close it — #253 is the deployment issue and gets its own wrap-up PR).

## Why

- The node default is `0.0` = disabled by design (shared-controller convention: land disabled, deployed config opts in — see the #66 work plan's flagged cross-repo follow-up).
- The 2026-06-10 (#250) RCA showed the zig-zag/hunting is gated by **replan churn** stepping the cross-track reference; the limiter ramps those steps in instead of slamming the pure-P helm.
- The 2026-06-11 deployment (#253) couldn't run the live A/B enable, so the boat drove with the fix built but dormant. This makes it default-on for the next launch.

## Value choice — 3.0 m/s

From the #253 plan: above genuine lateral drift (~boat speed, ≤1.5 m/s) so real recovery passes through, well below an instantaneous replan step. Review watch-out documented in the YAML comment: re-acquisition from a large offset is also ramped at this rate — don't tune it low.

## Revert hatch

Live-tunable, no rebuild: `ros2 param set /bizzy/controller_server FollowPath.cross_track_error_slew_rate 0.0` disables instantly.

## Deploy notes (gabby)

`git pull` + rebuild `bizzyboat_project11` (config installs via `install(DIRECTORY ...)` — data files copy, symlink install does not cover them) + relaunch nav. Requires `marine_nav_crabbing_path_follower` at or after the nav PR #75 merge (gitcloud is synced to it).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
