### PR TITLE
fix(nav2): wire bathymetry_layer map_frame on bizzy (companion to unh_marine_autonomy#220, missed by #328)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -106,6 +106,12 @@ local_costmap:
         # no-data cells are land. Mark them lethal (unh_marine_autonomy#216).
         unsurveyed_is_lethal: True
         map_tide_frame: <tf_prefix>/map_tide
+        # Ellipsoid-referenced world frame (REP-105 'map'): the layer reads the
+        # water-surface ellipsoidal height as map_tide's z in this frame. MUST be
+        # set and distinct from map_tide_frame — the costmap's own global frame is
+        # map_tide here, so without this the tide lookup self-references and reads
+        # 0, flooding the lake LETHAL (unh_marine_autonomy#220).
+        map_frame: <tf_prefix>/map
 
 global_costmap:
   global_costmap:
@@ -132,6 +138,12 @@ global_costmap:
         max_age: 0.0
         unsurveyed_is_lethal: True
         map_tide_frame: <tf_prefix>/map_tide
+        # Ellipsoid-referenced world frame (REP-105 'map'): the layer reads the
+        # water-surface ellipsoidal height as map_tide's z in this frame. MUST be
+        # set and distinct from map_tide_frame — the costmap's own global frame is
+        # map_tide here, so without this the tide lookup self-references and reads
+        # 0, flooding the lake LETHAL (unh_marine_autonomy#220).
+        map_frame: <tf_prefix>/map
       # Match the local costmap's inflation (echoboat_project11/nav2_params.base.yaml:
       # cost_scaling_factor 1.0, inflation_radius 3.0). The base's GLOBAL inflation is
       # still BEN's tuning (150.0 m / 0.05) — an intentional coastline standoff for a


### PR DESCRIPTION
## What

Set `map_frame: <tf_prefix>/map` on both the local and global `bathymetry_layer` blocks in
`bizzyboat_project11/config/nav2_overlay.yaml`.

## Why this is a separate PR

This is the **companion config for rolker/unh_marine_autonomy#220 / PR #222** (now merged). It was
added to `feature/issue-327` but landed *after* PR #328 (the inflation cleanup) had already been
merged, so it never reached `jazzy`. This PR carries just that 12-line delta.

**It is load-bearing.** With #222 merged, the `bathymetry_layer` reads the `map_frame` param to find
the water-surface ellipsoidal height (`lookupTransform(map_frame, map_tide_frame).z`). The plugin's
code default is the unprefixed `"map"`, which does not resolve in bizzy's namespaced TF tree
(`bizzy/map`). Without this config the tide lookup fails, `map_tide_valid_` never opens, and the
bathymetry layer contributes **no costs** — fail-safe, but the depth prior is silently inert.

## Verification

Already sim-verified end-to-end alongside #222 (with this `map_frame` value present): the global
costmap goes from 100 % lethal to 19.6 % free / 6.3 % ramp / 74.1 % lethal (land + shoals), robot
cell navigable. See unh_marine_autonomy#220.

Part of #220 (cross-repo). Completes the config half left out of the merged #328.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
