### PR TITLE
bizzyboat: add screenshooter crop+timestamp utility

### DIFF
--- a/bizzyboat_project11/scripts/crop_screenshooter.sh
+++ b/bizzyboat_project11/scripts/crop_screenshooter.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Crop a region out of an operator screenshooter time-lapse and burn the real
+# per-frame wall-clock timestamp (from the sidecar CSV) onto each frame, so
+# frames trace back to bag data. UTC is shown (matches ROS message epoch) plus
+# EDT in parens (matches local-time bag dir names like operator_...T14.21.16).
+#
+# Usage:  crop_screenshooter.sh <YYYY-MM-DD> [region]
+#   region = a named preset (default: middle) or a raw ffmpeg crop "w:h:x:y".
+#
+# Presets (tuned to the 3840x5760 3-monitor stack; re-check per deployment if
+# the operator monitor layout changes):
+#   middle      annunciator + CAMP/chart + camera grid + segmentation + the
+#               bottom sidescan waterfall (terminals flank it). 3840:2250:0:2000
+#   top-middle  the above PLUS the top screen above it.            3840:4250:0:0
+#
+# Source (from ccomjhc_project11/scripts/screenshooter.bash):
+#   ~/data/logs/operator/<date>/screenshots/operator_<date>.{mp4,csv}
+#   CSV cols: frame_index,timestamp(YYYY-MM-DDTHH-MM-SS, UTC),filename
+#   Output video is 2 fps -> each frame == 0.5 s of timeline.
+set -euo pipefail
+
+DATE="${1:?usage: crop_screenshooter.sh <YYYY-MM-DD> [region]}"
+REGION="${2:-middle}"
+FPS=2
+UTC_OFFSET_HOURS=-4   # EDT (June). Use -5 for EST outside DST.
+
+# --- resolve region preset -> ffmpeg crop w:h:x:y ---
+case "$REGION" in
+  middle)                            CROP="3840:2250:0:2000" ;;
+  top-middle|middle-top|top+middle)  CROP="3840:4250:0:0" ;;
+  *:*:*:*)                           CROP="$REGION" ;;   # raw w:h:x:y override
+  *) echo "unknown region '$REGION' (use: middle | top-middle | w:h:x:y)" >&2; exit 1 ;;
+esac
+TAG="$(echo "$REGION" | tr ':+' '__')"
+
+SRCDIR="$HOME/data/logs/operator/$DATE/screenshots"
+MP4="$SRCDIR/operator_$DATE.mp4"
+CSV="$SRCDIR/operator_$DATE.csv"
+OUTDIR="$HOME/data/logs/analysis/${DATE}_screenshooter_crop"
+ASS="$OUTDIR/operator_${DATE}_${TAG}_timestamps.ass"
+OUT="$OUTDIR/operator_${DATE}_${TAG}_ts.mp4"
+
+[[ -f "$MP4" ]] || { echo "missing video: $MP4" >&2; exit 1; }
+[[ -f "$CSV" ]] || { echo "missing CSV:   $CSV" >&2; exit 1; }
+mkdir -p "$OUTDIR"
+
+# --- ASS subtitle from CSV (explicit PlayRes -> predictable font size) ---
+python3 - "$CSV" "$ASS" "$FPS" "$UTC_OFFSET_HOURS" "$CROP" <<'PY'
+import csv, sys, datetime
+csvpath, asspath, fps, off, crop = sys.argv[1], sys.argv[2], float(sys.argv[3]), int(sys.argv[4]), sys.argv[5]
+w, h = crop.split(":")[0], crop.split(":")[1]
+frame_s = 1.0 / fps
+def ass_t(t):
+    cs = int(round(t * 100)); hh, cs = divmod(cs, 360000); mm, cs = divmod(cs, 6000); ss, cs = divmod(cs, 100)
+    return f"{hh:d}:{mm:02d}:{ss:02d}.{cs:02d}"
+rows = list(csv.DictReader(open(csvpath)))
+# Alignment 1 = bottom-left (clear of the annunciator panel in the top-left).
+hdr = f"""[Script Info]
+ScriptType: v4.00+
+PlayResX: {w}
+PlayResY: {h}
+ScaledBorderAndShadow: yes
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: ts,DejaVu Sans Mono,48,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,0,0,0,0,100,100,0,0,3,0,0,1,30,30,25,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+with open(asspath, "w") as f:
+    f.write(hdr)
+    for i, row in enumerate(rows):
+        dt = datetime.datetime.strptime(row["timestamp"], "%Y-%m-%dT%H-%M-%S")
+        loc = dt + datetime.timedelta(hours=off)
+        text = f"{dt:%Y-%m-%d %H:%M:%S} UTC ({loc:%H:%M:%S} EDT)"
+        f.write(f"Dialogue: 0,{ass_t(i*frame_s)},{ass_t((i+1)*frame_s)},ts,,0,0,0,,{text}\n")
+print(f"wrote {len(rows)} ASS events -> {asspath}")
+PY
+
+# --- crop + burn timestamp + re-encode ---
+ffmpeg -hide_banner -loglevel warning -stats -i "$MP4" \
+  -vf "crop=${CROP},subtitles='${ASS}'" \
+  -c:v libx264 -crf 20 -preset medium -pix_fmt yuv420p -r "$FPS" \
+  "$OUT" -y
+
+echo "==> region=$REGION crop=$CROP"
+echo "==> $OUT"
+ls -la "$OUT"

--- a/bizzyboat_project11/scripts/crop_screenshooter.sh
+++ b/bizzyboat_project11/scripts/crop_screenshooter.sh
@@ -7,8 +7,10 @@
 # Usage:  crop_screenshooter.sh <YYYY-MM-DD> [region]
 #   region = a named preset (default: middle) or a raw ffmpeg crop "w:h:x:y".
 #
-# Presets (tuned to the 3840x5760 3-monitor stack; re-check per deployment if
-# the operator monitor layout changes):
+# Presets are tuned to BIZZYBOAT's operator monitor layout (3840x5760 3-monitor
+# stack). The screenshooter is reused on other platforms with DIFFERENT layouts,
+# so on those pass a raw w:h:x:y crop instead. Re-check per deployment if the
+# monitor arrangement changes.
 #   middle      annunciator + CAMP/chart + camera grid + segmentation + the
 #               bottom sidescan waterfall (terminals flank it). 3840:2250:0:2000
 #   top-middle  the above PLUS the top screen above it.            3840:4250:0:0
@@ -21,8 +23,12 @@ set -euo pipefail
 
 DATE="${1:?usage: crop_screenshooter.sh <YYYY-MM-DD> [region]}"
 REGION="${2:-middle}"
+[[ -n "${2:-}" ]] || echo "note: default region 'middle' is bizzyboat-specific; pass a region or w:h:x:y for other platforms" >&2
 FPS=2
-UTC_OFFSET_HOURS=-4   # EDT (June). Use -5 for EST outside DST.
+# Local timezone for the burned label. Default EDT (June DST). For EST set
+# both: UTC_OFFSET_HOURS=-5 LOCAL_TZ=EST so offset and label stay consistent.
+UTC_OFFSET_HOURS="${UTC_OFFSET_HOURS:--4}"
+LOCAL_TZ="${LOCAL_TZ:-EDT}"
 
 # --- resolve region preset -> ffmpeg crop w:h:x:y ---
 case "$REGION" in
@@ -45,9 +51,9 @@ OUT="$OUTDIR/operator_${DATE}_${TAG}_ts.mp4"
 mkdir -p "$OUTDIR"
 
 # --- ASS subtitle from CSV (explicit PlayRes -> predictable font size) ---
-python3 - "$CSV" "$ASS" "$FPS" "$UTC_OFFSET_HOURS" "$CROP" <<'PY'
+python3 - "$CSV" "$ASS" "$FPS" "$UTC_OFFSET_HOURS" "$CROP" "$LOCAL_TZ" <<'PY'
 import csv, sys, datetime
-csvpath, asspath, fps, off, crop = sys.argv[1], sys.argv[2], float(sys.argv[3]), int(sys.argv[4]), sys.argv[5]
+csvpath, asspath, fps, off, crop, tzlabel = sys.argv[1], sys.argv[2], float(sys.argv[3]), int(sys.argv[4]), sys.argv[5], sys.argv[6]
 w, h = crop.split(":")[0], crop.split(":")[1]
 frame_s = 1.0 / fps
 def ass_t(t):
@@ -70,12 +76,21 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 """
 with open(asspath, "w") as f:
     f.write(hdr)
