### PR TITLE
BizzyBoat sim-aware core bringup for the Massabesic sim

### DIFF
--- a/.agent/work-plans/issue-261/progress.md
+++ b/.agent/work-plans/issue-261/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 261
+---
+
+# Issue #261 — BizzyBoat sim-aware core bringup for the Massabesic sim (no config duplication)
+
+## Local Review
+**Status**: complete
+**When**: 2026-06-13 12:30 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (after fix)
+
+**PR**: #264 at `c0510f2`
+**Mode**: post-PR
+**Depth**: Standard (reason: governance-relevant launch/config wiring)
+**Must-fix**: 1 | **Suggestions**: 0
+
+### Findings
+- [x] (must-fix) Dead `chart_layer.tide_invalidate_threshold` override — sibling-scope from nav2, moot at chart-less Massabesic; removed — `config/bizzyboat_sim.yaml`
+- Static nits (D100/I201/yaml-seq-indent) dropped: not enforced by package (no ament lint hooks) and match sibling style (`core_launch.py`, `ben_sim.yaml`).
+- Copilot Adversarial unavailable (monthly quota exceeded); static + Claude adversarial were the gate.

--- a/bizzyboat_project11/config/bizzyboat_sim.yaml
+++ b/bizzyboat_project11/config/bizzyboat_sim.yaml
@@ -33,17 +33,13 @@
             position: "sensors/nav/position"
             velocity: "sensors/nav/velocity"
 
-# Sim runs tide ~10x real-time (tide_speed_factor=10), so the field-appropriate
-# 1 cm chart-layer tide_invalidate_threshold fires ~10x as often. 5 cm restores
-# a roughly real-time-equivalent invalidation cadence and avoids costmap-stall
-# planner aborts. (Mirrors ben_sim.yaml; requires rolker/s57_tools#17. Harmless
-# where no ENC coverage exists, e.g. Lake Massabesic.)
-/**/local_costmap/local_costmap:
-  ros__parameters:
-    chart_layer:
-      tide_invalidate_threshold: 0.05
-
-/**/global_costmap/global_costmap:
-  ros__parameters:
-    chart_layer:
-      tide_invalidate_threshold: 0.05
+# NOTE: a sim chart-layer tide_invalidate_threshold override (as ben_sim.yaml
+# carries) is intentionally NOT set here. This overlay is applied via
+# SetParametersFromFile inside the core launch's namespace GroupAction, but nav2
+# is included as a sibling outside that scope and loads its costmap params via
+# its own RewrittenYaml chain (nav2_params.base + model + nav2_overlay) — so a
+# /**/{local,global}_costmap override placed here would never reach the costmap
+# nodes. It is also moot at Lake Massabesic, which has no ENC coverage (the
+# chart_layer is inert). If a sim tide-threshold is ever needed, it belongs in
+# the nav2 param chain via nav_launch.py's instance_params, not here.
+# (ben_sim.yaml has the same latent sibling-scope issue — tracked separately.)

--- a/bizzyboat_project11/config/bizzyboat_sim.yaml
+++ b/bizzyboat_project11/config/bizzyboat_sim.yaml
@@ -1,0 +1,49 @@
+# Sim overlay for BizzyBoat — applied only under is_simulator by
+# bizzyboat_sim_core_launch.py, on top of bizzyboat.yaml. Holds ONLY the
+# deltas from the field config. Never duplicate planner/costmap config here:
+# that stays in nav2_overlay.yaml (the single source of truth, loaded by
+# nav_launch.py). Mirrors ben_project11/config/ben_sim.yaml.
+
+# In sim there is no mavros/FCU or SBG INS; asv_sim publishes the platform's
+# nav on sensors/nav/{orientation,position,velocity} (sim_robot_launch.py
+# remaps asv_sim's position/orientation/velocity outputs there). Redirect the
+# nav consumers from the mavros sources in bizzyboat.yaml to those topics.
+# (Leaving the base 'mru' sensor defined but unselected is intentional — only
+# sensor_names is switched, matching ben_sim.yaml.)
+/**/mru_transform:
+  ros__parameters:
+    sensors:
+      nav:
+        topics:
+          orientation: "sensors/nav/orientation"
+          position: "sensors/nav/position"
+          velocity: "sensors/nav/velocity"
+    sensor_names:
+    - nav
+
+/**/platform_sender:
+  ros__parameters:
+    nav:
+      source_names:
+        - nav
+      sources:
+        nav:
+          topics:
+            orientation: "sensors/nav/orientation"
+            position: "sensors/nav/position"
+            velocity: "sensors/nav/velocity"
+
+# Sim runs tide ~10x real-time (tide_speed_factor=10), so the field-appropriate
+# 1 cm chart-layer tide_invalidate_threshold fires ~10x as often. 5 cm restores
+# a roughly real-time-equivalent invalidation cadence and avoids costmap-stall
+# planner aborts. (Mirrors ben_sim.yaml; requires rolker/s57_tools#17. Harmless
+# where no ENC coverage exists, e.g. Lake Massabesic.)
+/**/local_costmap/local_costmap:
+  ros__parameters:
+    chart_layer:
+      tide_invalidate_threshold: 0.05
+
+/**/global_costmap/global_costmap:
+  ros__parameters:
+    chart_layer:
+      tide_invalidate_threshold: 0.05

