### PR TITLE
fix(bizzyboat): sidescan grazing_deg default 62.5° → 35° (field-measured, #305)

### DIFF
--- a/.agent/work-plans/issue-305/progress.md
+++ b/.agent/work-plans/issue-305/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 305
+---
+
+# Issue #305 — sidescan grazing_deg default 62.5° → 35° (field-measured)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 16:51 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-305 at `aa202a2`
+**Mode**: pre-push
+**Depth**: Light (reason: single-file xacro default + rationale-comment change, 27 lines, non-security, non-cross-layer)
+**Must-fix**: 1 | **Suggestions**: 0
+**Round**: 1 | **Ship**: continue — one mechanical comment-only must-fix remains; otherwise shippable
+
+### Findings
+- [ ] (must-fix) Stale "Manual TF check" expected value: still cites old default `[0, 0.462, -0.887]` / "62.5 deg depression"; with new 35° default the check yields `[0, 0.819, -0.574]` / 35°. Cross-confirmed (lead + adversarial Lens A). — `bizzyboat_project11/urdf/sensors/sidescan.xacro:83`

--- a/bizzyboat_project11/urdf/sensors/sidescan.xacro
+++ b/bizzyboat_project11/urdf/sensors/sidescan.xacro
@@ -80,8 +80,8 @@
            ros2 run xacro xacro bizzyboat.urdf.xacro > /tmp/bizzy.urdf
            ros2 run robot_state_publisher robot_state_publisher /tmp/bizzy.urdf &
            ros2 run tf2_ros tf2_echo bizzy/base_link bizzy/garmin_sidescan_port
-         Expected rotation maps child +Z to ~[0, 0.462, -0.887] in bizzy/base_link
-         (62.5 deg depression toward port); +X stays [1, 0, 0] (forward). -->
+         Expected rotation maps child +Z to ~[0, 0.819, -0.574] in bizzy/base_link
+         (35 deg depression toward port); +X stays [1, 0, 0] (forward). -->
 
   </xacro:macro>
 </robot>

--- a/bizzyboat_project11/urdf/sensors/sidescan.xacro
+++ b/bizzyboat_project11/urdf/sensors/sidescan.xacro
@@ -19,17 +19,24 @@
        while +X stays forward — marine_sidescan_mosaic (#200) extracts heading
        from +Z via ecefPoseToGeoBeam and consumes exactly this tilted boresight.
 
-       Default grazing_deg = 62.5 = 90 - SideVu_fan/2 = 90 - 27.5 (half the
-       55-deg SideVu fan off nadir). This places the INNER edge of the fan at
-       nadir, tiling cleanly against the _down (ClearVu) beam with no nadir gap
-       or overlap. The fan half-width (55 deg) is published by the driver per
-       marine_tools#62, so this default can be refined after calibration.
+       Default grazing_deg = 35 (boresight depression below horizontal),
+       MEASURED from field sonar bags (Massabesic + bizzy runs, 2026-06-21):
+       the bottom-return angular profile I(phi) = asin(nadir_depth / slant_range)
+       peaks near 38 deg, and the near-nadir backscatter steep-bias puts the true
+       boresight a few degrees shallower (~35). A roll-day regression (per-ping
+       steep-edge vs vessel roll, opposite-sign +/-1 slopes per channel)
+       validated the geometry. This matches the recreational side-imaging norm
+       of ~20-40 deg, nominal ~30 (Garmin/Humminbird/Navico patents:
+       US7652952B2, US11137495B2); survey towfish run ~10.
 
-       Alternative: classic side-imaging aims the boresight ~20-30 deg below
-       horizontal for longer far across-track range; set grazing_deg to that
-       after field calibration if desired (it trades the clean nadir tiling for
-       a nadir gap). The default keeps the nadir seam clean out of the box. -->
-  <xacro:macro name="garmin_sidescan" params="parent name x:=0 y:=0 z:=0 grazing_deg:=62.5">
+       This is NOT the 90 - fan/2 = 62.5 "half-fan off nadir" that once shipped
+       (#303) — that was a tiling heuristic, ~27 deg too steep, and not how a
+       side-imaging sonar is aimed. The 55-deg fan (published by the driver,
+       marine_tools#62) could not be cleanly cross-checked here (the shallow
+       -3 dB edge falls outside the range window in shallow water; a 50-60 m
+       range pass over 10-15 m water would resolve it). Override grazing_deg
+       for further calibration. See issue #305 / #185. -->
+  <xacro:macro name="garmin_sidescan" params="parent name x:=0 y:=0 z:=0 grazing_deg:=35.0">
 
     <!-- Mount frame, aligned with base_link (X fwd, Y port, Z up). -->
     <link name="bizzy/${name}"/>


### PR DESCRIPTION
## Summary

Revise the SideVü side-scan **grazing tilt default** from `grazing_deg=62.5°` (half-fan-off-nadir, #303) to **35°**, measured from field sonar bags.

The 62.5° was a geometric tiling heuristic ~27° too steep. Offline analysis of field bags (Massabesic + bizzy runs, 5 days, 30/35/50 m range settings, two depth sources) puts the boresight depression at **~35°**: the bottom-return angular profile `I(φ)=asin(nadir_depth/slant_range)` peaks ~38°, less a few degrees of near-nadir backscatter steep-bias. A **roll-day regression** (per-ping steep-edge vs vessel roll; opposite-sign ±1 slopes per channel) validated the geometry. Matches the recreational side-imaging patent norm (~20–40°, nom 30°; US7652952B2, US11137495B2).

## Change

- `garmin_sidescan` macro: `grazing_deg` default `62.5` → **`35.0`**.
- Rationale comment rewritten (measured derivation, patent corroboration, fan-width limitation).
- Manual TF-check expected vector updated: port +Z `[0, 0.819, −0.574]` (35° depression).

Verified by rendering the source: port rpy `−2.1817` = `−(π/2 + 35°)`, +X stays forward. One file.

## Not cleanly resolved (documented)

The 55° fan-width cross-check (shallow −3 dB edge) couldn't be cleanly measured — it falls outside the range window in shallow water (soft-consistent at 50 m). A 50–60 m-range pass over 10–15 m water would resolve it; does not affect the boresight result.

Reviewed locally (pre-push, Light) — must-fix (stale TF vector) addressed.

Closes #305. Part of #185.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
