### PR TITLE
bizzyboat URDF: measured waterline frame + sidescan offsets (#282)

### DIFF
--- a/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
+++ b/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
@@ -129,6 +129,17 @@
     </visual>
   </link>
 
+  <!-- ========== Reference frames ========== -->
+  <!-- Measured water surface, 2026-06-15 Lake Massabesic: draft reference point
+       +0.180 m above base_link, waterline 0.150 m below that ref => waterline
+       +0.030 m above base_link (base_link sits ~30 mm below the surface). -->
+  <link name="bizzy/waterline"/>
+  <joint name="base_to_waterline" type="fixed">
+    <parent link="bizzy/base_link"/>
+    <child link="bizzy/waterline"/>
+    <origin xyz="0 0 0.030" rpy="0 0 0"/>
+  </joint>
+
 
   <!-- ========== Cameras (4x OAK-1 PoE) ========== -->
   <!-- Mounted at top of mast on 3D-printed bracket, 90deg apart.
@@ -246,15 +257,15 @@
     x="-0.23" y="0.0" z="-0.145"/>
 
   <!-- ========== Garmin GCV-20 Sidescan ========== -->
-  <!-- Centered, ~0.15 m forward of base_link, flush against the hull underside.
-       z = -0.30 is the flat hull bottom (hull depth 0.30 below the deck/base_link
+  <!-- Measured 2026-06-15 (Lake Massabesic): essentially centered (3 mm aft of
+       base_link), against the hull underside. z = -0.29 is the transducer face,
+       just above the flat hull bottom (hull depth ~0.30 below the deck/base_link
        plane per scripts/generate_hull_mesh.py). The garmin_sidescan driver stamps
        each channel image with a per-channel frame_id — the base frame_id param
        ("bizzy/garmin_sidescan", set in launch/sidescan_launch.py) plus a channel
        suffix, giving "bizzy/garmin_sidescan_down/_port/_starboard"; this macro
-       supplies the matching TF frames.
-       Offsets are approximate — confirm by measurement. -->
+       supplies the matching TF frames. -->
   <xacro:garmin_sidescan parent="bizzy/base_link" name="garmin_sidescan"
-    x="0.15" y="0.0" z="-0.30"/>
+    x="-0.003" y="0.0" z="-0.29"/>
 
 </robot>


### PR DESCRIPTION
## bizzyboat URDF: measured waterline + sidescan offsets

Applies offsets **measured 2026-06-15 at Lake Massabesic** to `bizzyboat.urdf.xacro`.

### Changes
1. **New `bizzy/waterline` frame** at `xyz="0 0 0.030"` off `base_link`
   - Derivation: draft ref point +0.180 m above base_link; waterline 0.150 m below ref ⇒ **+0.030 m** (base_link sits ~30 mm below the surface). Supports datum / sea-surface reference (#278) and sounding reduction.
2. **Garmin sidescan mount corrected** (was approximate):
   - `x: 0.15 → -0.003`, `z: -0.30 → -0.29` (essentially centered, 3 mm aft; transducer face just above the hull bottom). Orientation stays in TF per the macro.

### Verification
- `xacro` expands cleanly; `check_urdf` parses (`robot name is: bizzyboat`).
- Expanded origins confirmed: `base_to_waterline xyz="0 0 0.030"`, `base_to_garmin_sidescan xyz="-0.003 0.0 -0.29"`.

### Note — offsets diagram
`docs/bizzyboat_offsets.svg` is **hand-maintained and decoupled from the URDF** (hardcoded coordinate list, doesn't parse the xacro) and currently has **no sidescan or waterline entry**. Re-running its generator produced no change. Adding sidescan + waterline to that diagram is a **separate doc task** (visual label tuning), deliberately not bundled here.

Closes #282 · part of the 2026-06-15 deployment (#277) follow-ups · relates to #278.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