--- a/bizzyboat_project11/launch/bizzyboat_sim_core_launch.py
+++ b/bizzyboat_project11/launch/bizzyboat_sim_core_launch.py
@@ -1,0 +1,213 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import SetParameter
+from launch_ros.actions import SetParametersFromFile
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    """Sim-aware BizzyBoat core bringup (non-Gazebo Massabesic sim).
+
+    Brings up only the sim-shareable autonomy stack — transforms, the
+    marine_autonomy robot core, and nav2 — reusing the boat's REAL config
+    files. Hardware drivers wired by ``core_launch.py`` (mavros/FCU, SBG INS,
+    NTRIP, Garmin sidescan, sound-speed and ZDA serial bridges, network
+    monitor, GPS-RTK diagnostics, mavros frame bridges) are intentionally
+    excluded: in sim, ``asv_sim`` is the vehicle and ``mbes_sim`` the sonar.
+
+    Mirrors ``ben_project11/ben_core_launch.py``'s base-config +
+    ``*_sim.yaml``-overlay pattern so sim and field share one config source
+    (no duplication / drift): ``bizzyboat.yaml`` always, then
+    ``bizzyboat_sim.yaml`` only under ``is_simulator``. nav2 is included via
+    the real ``nav_launch.py`` (model 240 + ``nav2_overlay.yaml``) — not
+    re-specified here. The helm (``asv_helm``) and ``asv_sim`` are supplied by
+    the sim repo's ``sim_robot_launch.py``, as for Ben; ``echo_helm`` (the
+    hardware helm) is therefore omitted.
+    """
+    namespace = LaunchConfiguration('namespace')
+    namespace_arg = DeclareLaunchArgument(
+        'namespace', default_value=TextSubstitution(text='bizzy')
+    )
+
+    frame_prefix = LaunchConfiguration('frame_prefix')
+    frame_prefix_arg = DeclareLaunchArgument(
+        'frame_prefix', default_value='bizzy/'
+    )
+
+    # Exposed for parity with ben_core_launch.py; this launch is sim-only, so
+    # the overlay is applied by default.
+    is_simulator = LaunchConfiguration('is_simulator')
+    is_simulator_arg = DeclareLaunchArgument(
+        'is_simulator', default_value=TextSubstitution(text='true'),
+        description='Layer bizzyboat_sim.yaml (sim nav sourcing + sim tide '
+        'threshold) on top of bizzyboat.yaml.'
+    )
+
+    use_ca_safety = LaunchConfiguration('use_ca_safety')
+    use_ca_safety_arg = DeclareLaunchArgument(
+        'use_ca_safety', default_value='true',
+        description='Pass-through to nav_launch.py: CA safety helm gate '
+        '(default) vs the nav2 Collision Monitor.'
+    )
+
+    return LaunchDescription([
+        namespace_arg,
+        frame_prefix_arg,
+        is_simulator_arg,
+        use_ca_safety_arg,
+
+        # URDF / robot_state_publisher (outside the namespace group —
+        # publish_state_launch.py sets the namespace on its nodes itself).
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([
+                    FindPackageShare('bizzyboat_project11'),
+                    'launch',
+                    'publish_state_launch.py'
+                ])
+            ),
+            launch_arguments={'namespace': namespace}.items()
+        ),
+
+        GroupAction(
+            actions=[
+                PushRosNamespace(namespace),
+
+                # Base config (real, always), then sim deltas only.
+                # bizzyboat_sim.yaml never duplicates planner/costmap config —
+                # that lives in nav2_overlay.yaml, loaded by nav_launch.py.
+                SetParametersFromFile(
+                    filename=PathJoinSubstitution([
+                        FindPackageShare('bizzyboat_project11'),
+                        'config',
+                        'bizzyboat.yaml'
+                    ])
+                ),
+                SetParametersFromFile(
+                    filename=PathJoinSubstitution([
+                        FindPackageShare('bizzyboat_project11'),
+                        'config',
+                        'bizzyboat_sim.yaml'
+                    ]),
+                    condition=IfCondition(is_simulator)
+                ),
+
+                # MRU transform (map/odom/base_link TF). In sim it sources nav
+                # from asv_sim via the bizzyboat_sim.yaml overlay (the base
+                # config points it at mavros, which does not run in sim).
+                Node(
+                    package='mru_transform',
+                    executable='mru_transform_node',
+                    name='mru_transform',
+                    parameters=[{
+                        'map_frame': [frame_prefix, 'map'],
+                        'base_frame': [frame_prefix, 'base_link'],
+                        'odom_frame': [frame_prefix, 'odom'],
+                    }],
+                    emulate_tty=True
+                ),
+
+                # Sea surface estimator: publishes map -> map_tide TF.
+                SetParameter(
+                    name='sea_surface_frame',
+                    value=[frame_prefix, 'map_tide']
+                ),
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('mru_transform'),
+                            'launch',
+                            'sea_surface_estimator_launch.py'
+                        ])
+                    ),
+                    launch_arguments={
+                        'namespace': namespace,
+                        'enable_bridge': 'false',
+                    }.items()
+                ),
+
+                # Chart datum (MLLW vertical datum transform).
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('mru_transform'),
+                            'launch',
+                            'chart_datum_launch.py'
+                        ])
+                    ),
+                ),
+
+                # Marine autonomy robot core (mission manager, helm manager,
+                # status — the autonomy side of the helm; the actuating helm
+                # is asv_helm from the sim repo).
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([
+                            FindPackageShare('marine_autonomy'),
+                            'launch',
+                            'robot_core_launch.py'
+                        ])
+                    ),
+                    launch_arguments={
+                        'namespace': namespace,
+                        'enable_bridge': 'false',
+                    }.items()
+                ),
+
+                # S57 charts (mirrors the field bringup; harmless where no ENC
+                # coverage exists, e.g. Lake Massabesic).
+                GroupAction(
+                    actions=[
+                        PushRosNamespace('s57'),
+                        SetParameter(
+                            name='map_frame',
+                            value=[frame_prefix, 'map']
+                        ),
+                        SetParameter(
+                            name='robot_base_frame',
+                            value=[frame_prefix, 'base_link']
+                        ),
+                        SetParameter(
+                            name='precompute_radius',
+                            value=5000.0
+                        ),
+                        IncludeLaunchDescription(
+                            PythonLaunchDescriptionSource(
+                                PathJoinSubstitution([
+                                    FindPackageShare('s57_grids'),
+                                    'launch',
+                                    's57_grids_launch.py'
+                                ])
+                            ),
+                        )
+                    ]
+                ),
+            ]
+        ),
+
+        # Nav2 — reuse the real bizzy nav_launch.py (model 240 +
+        # nav2_overlay.yaml + costmap window). No nav2 config duplication:
+        # this is the same launch the boat runs in the field.
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([
+                    FindPackageShare('bizzyboat_project11'),
+                    'launch',
+                    'nav_launch.py'
+                ])
+            ),
+            launch_arguments={
+                'namespace': namespace,
+                'use_ca_safety': use_ca_safety,
+            }.items()
+        ),
+    ])


