### PR TITLE
fix(bizzyboat): portable bathymetry_layer store_path (#322)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -89,10 +89,11 @@ local_costmap:
       bathymetry_layer:
         plugin: "bathymetry_layer::BathymetryLayer"
         enabled: True
-        # Store on the boat (field user data root, mirrors dev ~/data/stores).
-        # The store (NH GRANIT chart prior + M3 draft) must be synced here before
-        # the layer contributes; until then it logs once and no-ops (safe).
-        store_path: "/home/field/data/stores/bathymetry"
+        # Leading ~ expands to $HOME (bathymetry_layer #218), so this resolves on
+        # both the boat (/home/field/...) and dev/sim (/home/roland/...). The store
+        # (NH GRANIT chart prior + M3 draft) must exist there before the layer
+        # contributes; until then it logs once and no-ops (safe).
+        store_path: "~/data/stores/bathymetry"
         minimum_depth: 1.0
         maximum_caution_depth: 2.5
         # COUPLED to the chart prior's import uncertainty (5.0 m). shallowestReliable
@@ -122,9 +123,9 @@ global_costmap:
       bathymetry_layer:
         plugin: "bathymetry_layer::BathymetryLayer"
         enabled: True
-        # See the local_costmap bathymetry_layer block for the store_path,
-        # max_uncertainty (chart-prior coupling) and unsurveyed_is_lethal rationale.
-        store_path: "/home/field/data/stores/bathymetry"
+        # See the local_costmap bathymetry_layer block for the store_path (~ expands
+        # to $HOME), max_uncertainty (chart-prior coupling) and unsurveyed_is_lethal.
+        store_path: "~/data/stores/bathymetry"
         minimum_depth: 1.0
         maximum_caution_depth: 2.5
         max_uncertainty: 5.0


### PR DESCRIPTION
## What

Changes bizzyboat's `bathymetry_layer.store_path` (both local and global costmaps
in `nav2_overlay.yaml`) from the hardcoded `/home/field/data/stores/bathymetry` to
the portable `~/data/stores/bathymetry`. Comments updated accordingly.

Closes #322. Depends on rolker/unh_marine_autonomy#218/PR#219 (merged), which makes
`bathymetry_layer` expand a leading `~` to `$HOME`.

## Why

The boat-specific absolute path couldn't resolve on a dev/sim host, so the layer
silently no-op'd in sim. `~/data/stores/bathymetry` resolves on both the boat
(`/home/field/...`) and dev/sim (`/home/roland/...`).

Validated: YAML parses; both blocks use the portable path; no `/home/field` store
path remains.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
