### PR TITLE
Bridge rqt_boat_state panel topics over udp_bridge

### DIFF
--- a/.agent/work-plans/issue-324/progress.md
+++ b/.agent/work-plans/issue-324/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 324
+---
+
+# Issue #324 — bridge rqt_boat_state panel topics to operator
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-24 13:20 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-324 at `72d9dd9`
+**Mode**: pre-push
+**Depth**: Light (reason: 1 config file, +36 lines, no override-trigger/Deep triggers)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix findings; only optional cell-link throttling suggestion
+
+### Findings
+- [ ] (suggestion) `mavros_rc_in`/`mavros_rc_out` (~10 Hz) added unthrottled to the minimal 300 KB/s cell link; consider a `period:` cap — `bizzyboat_project11/config/bizzyboat.yaml:366-370,395-399`
+- [ ] (suggestion) Same RC streams unthrottled on wifi/vpn — consistent and within budget, noted for completeness — `bizzyboat_project11/config/bizzyboat.yaml:116-120,250-254`
+- [ ] (suggestion) On-water: confirm mavros `rc_io` plugin is publishing `mavros/rc/in`+`mavros/rc/out`; if inactive the entries forward nothing (harmless)

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -113,6 +113,11 @@
             - mavros_velocity
             - mavros_position_ekf
             - mavros_velocity_body
+            - mavros_state
+            - mavros_rc_out
+            - mavros_rc_in
+            - mavros_cmd_vel
+            - sound_speed
             - tf
             - tf_static
             - usb_camera
@@ -180,6 +185,13 @@
               mavros_velocity: {source: mavros/global_position/raw/gps_vel}
               mavros_position_ekf: {source: mavros/global_position/global}
               mavros_velocity_body: {source: mavros/local_position/velocity_body}
+              # rqt_boat_state operator panel (rqt_operator_tools#85): FCU mode,
+              # actual/RC PWM, autonomy setpoint, and sound speed.
+              mavros_state: {source: mavros/state}
+              mavros_rc_out: {source: mavros/rc/out}
+              mavros_rc_in: {source: mavros/rc/in}
+              mavros_cmd_vel: {source: mavros/setpoint_velocity/cmd_vel}
+              sound_speed: {source: sensors/sound_speed/sound_speed}
               tf: {source: /tf, queue_size: 25}
               tf_static: {source: /tf_static}
               usb_camera: {source: sensors/cameras/usb/image_raw/compressed, period: 1.0}
@@ -235,6 +247,11 @@
             - mavros_velocity
             - mavros_position_ekf
             - mavros_velocity_body
+            - mavros_state
+            - mavros_rc_out
+            - mavros_rc_in
+            - mavros_cmd_vel
+            - sound_speed
             - tf
             - tf_static
             - usb_camera
@@ -300,6 +317,13 @@
               mavros_velocity: {source: mavros/global_position/raw/gps_vel}
               mavros_position_ekf: {source: mavros/global_position/global}
               mavros_velocity_body: {source: mavros/local_position/velocity_body}
+              # rqt_boat_state operator panel (rqt_operator_tools#85): FCU mode,
+              # actual/RC PWM, autonomy setpoint, and sound speed.
+              mavros_state: {source: mavros/state}
+              mavros_rc_out: {source: mavros/rc/out}
+              mavros_rc_in: {source: mavros/rc/in}
+              mavros_cmd_vel: {source: mavros/setpoint_velocity/cmd_vel}
+              sound_speed: {source: sensors/sound_speed/sound_speed}
               tf: {source: /tf, queue_size: 25}
               tf_static: {source: /tf_static}
               # Sidescan port/stbd + water-column (down) imagery at full rate on
@@ -339,6 +363,11 @@
             - mavros_orientation
             - mavros_position_ekf
             - mavros_velocity_body
+            - mavros_state
+            - mavros_rc_out
+            - mavros_rc_in
+            - mavros_cmd_vel
+            - sound_speed
             - mavros_gps_status
             - tf
             - tf_static
@@ -361,6 +390,13 @@
               mavros_orientation: {source: mavros/imu/data}
               mavros_position_ekf: {source: mavros/global_position/global}
               mavros_velocity_body: {source: mavros/local_position/velocity_body}
+              # rqt_boat_state operator panel (rqt_operator_tools#85): FCU mode,
+              # actual/RC PWM, autonomy setpoint, and sound speed.
+              mavros_state: {source: mavros/state}
+              mavros_rc_out: {source: mavros/rc/out}
+              mavros_rc_in: {source: mavros/rc/in}
+              mavros_cmd_vel: {source: mavros/setpoint_velocity/cmd_vel}
+              sound_speed: {source: sensors/sound_speed/sound_speed}
               mavros_gps_status: {source: mavros/gpsstatus/gps1/raw}
               tf: {source: /tf, queue_size: 25}
               tf_static: {source: /tf_static}


### PR DESCRIPTION
## Summary

Bridge the five topics the operator **`rqt_boat_state`** panel (rolker/rqt_operator_tools#85, merged) needs from BizzyBoat → operator over `udp_bridge`.

Closes #324.

## Change

Added to **all three** operator connection profiles (`wifi` / `vpn` / `cell`), at native rate, following the existing `topics_list` + `topics: {source: …}` convention:

| Bridge name | Source | Panel use |
|---|---|---|
| `mavros_state` | `mavros/state` | FCU mode → authority banner |
| `mavros_rc_out` | `mavros/rc/out` | actual throttle/steering PWM |
| `mavros_rc_in` | `mavros/rc/in` | RC-override commanded overlay |
| `mavros_cmd_vel` | `mavros/setpoint_velocity/cmd_vel` | commanded speed + yaw-rate |
| `sound_speed` | `sensors/sound_speed/sound_speed` | sound-speed readout/trend |

Manual helm (`piloting_mode/manual/helm`) is intentionally **not** bridged — it originates operator-side.

## Notes

- **No throttling**, including on `cell`, per operator direction (the payloads are small). The pre-push review flagged the unthrottled ~10 Hz RC streams on the 300 KB/s cell link as an optional `period:` cap — left off deliberately; easy to add later if the cell budget proves tight on-water.
- On-water: confirm the mavros `rc_io` plugin is publishing `mavros/rc/in` + `mavros/rc/out`; if inactive those two forward nothing (harmless).
- Verified: valid YAML, all five present in every profile's `topics_list` + `topics` map with sources resolved.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