+    written = 0
     for i, row in enumerate(rows):
-        dt = datetime.datetime.strptime(row["timestamp"], "%Y-%m-%dT%H-%M-%S")
+        try:
+            dt = datetime.datetime.strptime(row["timestamp"], "%Y-%m-%dT%H-%M-%S")
+        except (ValueError, KeyError) as e:
+            print(f"skip row {i}: bad timestamp {row.get('timestamp')!r} ({e})", file=sys.stderr)
+            continue
+        # Place each event at its true frame position (the CSV's frame_index),
+        # not the row ordinal, so a dropped frame can't silently desync times.
+        fi = int(row.get("frame_index", i))
         loc = dt + datetime.timedelta(hours=off)
-        text = f"{dt:%Y-%m-%d %H:%M:%S} UTC ({loc:%H:%M:%S} EDT)"
-        f.write(f"Dialogue: 0,{ass_t(i*frame_s)},{ass_t((i+1)*frame_s)},ts,,0,0,0,,{text}\n")
-print(f"wrote {len(rows)} ASS events -> {asspath}")
+        text = f"{dt:%Y-%m-%d %H:%M:%S} UTC ({loc:%H:%M:%S} {tzlabel})"
+        f.write(f"Dialogue: 0,{ass_t(fi*frame_s)},{ass_t((fi+1)*frame_s)},ts,,0,0,0,,{text}\n")
+        written += 1
+print(f"wrote {written} ASS events -> {asspath}")
 PY
 
 # --- crop + burn timestamp + re-encode ---


### PR DESCRIPTION
## Summary

Adds `bizzyboat_project11/scripts/crop_screenshooter.sh` — crops an operator
**screenshooter** time-lapse to a screen region and burns the real per-frame
wall-clock timestamp onto each frame, so debrief frames trace back to bag data.

## Details

- Region presets (tuned to the current 3840x5760 operator monitor layout):
  - `middle` (default) — annunciator + CAMP/chart + camera grid + segmentation +
    bottom sidescan waterfall. `crop=3840:2250:0:2000`
  - `top-middle` — the above plus the top screen. `crop=3840:4250:0:0`
  - raw `w:h:x:y` override also accepted
- Per-frame timestamp comes from the screenshooter's sidecar
  `operator_<date>.csv` (`frame_index,timestamp(UTC),filename`). Capture
  interval is variable (~30-44 s), so the time is read per frame, not assumed.
  Rendered as `... UTC (... EDT)` (UTC = ROS epoch; EDT = local bag dir names),
  bottom-left so it doesn't cover the annunciator.
- Output: `~/data/logs/analysis/<date>_screenshooter_crop/`.
- Crop geometry is layout-specific and documented in the script header.

Produced and verified on the 2026-06-12 Lake Massabesic shakedown recording.

Closes #259

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
