### PR TITLE
Enable cross-track gain schedule on BizzyBoat (gain_ref_speed 1.8)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -217,9 +217,10 @@ controller_server:
       # ±23). p=-13 restores margin: bounded ~±0.25 m, output ~±5, stable across
       # 3.0-3.75 kt (boat saturates ~3.85 kt). d -0.6→-1.2 kept (operator
       # preference; minor effect — the weave was over-gain, not under-damped).
-      # Proper fix is speed-normalised gains (gain scheduling) — see deployment
-      # log 2026-06-16 + wrap-up. Live-set during the session; banked here so it
-      # survives a nav relaunch. Other pid.* keys match the base.
+      # Proper fix is speed-normalised gains (gain scheduling) — now enabled
+      # below via gain_ref_speed (rolker/unh_marine_navigation#76, echoboats#292).
+      # Live-set during the session; banked here so it survives a nav relaunch.
+      # Other pid.* keys match the base.
       pid:
         p: -13.0
         i: -0.5
@@ -229,3 +230,17 @@ controller_server:
         u_clamp_max: 90.0
         u_clamp_min: -90.0
         activate_state_publisher: true
+        # Speed-normalise the cross-track gain (1/v law, rolker/unh_marine_navigation#76):
+        # the outer cross-track loop gain is ∝ v·p, so a flat p loses margin as
+        # speed rises (the -20→-13 field tune above only re-anchored at 3.5 kt).
+        # crab_angle is scaled by gain_ref_speed / max(target_speed, gain_v_min)
+        # right after the PID, holding the cross-track response ~constant across
+        # speed. REQUIRES the #76 build of marine_nav_crabbing_path_follower on
+        # gabby (core_ws) — older binaries don't declare these keys and ignore
+        # them (inert, harmless). NOT pre-tested: anchor 1.8 m/s = 3.5 kt, where
+        # p=-13 is field-validated, so this is a NO-OP at 3.5 kt and only adjusts
+        # off-anchor (3.0 kt → eff -15.2, 4.0 kt → eff -11.4). Tune live + record
+        # final anchor (echoboats#292). Live-tunable / instant revert hatch:
+        # `ros2 param set /bizzy/controller_server FollowPath.pid.gain_ref_speed 0.0`
+        gain_ref_speed: 1.8   # 3.5 kt anchor; 0.0 = disabled (flat-gain behaviour)
+        gain_v_min: 0.5       # divisor floor; no blow-up at creep / station-keep


### PR DESCRIPTION
## Summary
Enable the speed-normalized cross-track gain schedule on BizzyBoat by adding two keys to the inner-crabbing `FollowPath.pid` block of `bizzyboat_project11/config/nav2_overlay.yaml`:

```yaml
gain_ref_speed: 1.8   # 3.5 kt anchor; 0.0 = disabled (flat-gain behaviour)
gain_v_min: 0.5       # divisor floor; no blow-up at creep / station-keep
```

Realizes the "proper fix" already flagged in the overlay's 2026-06-16 field-tune comment. The mechanism merged default-off in [marine_nav#76](https://github.com/rolker/unh_marine_navigation/issues/76) (PR #78); this is BizzyBoat's opt-in.

## Why this is safe to enable without a prior test
`gain_ref_speed: 1.8` m/s **is** 3.5 kt — the scale factor is `1.8 / max(v, 0.5)`, so at 3.5 kt it is exactly **1.0** → effective gain = `p × 1.0 = −13`, identical to today's field-validated behaviour. The schedule only reshapes **off-anchor** response (3.0 kt → eff −15.2, 4.0 kt → eff −11.4). It cannot degrade the validated operating point; the next deployment tunes the anchor live. Instant revert: `ros2 param set /bizzy/controller_server FollowPath.pid.gain_ref_speed 0.0`.

## ⚠️ Deployment prerequisite (acceptance)
The YAML keys are **inert until gabby runs the #76 build** of `marine_nav_crabbing_path_follower` (core_ws). An older binary silently ignores the unknown overrides — no error — and the boat tracks on flat `p=−13` as before. Before relying on the schedule:
- [ ] gabby: `git pull` core_ws (#76 is on gitcloud) + rebuild `marine_nav_crabbing_path_follower`.
- [ ] After nav launch, verify the binary is live: `ros2 param get /bizzy/controller_server FollowPath.pid.gain_ref_speed` → `1.8`.
- [ ] Speed sweep (3.0 / 3.5 / 3.75+ kt): cross-track RMS ~constant, no limit cycle.
- [ ] Record final anchor here; fold back into the overlay if it moved from 1.8.

## Verification (local)
- YAML parses; keys resolve to `FollowPath.pid.gain_ref_speed = 1.8` / `gain_v_min = 0.5`.
- Namespacing matches the controller: it declares `base + ".pid.gain_ref_speed"` / `".pid.gain_v_min"` (base = `FollowPath`), so the nested overlay keys reach the inner CrabbingPathFollower (same path the field-validated `pid.p` uses).
- `u_clamp` interaction reviewed and accepted as-is (clamp bounds pre-scale crab; downstream cos-floor + yaw-rate clamp bound the helm).

Closes #292. Follow-on to [marine_nav#76](https://github.com/rolker/unh_marine_navigation/issues/76); field context rolker/unh_echoboats_project11#289.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
