### PR TITLE
datum: Lake Massabesic polygon config, drop scalar lake_datum (#285)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -474,13 +474,12 @@
     chart_datum_frame: bizzy/chart_datum
     base_frame: bizzy/base_link
     mhhw_frame: bizzy/chart_datum_mhhw
-    # Lake Massabesic (freshwater, no tidal signal, no VDatum coverage): fixed
-    # chart-datum override = lake datum height rel. WGS84 ellipsoid, metres
-    # (positive = above ellipsoid). Full-pool value derived 2026-06-16 from
-    # in-water nav z: /bizzy/odom base_link 48.737 m + 0.030 m waterline =
-    # 48.767 m surface, + 0.114 m below-full gauge offset = 48.88 m full pool.
-    # Supersedes the provisional 52.3 (boat on the trailer, ~3.6 m high). See #278.
-    lake_datum: 48.88
+    # Lake Massabesic datum comes from the polygon config (override:true entry,
+    # chart_datum_z = 48.88 m full-pool WGS84 ellipsoidal) in
+    # config/massabesic_datum_polygons.yaml, wired via datum_config_path in
+    # core_launch.py. No scalar lake_datum here, so the polygon is the live
+    # source (single source of truth, toward unh_marine_autonomy#163). Datum
+    # derivation: #278.
 
 /**/sea_surface_estimator:
   ros__parameters:

--- a/bizzyboat_project11/config/massabesic_datum_polygons.yaml
+++ b/bizzyboat_project11/config/massabesic_datum_polygons.yaml
@@ -1,0 +1,26 @@
+# Lake Massabesic polygon -> datum config for mru_transform's chart_datum_node.
+#
+# Wired via the `datum_config_path` param (set in core_launch.py). Resolution
+# order in the node: lake_datum param (if set) > override:true entry whose ring
+# contains the point > VDatum > override:false entry. The boat sets no
+# lake_datum param, so this override:true entry is the live source.
+#
+# chart_datum_z is the datum height rel. the WGS84 ellipsoid (metres, + = above).
+# Value 48.88 m (full-pool) derived 2026-06-16 from in-water nav z + waterline +
+# below-full gauge offset — see unh_echoboats_project11#278.
+#
+# Ring = the contour bathymetry raster (massabesic_bathy.tif, NAD83/UTM19N)
+# lat/lon extent padded ~0.005 deg (~0.5 km), covering the lake + buffer.
+# mhhw_z is intentionally omitted (freshwater, no tide): leaves the MHHW frame
+# unpublished so sea_surface_estimator's tide plausibility bound stays disabled
+# (#278). A point on a ring edge counts as inside.
+
+datum_polygons:
+  - name: "Lake Massabesic"
+    override: true
+    chart_datum_z: 48.88
+    ring:
+      - [43.0178, -71.4029]   # NW
+      - [43.0178, -71.3358]   # NE
+      - [42.9474, -71.3358]   # SE
+      - [42.9474, -71.4029]   # SW

--- a/bizzyboat_project11/launch/core_launch.py
+++ b/bizzyboat_project11/launch/core_launch.py
@@ -94,7 +94,11 @@ def generate_launch_description():
                     }.items()
                 ),
 
-                # Chart datum (MLLW vertical datum transform)
+                # Chart datum (MLLW vertical datum transform).
+                # Lake Massabesic datum comes from the polygon config
+                # (override:true entry, chart_datum_z = 48.88 m full-pool); no
+                # scalar lake_datum param is set, so the polygon is the live
+                # source (single source of truth, toward unh_marine_autonomy#163).
                 IncludeLaunchDescription(
                     PythonLaunchDescriptionSource(
                         PathJoinSubstitution([
@@ -103,6 +107,13 @@ def generate_launch_description():
                             'chart_datum_launch.py'
                         ])
                     ),
+                    launch_arguments={
+                        'datum_config_path': PathJoinSubstitution([
+                            FindPackageShare('bizzyboat_project11'),
+                            'config',
+                            'massabesic_datum_polygons.yaml'
+                        ])
+                    }.items(),
                 ),
 
                 # MAVROS frame bridges (workaround)


### PR DESCRIPTION
## Lake Massabesic datum → polygon config (single source of truth)

Moves BizzyBoat's chart datum from the scalar `lake_datum` param to a **polygon config** consumed by `mru_transform`'s `chart_datum_node` (option A — polygon live).

### Changes
- **New `config/massabesic_datum_polygons.yaml`** — `override: true` entry, **`chart_datum_z: 48.88`** (full-pool WGS84 ellipsoidal; derivation rolker/unh_echoboats_project11#278), `mhhw_z` omitted (freshwater, no tide → keeps `map_tide` unfiltered per #278). `ring` = the contour-bathy raster (`massabesic_bathy.tif`, NAD83/UTM19N) lat/lon extent padded ~0.5 km.
- **`core_launch.py`** — pass `datum_config_path` to `chart_datum_launch.py` via `FindPackageShare('bizzyboat_project11')/config/...` (package-relative).
- **`bizzyboat.yaml`** — remove the scalar `lake_datum: 48.88` (the scalar wins over any polygon; removing it lets the polygon drive `chart_datum`).

### Verification
- Both YAMLs parse; `core_launch.py` compiles.
- **Today's GPS track (lat 42.983–42.996, lon −71.393 to −71.385) is inside the ring** (lat 42.947–43.018, lon −71.403 to −71.336) with ~0.8–2.4 km margin → the override gate won't drop `chart_datum`.

### Trade-off (accepted, option A)
With the scalar gone, `chart_datum` publishes only when the boat is inside the (padded) ring — fine on the lake; would drop during transport/wild-fix.

### Follow-on
- **Sim-verify** in the Massabesic sim before live use (per #278): confirm `chart_datum` resolves from the polygon at 48.88 m and `map_tide` still publishes.
- Toward rolker/unh_marine_autonomy#163 (canonical shared DatumEntry); UMA #170 tracks the dependent value updates.

Closes #285

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
