### PR TITLE
feat(bizzyboat): sidescan grazing tilt on _port/_starboard (#303, #185 Stage 2)

### DIFF
--- a/.agent/work-plans/issue-303/plan.md
+++ b/.agent/work-plans/issue-303/plan.md
@@ -8,9 +8,21 @@ https://github.com/rolker/unh_echoboats_project11/issues/303
 
 `bizzyboat_project11/urdf/sensors/sidescan.xacro` mounts `_port`/`_starboard`
 as pure ±90° rotations about X (boresight horizontal, abeam). A placeholder
-comment notes this is uncalibrated. Real side-scan fires 20–30° below
-horizontal; for the SideVü 55° fan the boresight center should sit at
-90° − fan/2 = 62.5° depression below horizontal (27.5° off nadir).
+comment notes this is uncalibrated. Side-scan boresights should fire below
+horizontal by a grazing (depression) angle; this plan makes that angle an
+explicit `grazing_deg` macro param.
+
+**Default `grazing_deg = 62.5` = 90 − SideVü_fan/2 = 90 − 27.5** (half the
+55° SideVü fan off nadir). This places the **inner edge of the SideVü fan at
+nadir**, so the port/starboard fan tiles cleanly against the `_down` (ClearVü)
+beam with no nadir gap or overlap. The fan half-width is now published by the
+driver per marine_tools#62, so this default can be refined post-calibration.
+
+The classic "side-imaging" aim of ~20–30° below horizontal (for longer far
+across-track range) is available as an **alternative**: set `grazing_deg` to
+that value after field calibration. It trades the clean nadir tiling for a
+nadir gap, so it is not the default — the default keeps the nadir seam clean
+out of the box.
 
 `_down` (ClearVü) is correct and unchanged.
 
@@ -30,9 +42,10 @@ Result:
 - stbd +Z direction in parent: `[0, −cos(grazing_deg), −sin(grazing_deg)]` ✓
 - both +X directions in parent: `[1, 0, 0]` (forward, unchanged) ✓
 
-Default: `grazing_deg = 62.5` (derived from 90 − 55/2 for the SideVü 55° fan;
-the fan value is now published by the driver per marine_tools#62 and can be
-used to refine this parameter post-calibration).
+Default: `grazing_deg = 62.5` (= 90 − 55/2 for the SideVü 55° fan, half-fan
+off nadir — inner fan edge at nadir, tiling against `_down`; see Context). The
+fan value is now published by the driver per marine_tools#62 and can be used to
+refine this parameter post-calibration.
 
 ## Approach
 
@@ -52,13 +65,17 @@ used to refine this parameter post-calibration).
    re-calibrate (`grazing_deg` param).
 
 5. **Document a manual TF check** — no xacro unit-test harness exists in
-   `bizzyboat_project11`. Add a comment block (or a minimal `check_sidescan.py`
-   script in `bizzyboat_project11/scripts/`) describing how to verify:
+   `bizzyboat_project11`. Add a comment block in the xacro describing how to
+   verify against the real frames the macro produces. The macro is called as
+   `name="garmin_sidescan" parent="bizzy/base_link"` (bizzyboat.urdf.xacro:268),
+   so the port link is `bizzy/garmin_sidescan_port` (matching the deployed
+   driver frame from `launch/sidescan_launch.py`):
    ```
-   ros2 run xacro xacro sidescan.xacro name:=sidescan parent:=base_link \
-     | robot_state_publisher --ros-args -p robot_description:="$(cat)"
-   ros2 run tf2_ros tf2_echo base_link bizzy/sidescan_port
-   # Expected: Z axis ~[0, 0.462, −0.887] in base_link frame (62.5° depression)
+   ros2 run xacro xacro bizzyboat.urdf.xacro > /tmp/bizzy.urdf
+   ros2 run robot_state_publisher robot_state_publisher /tmp/bizzy.urdf &
+   ros2 run tf2_ros tf2_echo bizzy/base_link bizzy/garmin_sidescan_port
+   # Expected: child +Z ~[0, 0.462, −0.887] in bizzy/base_link (62.5° depression);
+   #           +X stays [1, 0, 0] (forward)
    ```
 
 ## Files to Change