### PR DESCRIPTION
Closes #261. Part of rolker/unh_marine_simulation#66.

Adds a **sim-aware BizzyBoat core bringup** so the non-Gazebo Massabesic sim can run
BizzyBoat's autonomy + nav2 stack against the boat's **real** config — no duplication,
no drift. Mirrors `ben_project11/ben_core_launch.py` + `ben_sim.yaml`.

## What's here
- **`launch/bizzyboat_sim_core_launch.py`** — sim-shareable stack only:
  `publish_state` (URDF) · `bizzyboat.yaml` + `bizzyboat_sim.yaml` overlay (under `is_simulator`)
  · `mru_transform` · `sea_surface_estimator` (map_tide) · `chart_datum` · `marine_autonomy`
  robot core · `s57_grids` · **nav2 via the real `nav_launch.py`** (model 240 + `nav2_overlay.yaml`).
  **Excludes** all hardware: mavros/FCU, SBG, NTRIP, sidescan, sound-speed/ZDA serial bridges,
  network monitor, GPS-RTK diag, mavros frame bridges. The helm (`asv_helm`) + `asv_sim` come
  from the sim repo's `sim_robot_launch.py` (as for Ben), so `echo_helm` is omitted.
- **`config/bizzyboat_sim.yaml`** — sim deltas only: nav sourced from `asv_sim`
  (`sensors/nav/*`) instead of mavros; sim chart-layer tide threshold (0.05). **No copy of
  `nav2_overlay.yaml`.**

## Verification
- `colcon build` clean; `config/` + `launch/` auto-install via existing `install(DIRECTORY ...)`.
- `ros2 launch ... --show-args` loads the description and resolves every included launch's
  package (args bubble up from `chart_datum`/`sea_surface_estimator`).
- End-to-end run requires the sim repo side (`asv_sim` + `sim_robot_launch` platform select,
  `unh_marine_simulation#66`) — **draft until that lands and the stack runs together.**

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
