### PR TITLE
logger: record garmin water_temperature + nadir_depth in the main deployment bag

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -360,6 +360,12 @@
       # the head is dry; the regex matches it). Parse failures → NaN.
       # See unh_echoboats_project11#104 wrap-up + marine_tools#7.
       - /bizzy/sensors/sound_speed/sound_speed
+      # Garmin transducer water temperature + nadir bottom range — small scalars,
+      # kept in the main bag (alongside sound_speed) so the sound-speed/depth
+      # cross-check is self-contained here, not only in the sonar bag (#270;
+      # follow-up to #257 which only added these to sonar_logger + the bridge).
+      - /bizzy/sensors/sidescan/garmin_sidescan/water_temperature
+      - /bizzy/sensors/sidescan/garmin_sidescan/nadir_depth
       - /bizzy/udp_bridge/bridge_info
       - /bizzy/udp_bridge/topic_statistics
       - /bizzy/udp_bridge/remotes/operator/bridge_info


### PR DESCRIPTION
Adds the Garmin `water_temperature` and `nadir_depth` to the **main** deployment logger (`/**/logger:`) in `bizzyboat.yaml`, so the primary `bizzyboat` bag is self-contained for the sound-speed/depth cross-check (it already records `/sound_speed` + `/tide_estimate`).

These were only in `sonar_logger` (the `bizzyboat_sonar` bag) — surfaced validating the 2026-06-12 Massabesic survey, where the Garmin transducer temp (~26.8 °C, confirming the ~1505 m/s SVS to 0.26%) had to be decoded from raw frames because it wasn't in the main bag.

Two-line record-list addition. Follow-up to #257.

Closes #270

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
