### PR TITLE
udp_bridge: redundant cell connection for safety-critical topics (#145)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -66,6 +66,7 @@
         connections_list:
           - wifi
           - vpn
+          - cell
         connections:
           wifi:
             maximum_bytes_per_second: 1500000
@@ -310,6 +311,44 @@
               watercolumn_down: {source: sensors/sidescan/garmin_sidescan/sonar_image_down, queue_size: 25}
               sidescan_nadir_depth: {source: sensors/sidescan/garmin_sidescan/nadir_depth, period: 1.0}
               sidescan_water_temperature: {source: sensors/sidescan/garmin_sidescan/water_temperature}
+
+          # Redundant cell-VPN downlink (#145): a thin always-on awareness channel
+          # carried concurrently over the cell tunnel. Curated to the safety-
+          # critical minimum — deliberately NO video / costmap / sidescan /
+          # pointclouds. The CAMP boat-monitoring topics (orientation / position /
+          # velocity) match platform_sender's nav sources above, so CAMP can track
+          # the boat over cell alone. tf left unthrottled per request; the byte cap
+          # is provisional — raise if tf saturates it, tune down on-water.
+          cell:
+            maximum_bytes_per_second: 300000
+            topics_list:
+            - heartbeat
+            - heartbeat_nav
+            - command_response
+            - battery
+            - collision_monitor_state
+            - platforms
+            - mavros_orientation
+            - mavros_position_ekf
+            - mavros_velocity_body
+            - mavros_gps_status
+            - tf
+            - tf_static
+            - local_costmap_footprint
+            topics:
+              heartbeat: {source: marine/heartbeat}
+              heartbeat_nav: {source: marine/status/mission_manager}
+              command_response: {source: marine/response}
+              battery: {source: /bizzy/mavros/battery}
+              collision_monitor_state: {source: collision_monitor_state}
+              platforms: {source: /marine/platforms}
+              mavros_orientation: {source: mavros/imu/data}
+              mavros_position_ekf: {source: mavros/global_position/global}
+              mavros_velocity_body: {source: mavros/local_position/velocity_body}
+              mavros_gps_status: {source: mavros/gpsstatus/gps1/raw}
+              tf: {source: /tf, queue_size: 25}
+              tf_static: {source: /tf_static}
+              local_costmap_footprint: {source: local_costmap/published_footprint}
 
 /**/logger:
   ros__parameters:

--- a/bizzyboat_project11/config/operator.yaml
+++ b/bizzyboat_project11/config/operator.yaml
@@ -9,6 +9,7 @@
         connections_list:
           - wifi
           - vpn
+          - cell
         connections:
           wifi:
             host: gabby.bizzy.p11.lan
@@ -26,6 +27,21 @@
             host: gabby.vpn.bizzy.p11.lan
             port: 4200
             return_host: salmon.vpn.bizzy.p11.lan
+            return_port: 4200
+            topics_list:
+            - command
+            - joystick_helm
+            topics:
+              command: {source: /bizzy/marine/command}
+              joystick_helm: {source: /bizzy/piloting_mode/manual/helm}
+
+          # Redundant cell-VPN path (#145): same safety-critical uplink as
+          # wifi/vpn, carried concurrently over the cell tunnel. Names resolve to
+          # the cell NETMAP ranges (gabby.cell -> .23.5, salmon.cell -> .24.142).
+          cell:
+            host: gabby.cell.bizzy.p11.lan
+            port: 4200
+            return_host: salmon.cell.bizzy.p11.lan
             return_port: 4200
             topics_list:
             - command


### PR DESCRIPTION
## Summary

Add a third `cell` udp_bridge connection on both ends, carrying a thin
always-on copy of safety-critical traffic over the new cell-VPN tunnel,
concurrent with wifi + Starlink VPN. Completes the application-layer piece of #145.

## Changes

- **`operator.yaml`** (uplink, operator→boat): `cell` connection mirrors wifi/vpn —
  `command` + `joystick_helm` — to `gabby.cell` / `salmon.cell` (the cell NETMAP names).
- **`bizzyboat.yaml`** (downlink, boat→operator): curated `cell` connection,
  `maximum_bytes_per_second: 300000` (provisional). Topics:
  - status: `heartbeat`, `heartbeat_nav`, `command_response`, `battery`, `collision_monitor_state`, `platforms`
  - CAMP boat-monitoring (match `platform_sender` nav sources): `mavros_orientation`, `mavros_position_ekf`, `mavros_velocity_body`
  - `mavros_gps_status`, `tf`, `tf_static`, `local_costmap_footprint`
  - **deliberately excluded**: video / costmap window / sidescan / collision pointcloud+polygons / diagnostics.

`tf` left unthrottled per request — it's the bandwidth watch-item, so the 300 KB/s cap is provisional (raise if it saturates; tune down once measured on-water).

## Context / status

Network + DNS for the cell path are already live and verified (gabby↔salmon over cell). DNS records are in CCOMJHC/ccomjhc_project11#74. After merge, this needs deploying to gabby + salmon with a udp_bridge restart (briefly drops all bridge links). Operator annunciator "UDP Cell" row + `ping_targets` cell entries are a small follow-up.

Part of #145.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