@@ -93,7 +110,7 @@ used to refine this parameter post-calibration).
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| `_port`/`_starboard` boresight direction | `marine_sidescan_mosaic` heading extraction (unh_marine_autonomy#200) | Mitigated — `+X` stays forward; no API change needed |
+| `_port`/`_starboard` boresight direction | `marine_sidescan_mosaic` heading extraction (unh_marine_autonomy#200) | No update needed — #200 reads the +Z boresight via `ecefPoseToGeoBeam` and `+X` stays forward, so it consumes the tilted boresight directly (see resolved Open Question) |
 | `grazing_deg` default | Field calibration notes / deployment docs | No — follow-up when measured |
 | `garmin_sidescan` macro params | Any `.xacro` files that call the macro (need to verify no callers pass positional args beyond `x y z`) | Verify callers — `grazing_deg` has a default, so no breakage expected |
 
@@ -102,8 +119,12 @@ used to refine this parameter post-calibration).
 - [x] Verify call sites of `garmin_sidescan` — `bizzyboat.urdf.xacro` is the
   only caller and uses keyword args (`parent`, `name`, `x`, `y`, `z`); the
   new defaulted `grazing_deg` param is safe.
-- [ ] Confirm marine_sidescan_mosaic (#200) truly depends only on `+X`
-  forward (not on `+Z` being horizontal) before merging.
+- [x] Confirm marine_sidescan_mosaic (#200) truly depends only on `+X`
+  forward (not on `+Z` being horizontal). **Resolved:** #200 (Stage 2
+  projection) reads the sensor **+Z** boresight via `ecefPoseToGeoBeam`
+  (azimuth + depression), and the about-X roll here **preserves +X forward**.
+  The tilt is therefore exactly the boresight #200 consumes — no breakage; the
+  tilt is a feature #200 already accounts for, not an unexpected change.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-303/plan.md
+++ b/.agent/work-plans/issue-303/plan.md
@@ -1,0 +1,110 @@
+# Plan: Bizzyboat sidescan URDF grazing tilt — SideVü #185 Stage 2
+
+## Issue
+
+https://github.com/rolker/unh_echoboats_project11/issues/303
+
+## Context
+
+`bizzyboat_project11/urdf/sensors/sidescan.xacro` mounts `_port`/`_starboard`
+as pure ±90° rotations about X (boresight horizontal, abeam). A placeholder
+comment notes this is uncalibrated. Real side-scan fires 20–30° below
+horizontal; for the SideVü 55° fan the boresight center should sit at
+90° − fan/2 = 62.5° depression below horizontal (27.5° off nadir).
+
+`_down` (ClearVü) is correct and unchanged.
+
+**Coordinate convention** (from the file header):
+- Per-channel range/boresight axis = frame's local +Z
+- Mount frame: +X forward, +Y port, +Z up — same as base_link
+- `_port` currently: rpy `${-pi/2} 0 0` → child +Z → +Y_parent (port, horizontal)
+- `_starboard` currently: rpy `${pi/2} 0 0` → child +Z → −Y_parent (starboard, horizontal)
+
+**Rotation math** — to tilt boresight DOWN by `grazing_deg` while keeping
+`+X` forward (required by marine_sidescan_mosaic heading extraction, #200):
+- Roll about mount-frame X by `−(π/2 + grazing_rad)` for port
+- Roll about mount-frame X by `+(π/2 + grazing_rad)` for starboard
+
+Result:
+- port +Z direction in parent: `[0, cos(grazing_deg), −sin(grazing_deg)]` ✓
+- stbd +Z direction in parent: `[0, −cos(grazing_deg), −sin(grazing_deg)]` ✓
+- both +X directions in parent: `[1, 0, 0]` (forward, unchanged) ✓
+
+Default: `grazing_deg = 62.5` (derived from 90 − 55/2 for the SideVü 55° fan;
+the fan value is now published by the driver per marine_tools#62 and can be
+used to refine this parameter post-calibration).
+
+## Approach
+
+1. **Add `grazing_deg` macro param** — append `grazing_deg:=62.5` to the
+   `garmin_sidescan` param list; add a comment that the default is
+   `90 − SideVü_fan/2 = 90 − 27.5 = 62.5°` and references marine_tools#62.
+
+2. **Update `_port` joint rpy** — change `${-pi/2} 0 0` to
+   `${-pi/2 - grazing_deg * pi / 180} 0 0`. Update the inline comment to
+   describe the resulting frame orientation with tilt.
+
+3. **Update `_starboard` joint rpy** — change `${pi/2} 0 0` to
+   `${pi/2 + grazing_deg * pi / 180} 0 0`. Update comment symmetrically.
+
+4. **Update the file header** — remove the PLACEHOLDER notice; replace with a
+   concise description of the grazing angle, its derivation, and how to
+   re-calibrate (`grazing_deg` param).
+
+5. **Document a manual TF check** — no xacro unit-test harness exists in
+   `bizzyboat_project11`. Add a comment block (or a minimal `check_sidescan.py`
+   script in `bizzyboat_project11/scripts/`) describing how to verify:
+   ```
+   ros2 run xacro xacro sidescan.xacro name:=sidescan parent:=base_link \
+     | robot_state_publisher --ros-args -p robot_description:="$(cat)"
+   ros2 run tf2_ros tf2_echo base_link bizzy/sidescan_port
+   # Expected: Z axis ~[0, 0.462, −0.887] in base_link frame (62.5° depression)
+   ```
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `bizzyboat_project11/urdf/sensors/sidescan.xacro` | Add `grazing_deg` param; update `_port`/`_starboard` rpy; update comments |
+
+**Optional** (include if the check proves useful during review):
+
+| File | Change |
+|------|--------|
+| `bizzyboat_project11/scripts/check_sidescan_tilt.py` | 10-line Python snippet: parse xacro output with `xacro` module, assert boresight Z-axis depression matches `grazing_deg` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | `grazing_deg` is an explicit param; default is derived and documented; easy to override for field calibration |
+| Capture decisions, not just implementations | Default derivation (90 − fan/2) and source (marine_tools#62) documented in the file header |
+| A change includes its consequences | `_down` joint unchanged; `+X` forward preserved — no downstream breakage for marine_sidescan_mosaic (#200) |
+| Only what's needed | One file changed; `_down` untouched; no new abstractions |
+| Test what breaks | Manual TF check documented; optional assertion script if harness is feasible |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 — Follow ROS 2 conventions | Yes (URDF/xacro change) | xacro param syntax follows existing macro style; no new conventions introduced |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `_port`/`_starboard` boresight direction | `marine_sidescan_mosaic` heading extraction (unh_marine_autonomy#200) | Mitigated — `+X` stays forward; no API change needed |
+| `grazing_deg` default | Field calibration notes / deployment docs | No — follow-up when measured |
+| `garmin_sidescan` macro params | Any `.xacro` files that call the macro (need to verify no callers pass positional args beyond `x y z`) | Verify callers — `grazing_deg` has a default, so no breakage expected |
+
+## Open Questions
+
+- [x] Verify call sites of `garmin_sidescan` — `bizzyboat.urdf.xacro` is the
+  only caller and uses keyword args (`parent`, `name`, `x`, `y`, `z`); the
+  new defaulted `grazing_deg` param is safe.
+- [ ] Confirm marine_sidescan_mosaic (#200) truly depends only on `+X`
+  forward (not on `+Z` being horizontal) before merging.
+
+## Estimated Scope
+
+Single PR, 1 file changed (~10 lines).

--- a/.agent/work-plans/issue-303/progress.md
+++ b/.agent/work-plans/issue-303/progress.md
@@ -85,3 +85,23 @@ manual field check (matches the rendered values above).
 
 ### Next step
 Code review of `feature/issue-303` (commit `7ed439e`), then PR.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 13:16 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-303 at `164d625`
+**Mode**: pre-push
+**Depth**: Standard (reason: project-repo plan.md present in diff = override trigger; raw 252-line total inflated by 218 lines of plan/progress process docs — code surface is one xacro file, +34 −10)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 1 | **Ship**: recommended — no must-fix; math verified independently and by render, +X-forward preserved so #200 unaffected.
+
+### Findings
+- [ ] No issues found. LGTM.
+
+### Notes
+- Rotation math verified independently and by rendering the macro under Jazzy xacro: port rpy `-2.661627` = `-(pi/2 + 62.5deg)`, starboard `+2.661627`, `_down` `pi` unchanged; port +Z `[0,0.462,-0.887]`, +X `[1,0,0]`.
+- Adversarial Lens A "must-fix" (comment "inner edge at nadir" allegedly inconsistent) evaluated and **rejected as a false positive**: in sidescan terms the inner edge is the near-nadir one; boresight 62.5deg + half-fan 27.5deg = 90deg (nadir) inner edge — comment is correct.
+- Sole macro caller `bizzyboat.urdf.xacro:268` uses keyword args, no `grazing_deg` override → backward compatible.

--- a/.agent/work-plans/issue-303/progress.md
+++ b/.agent/work-plans/issue-303/progress.md
@@ -36,3 +36,52 @@ authored by Sonnet, reviewed by Opus) — no self-review annotation despite shar
 - [ ] (must-fix) Reconcile contradictory default derivation before writing header — Context says sidescan fires "20–30° below horizontal" but sets default to 62.5° via `90 − fan/2`; `fan/2`=27.5° is the horizontal-aligned reading. Differ by 35°. — `plan.md:11`
 - [ ] (suggestion) Open question on #200 depending only on `+X` (not `+Z` horizontal) still unchecked; confirm before merge — `plan.md:105`
 - [ ] (suggestion) Documented TF check uses `name:=sidescan`; deployed frame is `bizzy/garmin_sidescan_port` — use real frame name — `plan.md:57`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-21 07:10 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-303/plan.md` (followed, with the 3 review must-fixes folded in)
+**Branch**: feature/issue-303 at `7ed439e`
+**Phases**: single
+
+### What changed
+- `bizzyboat_project11/urdf/sensors/sidescan.xacro`:
+  - Added `grazing_deg:=62.5` param to the `garmin_sidescan` macro.
+  - `_port` rpy `${-pi/2} 0 0` → `${-pi/2 - grazing_deg * pi / 180} 0 0`.
+  - `_starboard` rpy `${pi/2} 0 0` → `${pi/2 + grazing_deg * pi / 180} 0 0`.
+  - `_down` unchanged; +X forward preserved on both side channels.
+  - Removed the PLACEHOLDER header; documented the 62.5° rationale (90 − fan/2,
+    half-fan off nadir → inner fan edge at nadir, clean tiling vs `_down`), the
+    ~20–30° side-imaging alternative, and a manual `tf2_echo` check.
+- `.agent/work-plans/issue-303/plan.md`: synced to match (self-consistent 62.5
+  rationale, real-frame TF check, resolved #200 open question).
+
+### Verification
+No xacro unit-test harness exists; verified by rendering the macro under ROS 2
+Jazzy xacro:
+- `_to_garmin_sidescan_port` rpy = `-2.661627…` = `-(π/2 + 62.5°)` ✓
+- `_to_garmin_sidescan_starboard` rpy = `+2.661627…` ✓
+- `_to_garmin_sidescan_down` rpy = `π 0 0` (unchanged) ✓
+- port child +Z in `bizzy/base_link` = `[0, 0.462, -0.887]` (62.5° depression) ✓
+- port child +X = `[1, 0, 0]` (forward) ✓
+The documented `tf2_echo bizzy/base_link bizzy/garmin_sidescan_port` is the
+manual field check (matches the rendered values above).
+
+### Review must-fixes folded in
+1. Reconciled the contradictory rationale — header + plan now state 62.5° as
+   half-fan-off-nadir (inner fan edge at nadir); 20–30° is named only as an
+   alternative, never as the default's justification.
+2. TF check now uses the real frame names produced by the macro
+   (`bizzy/base_link` → `bizzy/garmin_sidescan_port`), not the placeholder
+   `name:=sidescan` / `bizzy/sidescan_port`.
+3. #200 open question resolved: #200 reads the +Z boresight via
+   `ecefPoseToGeoBeam` and +X stays forward, so it consumes the tilted
+   boresight directly — no breakage.
+
+### Open questions
+- None remaining (both prior questions resolved).
+
+### Next step
+Code review of `feature/issue-303` (commit `7ed439e`), then PR.

--- a/.agent/work-plans/issue-303/progress.md
+++ b/.agent/work-plans/issue-303/progress.md
@@ -16,3 +16,23 @@ issue: 303
 ### Open questions
 - [x] Verify call sites of `garmin_sidescan` — only `bizzyboat.urdf.xacro`, uses keyword args; safe.
 - [ ] Confirm marine_sidescan_mosaic (#200) depends only on `+X` forward (not `+Z` horizontal) before merging.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 06:20 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-303/plan.md` at `af04e2e`
+**PR**: PR-less (`--issue` mode; `gh` unauthenticated — issue context read from plan's captured Context)
+**Verdict**: approve-with-suggestions
+
+Mechanism verified independently: port rpy `${-pi/2 - g}` → child `+Z=[0,cos g,−sin g]`, `+X=[1,0,0]`;
+for `g=62.5°` → `[0,0.462,−0.887]` (matches plan's TF check; +X-forward preserved, so #200 heading
+extraction is safe). Single caller (`bizzyboat.urdf.xacro:268`, keyword args) confirms the defaulted
+param is non-breaking. Scope/file-targeting/ADR-0008/REP-103 all good. Independent review (plan
+authored by Sonnet, reviewed by Opus) — no self-review annotation despite shared agent name.
+
+### Findings
+- [ ] (must-fix) Reconcile contradictory default derivation before writing header — Context says sidescan fires "20–30° below horizontal" but sets default to 62.5° via `90 − fan/2`; `fan/2`=27.5° is the horizontal-aligned reading. Differ by 35°. — `plan.md:11`
+- [ ] (suggestion) Open question on #200 depending only on `+X` (not `+Z` horizontal) still unchecked; confirm before merge — `plan.md:105`
+- [ ] (suggestion) Documented TF check uses `name:=sidescan`; deployed frame is `bizzy/garmin_sidescan_port` — use real frame name — `plan.md:57`

--- a/.agent/work-plans/issue-303/progress.md
+++ b/.agent/work-plans/issue-303/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 303
+---
+
+# Issue #303 — Bizzyboat sidescan URDF grazing tilt (#185 Stage 2)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-303/plan.md` at `af04e2e`
+**Branch**: feature/issue-303 at `af04e2e`
+**Phases**: single
+
+### Open questions
+- [x] Verify call sites of `garmin_sidescan` — only `bizzyboat.urdf.xacro`, uses keyword args; safe.
+- [ ] Confirm marine_sidescan_mosaic (#200) depends only on `+X` forward (not `+Z` horizontal) before merging.

--- a/bizzyboat_project11/urdf/sensors/sidescan.xacro
+++ b/bizzyboat_project11/urdf/sensors/sidescan.xacro
@@ -11,13 +11,25 @@
        Per-channel range axis is the frame's local +Z (rviz_sonar_image places a
        fixed beam's samples along +Z when rx/tx steering = 0):
          _down       +Z points down   (matches the M3/DeltaT transducer convention)
-         _port       +Z points to port (+Y)
-         _starboard  +Z points to starboard (-Y)
+         _port       +Z tilted down by grazing_deg toward port    (+X stays forward)
+         _starboard  +Z tilted down by grazing_deg toward starboard (+X stays forward)
 
-       PLACEHOLDER: side-scan grazing tilt is 0 (port/starboard beams horizontal).
-       Real side-scan fires a few tens of degrees below horizontal — refine the
-       _port/_starboard pitch once the install is measured/calibrated. -->
-  <xacro:macro name="garmin_sidescan" params="parent name x:=0 y:=0 z:=0">
+       Grazing tilt: the _port/_starboard boresights are rolled about the mount
+       X axis so they fire grazing_deg below horizontal (a depression angle),
+       while +X stays forward — marine_sidescan_mosaic (#200) extracts heading
+       from +Z via ecefPoseToGeoBeam and consumes exactly this tilted boresight.
+
+       Default grazing_deg = 62.5 = 90 - SideVu_fan/2 = 90 - 27.5 (half the
+       55-deg SideVu fan off nadir). This places the INNER edge of the fan at
+       nadir, tiling cleanly against the _down (ClearVu) beam with no nadir gap
+       or overlap. The fan half-width (55 deg) is published by the driver per
+       marine_tools#62, so this default can be refined after calibration.
+
+       Alternative: classic side-imaging aims the boresight ~20-30 deg below
+       horizontal for longer far across-track range; set grazing_deg to that
+       after field calibration if desired (it trades the clean nadir tiling for
+       a nadir gap). The default keeps the nadir seam clean out of the box. -->
+  <xacro:macro name="garmin_sidescan" params="parent name x:=0 y:=0 z:=0 grazing_deg:=62.5">
 
     <!-- Mount frame, aligned with base_link (X fwd, Y port, Z up). -->
     <link name="bizzy/${name}"/>
@@ -36,21 +48,33 @@
       <origin xyz="0 0 0" rpy="${pi} 0 0"/>
     </joint>
 
-    <!-- Port side-scan beam: +Z to port (+Y). -->
+    <!-- Port side-scan beam: +Z tilted grazing_deg below horizontal toward port.
+         Roll about mount X by -(pi/2 + grazing_rad); +Z -> [0, cos g, -sin g]
+         in the mount frame (port and down), +X stays forward. -->
     <link name="bizzy/${name}_port"/>
     <joint name="${name}_to_${name}_port" type="fixed">
       <parent link="bizzy/${name}"/>
       <child link="bizzy/${name}_port"/>
-      <origin xyz="0 0 0" rpy="${-pi/2} 0 0"/>
+      <origin xyz="0 0 0" rpy="${-pi/2 - grazing_deg * pi / 180} 0 0"/>
     </joint>
 
-    <!-- Starboard side-scan beam: +Z to starboard (-Y). -->
+    <!-- Starboard side-scan beam: +Z tilted grazing_deg below horizontal toward
+         starboard. Roll about mount X by +(pi/2 + grazing_rad); +Z ->
+         [0, -cos g, -sin g] in the mount frame (stbd and down), +X stays forward. -->
     <link name="bizzy/${name}_starboard"/>
     <joint name="${name}_to_${name}_starboard" type="fixed">
       <parent link="bizzy/${name}"/>
       <child link="bizzy/${name}_starboard"/>
-      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+      <origin xyz="0 0 0" rpy="${pi/2 + grazing_deg * pi / 180} 0 0"/>
     </joint>
+
+    <!-- Manual TF check (no xacro unit-test harness in this package): render the
+         full robot and echo the port boresight against the mount parent.
+           ros2 run xacro xacro bizzyboat.urdf.xacro > /tmp/bizzy.urdf
+           ros2 run robot_state_publisher robot_state_publisher /tmp/bizzy.urdf &
+           ros2 run tf2_ros tf2_echo bizzy/base_link bizzy/garmin_sidescan_port
+         Expected rotation maps child +Z to ~[0, 0.462, -0.887] in bizzy/base_link
+         (62.5 deg depression toward port); +X stays [1, 0, 0] (forward). -->
 
   </xacro:macro>
 </robot>


### PR DESCRIPTION
## Summary

Add the **grazing tilt** to the bizzyboat SideVü side-scan staves (#185 Stage 2, the URDF half).

`sidescan.xacro` previously mounted `_port`/`_starboard` as pure ±90° rotations (boresight horizontal, abeam) with a PLACEHOLDER comment. This tilts each side beam's **+Z** down by a `grazing_deg` macro param while keeping **+X forward**, so the projection (unh_marine_autonomy#200) reads the correct depression.

## Changes

- **`sidescan.xacro`**: new `grazing_deg:=62.5` macro param; `_port` rpy `${-pi/2} 0 0` → `${-pi/2 - grazing_deg*pi/180} 0 0`, `_starboard` symmetric; `_down` (ClearVü) unchanged. Header rewritten (PLACEHOLDER removed) documenting the derivation + a manual `tf2_echo` check.

## Default rationale

`grazing_deg = 62.5 = 90 − SideVü_fan/2 = 90 − 27.5` (**half-fan off nadir**): places the inner edge of the 55° SideVü fan at nadir, tiling cleanly against the `_down` ClearVü beam. The ~20–30°-below-horizontal "typical side-imaging" aim (longer far range, nadir gap) is documented as an alternative the param can be set to post-calibration. Operator-confirmed 2026-06-21.

## Verification

No xacro unit-test harness exists; verified by rendering under Jazzy xacro:
port rpy `−2.661627` = `−(π/2 + 62.5°)`, starboard `+2.661627`, `_down` `π` unchanged; port child **+Z = [0, 0.462, −0.887]** (62.5° depression), **+X = [1, 0, 0]** (forward). Sole caller `bizzyboat.urdf.xacro` uses keyword args → backward compatible.

Reviewed locally (dual-lens adversarial, pre-push) — approved, zero findings.

Closes #303

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
