### PR TITLE
fix(nav2): re-enable bathymetry_layer on both costmaps (Part of #276)

### DIFF
--- a/bizzyboat_project11/config/nav2_overlay.yaml
+++ b/bizzyboat_project11/config/nav2_overlay.yaml
@@ -88,10 +88,13 @@ local_costmap:
         published_topic: <robot_namespace>/sea_surface/lethal_grid
       bathymetry_layer:
         plugin: "bathymetry_layer::BathymetryLayer"
-        # DISABLED 2026-06-26 (gabby/field): bathymetry prior not ready — the store
-        # rebuilt this morning floods the lake LETHAL (unsurveyed_is_lethal + depth
-        # gate). Slipped in by mistake per operator; re-enable when the prior is vetted.
-        enabled: False
+        # Re-enabled 2026-06-27 (#276). The Jun-26 field disable was for an
+        # UNCORRECTED store: the chart re-import (unh_marine_autonomy#221,
+        # --depth-offset 48.88) makes the lake water navigable (0% depth-lethal,
+        # clearance ~1.5-7.6 m at full pool) and the depth prior now reports current
+        # promptly (#226 robot-first core-readiness fix). Land / no-data stays LETHAL
+        # via unsurveyed_is_lethal (intended closed-basin shore keepout).
+        enabled: True
         # Leading ~ expands to $HOME (bathymetry_layer #218), so this resolves on
         # both the boat (/home/field/...) and dev/sim (/home/roland/...). The store
         # (NH GRANIT chart prior + M3 draft) must exist there before the layer
@@ -131,9 +134,9 @@ global_costmap:
         - "inflation_layer"
       bathymetry_layer:
         plugin: "bathymetry_layer::BathymetryLayer"
-        # DISABLED 2026-06-26 (gabby/field): see local_costmap block — bathymetry
-        # prior not ready, floods the lake LETHAL. Re-enable when vetted.
-        enabled: False
+        # Re-enabled 2026-06-27 (#276): see local_costmap block — corrected store
+        # (unh_marine_autonomy#221) + readiness fix (#226).
+        enabled: True
         # See the local_costmap bathymetry_layer block for the store_path (~ expands
         # to $HOME), max_uncertainty (chart-prior coupling) and unsurveyed_is_lethal.
         store_path: "~/data/stores/bathymetry"


### PR DESCRIPTION
Re-enables the `bathymetry_layer` depth prior on the bizzy **local + global**
costmaps (`nav2_overlay.yaml`), reverting the Jun-26 field hotfix (`697e098`)
that disabled it because the store "floods the lake LETHAL."

## Why the disable reason is now stale
- The chart store re-import (`unh_marine_autonomy#221`, `--depth-offset 48.88`)
  makes the lake **water navigable**: across 47 tiles, **0%** of data cells are
  lethal; clearance ~1.5–7.6 m at full pool (0–10 ft zone = ramp/go-slow, deeper
  = free). The only lethal is land / no-data via `unsurveyed_is_lethal` — the
  intended closed-basin shore keepout.
- The readiness fix (`unh_marine_autonomy#226`, robot-first core-readiness) makes
  the prior report `current` within ~2 cycles instead of stalling the planner.

## Sim validation (`bizzyboat_massabesic_launch`, #226 layer + this config)
- Layer goes `current` in 2 cycles (was: never).
- Global costmap: 28.5% lethal (land), 8.7% free, 4.2% ramp — real content.
- Boat cell = ramp (go-slow), goal = free — not boxed in.
- Planner: **0 failures**, continuous `Passing new path to controller`; the boat plans and follows.

## Scope / dependencies
- **Depends on `unh_marine_autonomy#226`** (PR #227, the readiness fix). Do NOT
  merge to the default branch before #226 lands, or the config re-enables a layer
  whose old build stalls the planner.
- **Part of #276**, not a full close: this PR does the bathymetry re-enable only.
  The remaining #276 scope — re-enable `s57_layer`, verify bathy-after-s57
  ordering, and re-evaluate `allow_unknown` / the global rolling window — stays open.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
