### PR TITLE
Activate reflex confidence floor on BizzyBoat (obstacle_prob_min 0.60)

### DIFF
--- a/bizzyboat_project11/launch/perception_launch.py
+++ b/bizzyboat_project11/launch/perception_launch.py
@@ -205,6 +205,14 @@ def generate_launch_description():
                                     launch_arguments={
                                         'name': 'segments_to_pointcloud_reflex',
                                         'target_frame': 'bizzy/base_link_level',
+                                        # Reflex confidence floor: drop low-
+                                        # confidence returns (calm-water
+                                        # reflections ~0.55) so the e-stop reacts
+                                        # to real obstacles (buoys/pots 0.85+).
+                                        # "Balanced" default; raise to ~0.75 on
+                                        # glassy water via ros2 param set. See
+                                        # unh_marine_perception#35/#37/#34.
+                                        'obstacle_prob_min': '0.60',
                                     }.items()
                                 ),
                             ]


### PR DESCRIPTION
## What
Activate the reflex confidence floor on BizzyBoat: pass `obstacle_prob_min: 0.60` to the
`segments_to_pointcloud_reflex` include in `bizzyboat_project11/launch/perception_launch.py`.

## Why
Capability (unh_marine_perception#35) + launch arg (#37) are merged; this sets the
harness-validated **0.60 "Balanced"** value so the reflex e-stop stops firing on low-confidence
calm-water reflections (~0.55) while keeping real obstacles (buoys/pots 0.85+) and most debris.
Operator can raise to ~0.75 on glassy water via `ros2 param set`; the eWaSR retrain (#34) is the
durable fix for high-confidence bright reflections.

## Verification
Syntax-checked. Launch-only change — **boat needs `git pull` + relaunch (no rebuild)**. Verify on
the boat: `ros2 param get /bizzy/oak_forward/segments_to_pointcloud_reflex obstacle_prob_min` -> 0.60.

Closes #266 · Related unh_marine_perception#35, #37, #34, #30

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
