### PR TITLE
bizzyboat: record M3 .all files alongside sonar bags

### DIFF
--- a/bizzyboat_project11/launch/perception_launch.py
+++ b/bizzyboat_project11/launch/perception_launch.py
@@ -111,6 +111,19 @@ def generate_launch_description():
                             parameters=[{
                                 'bind_port': 20002,
                                 'frame_id': 'bizzy/m3',
+                                # Archive the M3's raw Kongsberg EM stream as
+                                # genuine .all files (Caris/Qimera/MB-System)
+                                # alongside the sonar bags. Use an `m3_all`
+                                # subdir of the sonar-log base, NOT the bag's
+                                # own `<base>/<sonar_log_subdirectory>` dir:
+                                # the sonar_logger rosbag2 recorder errors if
+                                # its target dir pre-exists, and the bridge
+                                # makedirs its save dir -- so writing there (or
+                                # to that session parent) would race the bag.
+                                # `<base>/m3_all` is a collision-free sibling.
+                                'save_all_dir': PathJoinSubstitution([
+                                    sonar_log_directory, 'm3_all'
+                                ]),
                             }],
                             emulate_tty=True
                         ),


### PR DESCRIPTION
## Summary

Enables the new `kongsberg_em_bridge` `.all` recording option (from
`rolker/marine_tools#46`, merged) on BizzyBoat. The M3 multibeam's raw Kongsberg
EM datagram stream is now archived as genuine `.all` files — loadable by Caris
HIPS / QPS Qimera / MB-System — saved alongside the sonar bags.

## Change

`bizzyboat_project11/launch/perception_launch.py`: pass `save_all_dir` to the
`kongsberg_em_bridge` node, derived from the existing `sonar_log_directory`
(`P11_SONAR_LOG_DIR` base, default `/home/field/data/logs/bizzyboat_sonar`):

```python
'save_all_dir': PathJoinSubstitution([sonar_log_directory, 'm3_all']),
```

Resolves to `<sonar-log-base>/m3_all/`, where the node writes timestamped
`m3_<UTC>.all` files. Empty default in the driver means this is opt-in; here we
opt BizzyBoat in.

### Why `m3_all/` and not the bag dir

The `sonar_logger` rosbag2 recorder writes to `<base>/<sonar_log_subdirectory>`
and **errors if that directory already exists**. The bridge `makedirs` its save
directory at startup, so pointing it at the bag dir — or at the session parent
that contains it — would race the recorder and could break bag recording.
`<base>/m3_all/` is a collision-free sibling of the per-session bag directories,
under the same sonar-log root (same disk / `P11_SONAR_LOG_DIR` override).

## Testing

- `python3 -m ast` parse + `generate_launch_description()` constructs cleanly
  (6 top-level actions).
- Resolved the substitution via a `LaunchContext`:
  `save_all_dir` → `/home/field/data/logs/bizzyboat_sonar/m3_all` (sibling of the
  `<base>/<timestamp>` bag dirs — confirmed no overlap).
- Full on-boat launch verification (gabby) pending — config-only change in the
  established `PathJoinSubstitution` pattern already used in this file.

Enables `rolker/marine_tools#46`. Closes #280.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
