### PR TITLE
feat(bizzyboat): wire bathymetry_layer into nav2 costmaps (#319)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -25,9 +25,12 @@ local_costmap:
       # between camera views.
       # chart_layer (base's s57_layer::S57Layer) commented out for bizzyboat 2026-06-12
       # per operator; the base's chart_layer config block stays defined but unreferenced.
+      # bathymetry_layer (#319) provides the store-backed depth prior (NH GRANIT
+      # contour chart + M3 survey draft) in place of the disabled s57 chart_layer.
       plugins:
         # - "chart_layer"
         - "sea_surface_layer"
+        - "bathymetry_layer"
         - "inflation_layer"
       sea_surface_layer:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
@@ -83,6 +86,25 @@ local_costmap:
         # rolker/seafloor_echoboat_project11#35) so Smac plans around buoys too.
         # Empty-string would disable the publication.
         published_topic: <robot_namespace>/sea_surface/lethal_grid
+      bathymetry_layer:
+        plugin: "bathymetry_layer::BathymetryLayer"
+        enabled: True
+        # Store on the boat (field user data root, mirrors dev ~/data/stores).
+        # The store (NH GRANIT chart prior + M3 draft) must be synced here before
+        # the layer contributes; until then it logs once and no-ops (safe).
+        store_path: "/home/field/data/stores/bathymetry"
+        minimum_depth: 1.0
+        maximum_caution_depth: 2.5
+        # COUPLED to the chart prior's import uncertainty (5.0 m). shallowestReliable
+        # rejects cells with uncertainty > max_uncertainty and a present-but-rejected
+        # cell is written LETHAL — so a tighter gate (e.g. the 0.5 m default) would
+        # make the whole chart-covered lake lethal. Keep >= the chart's 5.0 m.
+        max_uncertainty: 5.0
+        max_age: 0.0
+        # Closed lake basin: the chart prior is masked to the lake outline, so
+        # no-data cells are land. Mark them lethal (unh_marine_autonomy#216).
+        unsurveyed_is_lethal: True
+        map_tide_frame: <tf_prefix>/map_tide
 
 global_costmap:
   global_costmap:
@@ -95,7 +117,20 @@ global_costmap:
       plugins:
         # - "chart_layer"
         - "sea_surface_relay"
+        - "bathymetry_layer"
         - "inflation_layer"
+      bathymetry_layer:
+        plugin: "bathymetry_layer::BathymetryLayer"
+        enabled: True
+        # See the local_costmap bathymetry_layer block for the store_path,
+        # max_uncertainty (chart-prior coupling) and unsurveyed_is_lethal rationale.
+        store_path: "/home/field/data/stores/bathymetry"
+        minimum_depth: 1.0
+        maximum_caution_depth: 2.5
+        max_uncertainty: 5.0
+        max_age: 0.0
+        unsurveyed_is_lethal: True
+        map_tide_frame: <tf_prefix>/map_tide
 
 collision_monitor:
   ros__parameters:


### PR DESCRIPTION
## What

Wires the `bathymetry_layer` Nav2 costmap plugin into **bizzyboat's** local and
global costmaps in `bizzyboat_project11/config/nav2_overlay.yaml`:

- Adds `bathymetry_layer` to both plugin lists (before `inflation_layer`).
- Adds a config block to each costmap.

Closes #319. Consumer side of rolker/unh_marine_autonomy#216 (the plugin's
`unsurveyed_is_lethal` feature) — uses the bathymetric store (NH GRANIT contour
chart prior + M3 survey draft) for depth-aware planning at Lake Massabesic.

## Why the overlay (not the base)

Bizzy's overlay disabled `chart_layer` (s57) per operator on 2026-06-12 and
restates the plugin lists wholesale (deep-merge replaces lists), so the base's
`chart_layer` block is defined-but-unreferenced for bizzy. The store-backed layer
takes that depth-prior role here, in the overlay.

## Parameters

| Param | Value | Note |
|---|---|---|
| `store_path` | `/home/field/data/stores/bathymetry` | Boat `field` data root (mirrors dev `~/data/stores`). |
| `unsurveyed_is_lethal` | `True` | Closed lake basin — chart is masked to the lake outline, so no-data = land. |
| `max_uncertainty` | `5.0` | **Coupled** to the chart prior's 5.0 m import uncertainty: `shallowestReliable` rejects `uncertainty > max_uncertainty`, and a rejected present cell is LETHAL — the 0.5 m default would make the whole chart-covered lake lethal. |
| `minimum_depth` / `maximum_caution_depth` | `1.0` / `2.5` | Plugin defaults; tune live for the lake. |
| `map_tide_frame` | `<tf_prefix>/map_tide` | Matches the base chart_layer's `sea_surface_frame`. |

## Before this does anything on the boat

The materialized store currently lives on the dev machine
(`~/data/stores/bathymetry`). **Sync it to `/home/field/data/stores/bathymetry` on
gabby** before relying on the layer. Until present, the layer logs once and
no-ops; with no valid `map_tide` it also contributes nothing (tide gate). Both are
safe, fail-quiet states.

## Follow-up

Consider re-importing the chart prior with a lower, more honest
contour-interpolation uncertainty so a tighter `max_uncertainty` gate can be used
(the current 5.0 m coupling is conservative).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
