### PR TITLE
bizzyboat: correct lake_datum 52.3 -> 48.88 (full-pool, #278)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -476,8 +476,11 @@
     mhhw_frame: bizzy/chart_datum_mhhw
     # Lake Massabesic (freshwater, no tidal signal, no VDatum coverage): fixed
     # chart-datum override = lake datum height rel. WGS84 ellipsoid, metres
-    # (positive = above ellipsoid). Set 2026-06-15 for survey ops.
-    lake_datum: 52.3
+    # (positive = above ellipsoid). Full-pool value derived 2026-06-16 from
+    # in-water nav z: /bizzy/odom base_link 48.737 m + 0.030 m waterline =
+    # 48.767 m surface, + 0.114 m below-full gauge offset = 48.88 m full pool.
+    # Supersedes the provisional 52.3 (boat on the trailer, ~3.6 m high). See #278.
+    lake_datum: 48.88
 
 /**/sea_surface_estimator:
   ros__parameters:


### PR DESCRIPTION
## Correct `lake_datum`: 52.3 → 48.88 (full-pool)

The provisional `lake_datum: 52.3` (wired via #279) was **read off the boat on the trailer** before launch — ~3.5 m too high. This sets the correct **full-pool** value.

### Derivation (SBG-free)
```
base_link in-water z  (/bizzy/odom, ArduPilot FCU-EKF3 per #91, NOT SBG)   48.737 m
+ waterline offset    (base_link -> surface, measured #282)                 0.030 m
current water surface (2026-06-15)                                          48.767 m
+ below-full          (lake gauge 65.5" vs full 61" = 4.5")                 0.114 m
FULL-POOL lake datum                                                      = 48.88 m  (WGS84 ellipsoidal)
```

### Evidence
- Friday 06-12 odom z: **52.3–52.4 m on the trailer** (18:21–18:23, out of water) → **48.73 m afloat** from 18:31.
- In-water average: Friday 48.728 m / today 48.737 m — **agree to ~1 cm**.
- SBG cross-check agrees: gps_pos ellipsoidal (MSL 82.37 + undulation −32.79) = 49.58 m antenna − 0.89 m = 48.69 m base_link.

Full derivation + data: #278 comment.

### Follow-on (not in this PR)
Dependents still carrying the old 52.3 to update separately: **UMA #148** (Phase-2 imports) and bathy costmap **#164**.

Closes #278



---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
