### PR TITLE
feat(bizzyboat): one-off retrofit_sidescan_bag.py for legacy bags (#307)

### DIFF
--- a/.agent/work-plans/issue-307/progress.md
+++ b/.agent/work-plans/issue-307/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 307
+---
+
+# Issue #307 — one-off retrofit_sidescan_bag.py for legacy bizzy sidescan bags
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-22 02:56 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-307 at `285e27b`
+**Mode**: pre-push
+**Depth**: Standard (reason: single new 115-line Python file; 50–199 changed lines)
+**Must-fix**: 0 | **Suggestions**: 5
+**Round**: 1 | **Ship**: recommended — no must-fix; happy-path correct (geometry matches URDF #305, QoS/storage preserved); 5 robustness/style suggestions are optional for a not-installed one-off
+
+### Findings
+- [ ] (suggestion) No try/finally; reader never closed and writer finalized via `del wr` — a mid-loop exception leaves a partial output bag that the startup existence-guard then blocks on re-run. Add explicit `rd.close()`/`wr.close()` in finally + remove partial output on failure (cross-confirmed Lens A + Lens B). — `bizzyboat_project11/scripts/retrofit_sidescan_bag.py:75,82,107`
+- [ ] (suggestion) Silent no-op on legacy naming: if the expected sonar/tf topics are absent or lack the `bizzy/` prefix in an older bag, everything passes through and the script still prints success with `0 sonar, 0 tf` — exactly the "legacy bag" case this tool targets. Warn (or exit non-zero) when both rewrite counters are 0. — `bizzyboat_project11/scripts/retrofit_sidescan_bag.py:88-106`
+- [ ] (suggestion) `sid = meta.storage_identifier or "mcap"` silently defaults to mcap; a sqlite3 legacy bag with an empty identifier would change storage format, contradicting the "storage format preserved" claim. Fail loudly or detect explicitly. — `bizzyboat_project11/scripts/retrofit_sidescan_bag.py:78`
+- [ ] (suggestion) `/tf_static` messages with none of the three sidescan children are still deserialized + re-serialized (counted as `tf`) rather than passed through byte-for-byte; re-serialization is not guaranteed bit-identical. Passthrough when no child matches. — `bizzyboat_project11/scripts/retrofit_sidescan_bag.py:97-104`
+- [ ] (suggestion) Static analysis: file diverges from the ament_flake8 style its sibling `scripts/` files already follow (double quotes ×47 Q000, semicolon multi-statements ×7 E702, one-line import E401, C408). No CI/pre-commit enforces it here, so non-blocking — flagged for in-directory consistency. — `bizzyboat_project11/scripts/retrofit_sidescan_bag.py`

--- a/bizzyboat_project11/scripts/retrofit_sidescan_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_sidescan_bag.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Retrofit a *legacy* bizzy Garmin-sidescan bag with corrected geometry + radiometry.
+
+ONE-OFF utility. New captures do NOT need this: the garmin_sidescan driver now
+stamps frequency + beamwidths (marine_tools#62) and the bizzy URDF carries the
+measured grazing tilt (this repo #305). This exists only to make bags recorded
+*before* those fixes reprocessable (mosaic / backscatter) with correct geometry
+and radiometry. Run it manually; it is not a ROS node and is not installed.
+
+It writes a NEW bag (the input is never modified):
+
+  * RawSonarImage ping_info  -> frequency + rx_beamwidths (across-track, the wide
+    fan, FULL -3dB, rad) + tx_beamwidths (along-track, FULL -3dB, rad), per
+    channel, from the GCV-20 spec table (== the values garmin_sidescan #62 stamps).
+  * tf_static  -> the three  garmin_sidescan -> _{port,starboard,down}  rotations
+    replaced with the grazing-tilt geometry (port = -(pi/2+g) about X,
+    starboard = +(pi/2+g), down = pi). Mount offset and all other frames untouched.
+    NOTE: this fixes the STATIC mount frame only; per-ping vessel roll lives in
+    the bag's localization TF (earth->base_link) and composes correctly on
+    reprocessing (unh_marine_autonomy#200).
+
+Everything else passes through byte-for-byte (storage format + QoS preserved).
+Offline read/write (rosbag2), no replay. Requires a sourced ROS 2 (jazzy) env.
+
+Usage:
+    python3 retrofit_sidescan_bag.py <in_bag> [out_bag] [--grazing-deg 35] \
+        [--no-beamwidths] [--no-tf] [--device gcv20]
+
+Default out_bag is "<in_bag>_retrofit". See #307 / #305 / #185.
+"""
+import sys, math, argparse, os
+from rosbag2_py import (SequentialReader, SequentialWriter, StorageOptions,
+                        ConverterOptions)
+from rclpy.serialization import deserialize_message, serialize_message
+from rosidl_runtime_py.utilities import get_message
+
+PFX = "/bizzy/sensors/sidescan/garmin_sidescan"
+SONAR = {f"{PFX}/sonar_image_port": "side", f"{PFX}/sonar_image_starboard": "side",
+         f"{PFX}/sonar_image_down": "down"}
+# GCV-20 spec table (band-center Hz; FULL -3dB beamwidths in radians).
+#   rx = across-track (wide fan), tx = along-track (narrow).  PingInfo.msg convention.
+RADIO = {
+    "gcv20": {"side": dict(freq=1_120_000.0, rx=math.radians(55.0), tx=math.radians(0.44)),
+              "down": dict(freq=820_000.0,  rx=math.radians(46.0), tx=math.radians(0.74))},
+    "gcv10": {"side": dict(freq=455_000.0, rx=math.radians(55.0), tx=math.radians(0.44)),
+              "down": dict(freq=800_000.0, rx=math.radians(46.0), tx=math.radians(0.74))},
+}
+SIDESCAN_CHILDREN = {  # child_frame_id -> roll(grazing_rad) about mount X
+    "bizzy/garmin_sidescan_port":      lambda g: -(math.pi / 2 + g),
+    "bizzy/garmin_sidescan_starboard": lambda g: +(math.pi / 2 + g),
+    "bizzy/garmin_sidescan_down":      lambda g: math.pi,           # unchanged
+}
+
+
+def quat_x(roll):
+    """Quaternion for a pure rotation of `roll` about the X axis."""
+    return (math.sin(roll / 2), 0.0, 0.0, math.cos(roll / 2))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("in_bag")
+    ap.add_argument("out_bag", nargs="?")
+    ap.add_argument("--grazing-deg", type=float, default=35.0)
+    ap.add_argument("--device", choices=["gcv20", "gcv10"], default="gcv20")
+    ap.add_argument("--no-beamwidths", action="store_true")
+    ap.add_argument("--no-tf", action="store_true")
+    a = ap.parse_args()
+    out = a.out_bag or (a.in_bag.rstrip("/") + "_retrofit")
+    if os.path.exists(out):
+        sys.exit(f"output already exists: {out}")
+    g = math.radians(a.grazing_deg)
+    radio = RADIO[a.device]
+
+    rd = SequentialReader(); rd.open(StorageOptions(uri=a.in_bag, storage_id=""),
+                                     ConverterOptions("", ""))
+    meta = rd.get_metadata()
+    sid = meta.storage_identifier or "mcap"
+    topics = rd.get_all_topics_and_types()
+    msgcls = {t.name: get_message(t.type) for t in topics}
+
+    wr = SequentialWriter(); wr.open(StorageOptions(uri=out, storage_id=sid),
+                                     ConverterOptions("", ""))
+    for t in topics:                                   # reuse reader's TopicMetadata
+        wr.create_topic(t)                             # preserves type, QoS, hash
+
+    n = dict(sonar=0, tf=0, pass_=0)
+    while rd.has_next():
+        topic, data, ts = rd.read_next()
+        if topic in SONAR and not a.no_beamwidths:
+            m = deserialize_message(data, msgcls[topic])
+            spec = radio[SONAR[topic]]
+            m.ping_info.frequency = spec["freq"]
+            m.ping_info.rx_beamwidths = [spec["rx"]]   # across-track fan
+            m.ping_info.tx_beamwidths = [spec["tx"]]   # along-track
+            wr.write(topic, serialize_message(m), ts); n["sonar"] += 1
+        elif topic == "/tf_static" and not a.no_tf:
+            m = deserialize_message(data, msgcls[topic])
+            for tr in m.transforms:
+                if tr.child_frame_id in SIDESCAN_CHILDREN:
+                    qx, qy, qz, qw = quat_x(SIDESCAN_CHILDREN[tr.child_frame_id](g))
+                    tr.transform.rotation.x = qx; tr.transform.rotation.y = qy
+                    tr.transform.rotation.z = qz; tr.transform.rotation.w = qw
+            wr.write(topic, serialize_message(m), ts); n["tf"] += 1
+        else:
+            wr.write(topic, data, ts); n["pass_"] += 1   # byte-for-byte passthrough
+    del wr
+    print(f"retrofit -> {out}")
+    print(f"  storage={sid}  grazing={a.grazing_deg}deg  device={a.device}")
+    print(f"  rewrote: {n['sonar']} sonar (freq+beamwidths), {n['tf']} tf_static; "
+          f"{n['pass_']} passthrough")
+
+
+if __name__ == "__main__":
+    main()

--- a/bizzyboat_project11/scripts/retrofit_sidescan_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_sidescan_bag.py
@@ -26,29 +26,35 @@ Usage:
     python3 retrofit_sidescan_bag.py <in_bag> [out_bag] [--grazing-deg 35] \
         [--no-beamwidths] [--no-tf] [--device gcv20]
 
-Default out_bag is "<in_bag>_retrofit". See #307 / #305 / #185.
+Default out_bag is '<in_bag>_retrofit'. See #307 / #305 / #185.
 """
-import sys, math, argparse, os
-from rosbag2_py import (SequentialReader, SequentialWriter, StorageOptions,
-                        ConverterOptions)
+import argparse
+import math
+import os
+import shutil
+import sys
+
 from rclpy.serialization import deserialize_message, serialize_message
+from rosbag2_py import (ConverterOptions, SequentialReader, SequentialWriter,
+                        StorageOptions)
 from rosidl_runtime_py.utilities import get_message
 
-PFX = "/bizzy/sensors/sidescan/garmin_sidescan"
-SONAR = {f"{PFX}/sonar_image_port": "side", f"{PFX}/sonar_image_starboard": "side",
-         f"{PFX}/sonar_image_down": "down"}
+PFX = '/bizzy/sensors/sidescan/garmin_sidescan'
+SONAR = {f'{PFX}/sonar_image_port': 'side', f'{PFX}/sonar_image_starboard': 'side',
+         f'{PFX}/sonar_image_down': 'down'}
 # GCV-20 spec table (band-center Hz; FULL -3dB beamwidths in radians).
 #   rx = across-track (wide fan), tx = along-track (narrow).  PingInfo.msg convention.
 RADIO = {
-    "gcv20": {"side": dict(freq=1_120_000.0, rx=math.radians(55.0), tx=math.radians(0.44)),
-              "down": dict(freq=820_000.0,  rx=math.radians(46.0), tx=math.radians(0.74))},
-    "gcv10": {"side": dict(freq=455_000.0, rx=math.radians(55.0), tx=math.radians(0.44)),
-              "down": dict(freq=800_000.0, rx=math.radians(46.0), tx=math.radians(0.74))},
+    'gcv20': {'side': {'freq': 1_120_000.0, 'rx': math.radians(55.0), 'tx': math.radians(0.44)},
+              'down': {'freq': 820_000.0, 'rx': math.radians(46.0), 'tx': math.radians(0.74)}},
+    'gcv10': {'side': {'freq': 455_000.0, 'rx': math.radians(55.0), 'tx': math.radians(0.44)},
+              'down': {'freq': 800_000.0, 'rx': math.radians(46.0), 'tx': math.radians(0.74)}},
 }
-SIDESCAN_CHILDREN = {  # child_frame_id -> roll(grazing_rad) about mount X
-    "bizzy/garmin_sidescan_port":      lambda g: -(math.pi / 2 + g),
-    "bizzy/garmin_sidescan_starboard": lambda g: +(math.pi / 2 + g),
-    "bizzy/garmin_sidescan_down":      lambda g: math.pi,           # unchanged
+# child_frame_id -> roll(grazing_rad) about the mount X axis
+SIDESCAN_CHILDREN = {
+    'bizzy/garmin_sidescan_port': lambda g: -(math.pi / 2 + g),
+    'bizzy/garmin_sidescan_starboard': lambda g: +(math.pi / 2 + g),
+    'bizzy/garmin_sidescan_down': lambda g: math.pi,            # unchanged
 }
 
 
@@ -57,59 +63,93 @@ def quat_x(roll):
     return (math.sin(roll / 2), 0.0, 0.0, math.cos(roll / 2))
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("in_bag")
-    ap.add_argument("out_bag", nargs="?")
-    ap.add_argument("--grazing-deg", type=float, default=35.0)
-    ap.add_argument("--device", choices=["gcv20", "gcv10"], default="gcv20")
-    ap.add_argument("--no-beamwidths", action="store_true")
-    ap.add_argument("--no-tf", action="store_true")
-    a = ap.parse_args()
-    out = a.out_bag or (a.in_bag.rstrip("/") + "_retrofit")
-    if os.path.exists(out):
-        sys.exit(f"output already exists: {out}")
-    g = math.radians(a.grazing_deg)
-    radio = RADIO[a.device]
+def parse_args():
+    """Parse command-line arguments."""
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('in_bag')
+    ap.add_argument('out_bag', nargs='?')
+    ap.add_argument('--grazing-deg', type=float, default=35.0)
+    ap.add_argument('--device', choices=['gcv20', 'gcv10'], default='gcv20')
+    ap.add_argument('--no-beamwidths', action='store_true')
+    ap.add_argument('--no-tf', action='store_true')
+    return ap.parse_args()
 
-    rd = SequentialReader(); rd.open(StorageOptions(uri=a.in_bag, storage_id=""),
-                                     ConverterOptions("", ""))
-    meta = rd.get_metadata()
-    sid = meta.storage_identifier or "mcap"
-    topics = rd.get_all_topics_and_types()
-    msgcls = {t.name: get_message(t.type) for t in topics}
 
-    wr = SequentialWriter(); wr.open(StorageOptions(uri=out, storage_id=sid),
-                                     ConverterOptions("", ""))
-    for t in topics:                                   # reuse reader's TopicMetadata
-        wr.create_topic(t)                             # preserves type, QoS, hash
-
-    n = dict(sonar=0, tf=0, pass_=0)
+def retrofit(rd, wr, msgcls, radio, g, a, n):
+    """Stream every message: rewrite sonar/tf_static, pass the rest through."""
     while rd.has_next():
         topic, data, ts = rd.read_next()
         if topic in SONAR and not a.no_beamwidths:
             m = deserialize_message(data, msgcls[topic])
             spec = radio[SONAR[topic]]
-            m.ping_info.frequency = spec["freq"]
-            m.ping_info.rx_beamwidths = [spec["rx"]]   # across-track fan
-            m.ping_info.tx_beamwidths = [spec["tx"]]   # along-track
-            wr.write(topic, serialize_message(m), ts); n["sonar"] += 1
-        elif topic == "/tf_static" and not a.no_tf:
+            m.ping_info.frequency = spec['freq']
+            m.ping_info.rx_beamwidths = [spec['rx']]       # across-track fan
+            m.ping_info.tx_beamwidths = [spec['tx']]       # along-track
+            wr.write(topic, serialize_message(m), ts)
+            n['sonar'] += 1
+        elif topic == '/tf_static' and not a.no_tf:
             m = deserialize_message(data, msgcls[topic])
+            matched = False
             for tr in m.transforms:
                 if tr.child_frame_id in SIDESCAN_CHILDREN:
                     qx, qy, qz, qw = quat_x(SIDESCAN_CHILDREN[tr.child_frame_id](g))
-                    tr.transform.rotation.x = qx; tr.transform.rotation.y = qy
-                    tr.transform.rotation.z = qz; tr.transform.rotation.w = qw
-            wr.write(topic, serialize_message(m), ts); n["tf"] += 1
+                    tr.transform.rotation.x = qx
+                    tr.transform.rotation.y = qy
+                    tr.transform.rotation.z = qz
+                    tr.transform.rotation.w = qw
+                    matched = True
+            if matched:                                    # only re-serialize if changed
+                wr.write(topic, serialize_message(m), ts)
+                n['tf'] += 1
+            else:
+                wr.write(topic, data, ts)                  # else byte-for-byte passthrough
+                n['pass'] += 1
         else:
-            wr.write(topic, data, ts); n["pass_"] += 1   # byte-for-byte passthrough
-    del wr
-    print(f"retrofit -> {out}")
-    print(f"  storage={sid}  grazing={a.grazing_deg}deg  device={a.device}")
+            wr.write(topic, data, ts)                      # byte-for-byte passthrough
+            n['pass'] += 1
+
+
+def main():
+    """Retrofit one bag into a new bag (geometry + radiometry)."""
+    a = parse_args()
+    out = a.out_bag or (a.in_bag.rstrip('/') + '_retrofit')
+    if os.path.exists(out):
+        sys.exit(f'output already exists: {out}')
+    g = math.radians(a.grazing_deg)
+    radio = RADIO[a.device]
+
+    rd = SequentialReader()
+    rd.open(StorageOptions(uri=a.in_bag, storage_id=''), ConverterOptions('', ''))
+    sid = rd.get_metadata().storage_identifier
+    if not sid:                                            # don't silently change format
+        sys.exit('could not determine input bag storage format')
+    topics = rd.get_all_topics_and_types()
+    msgcls = {t.name: get_message(t.type) for t in topics}
+
+    wr = SequentialWriter()
+    wr.open(StorageOptions(uri=out, storage_id=sid), ConverterOptions('', ''))
+    for t in topics:                                       # reuse reader's TopicMetadata
+        wr.create_topic(t)                                 # preserves type, QoS, hash
+
+    n = {'sonar': 0, 'tf': 0, 'pass': 0}
+    ok = False
+    try:
+        retrofit(rd, wr, msgcls, radio, g, a, n)
+        ok = True
+    finally:
+        del wr                                             # finalize the writer exactly once
+        if not ok and os.path.isdir(out):
+            shutil.rmtree(out)                             # no partial bag left behind
+
+    print(f'retrofit -> {out}')
+    print(f'  storage={sid}  grazing={a.grazing_deg}deg  device={a.device}')
     print(f"  rewrote: {n['sonar']} sonar (freq+beamwidths), {n['tf']} tf_static; "
-          f"{n['pass_']} passthrough")
+          f"{n['pass']} passthrough")
+    if not a.no_beamwidths and not a.no_tf and n['sonar'] == 0 and n['tf'] == 0:
+        print('WARNING: no sidescan sonar topics or tf_static sidescan frames matched '
+              '-- is this a bizzy garmin_sidescan bag?', file=sys.stderr)
+        sys.exit(2)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary

Add a one-off `retrofit_sidescan_bag.py` to `bizzyboat_project11/scripts/` that rewrites *legacy* bizzy Garmin-sidescan bags (into a NEW bag, input untouched) with correct **radiometry** (RawSonarImage freq + rx/tx beamwidths, GCV-20 table per marine_tools#62) and **geometry** (`tf_static` `garmin_sidescan→{port,starboard,down}` rotations patched to the measured **35° grazing tilt**, #305). All other topics pass through byte-for-byte; storage format + QoS preserved.

## Why bizzyboat_project11 (not marine_tools)

Not needed by future users of the driver — new captures already get correct beamwidths (driver) + grazing tilt (URDF). This only fixes *pre-fix* bizzy bags so they're reprocessable (mosaic / backscatter). Lives with the platform; **not installed** (run manually, like the other `scripts/` one-offs).

## Correctness

- Fixes the **static** mount frame only; per-ping vessel roll lives in the bag's localization TF and composes correctly on reprocessing (#200).
- Verified on field bags: side → 1.12 MHz / rx 55° / tx 0.44°, down → 820 kHz / rx 46° / tx 0.74°; port/stbd TF rotations → ∓125° (= ∓(90+35)).

## Review

Pre-push review-code: **approved** (0 must-fix). Folded in the robustness suggestions: `try/finally` writer finalization + partial-output cleanup on failure, fail-loud on unknown storage format, `tf_static` byte-passthrough when no sidescan child matches, warn+exit when nothing matched, and ament-style cleanup (single quotes, no semicolons, docstrings). flake8-clean.

Closes #307. Part of #185.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
