### PR TITLE
manifest: add marine_control to core layer

### DIFF
--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: git@gitcloud:field/marine_ais.git
     version: jazzy
+  marine_control:
+    type: git
+    url: git@gitcloud:field/marine_control.git
+    version: jazzy
   udp_bridge:
     type: git
     url: git@gitcloud:field/udp_bridge.git


### PR DESCRIPTION
Adds `marine_control` to the BOAT manifest core layer (gitcloud URL). Mirrors DEV PR rolker/unh_marine_autonomy#155; gitcloud mirror `field/marine_control` exists.

Closes #267

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
