### PR TITLE
Field import: SBG as primary nav source (#339, 2026-06-27)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -16,10 +16,19 @@
       blue: 0.0
 
     nav:
+      # SBG INS primary, FCU fallback (#339) — list order is preference, as on
+      # izzyboat (posmv, mru). SBG topics are the namespaced ros_standard
+      # messages from sbg_launch (use_enu:true).
       source_names:
-        - mru
+        - sbg
+        - fcu
       sources:
-        mru:
+        sbg:
+          topics:
+            orientation: "sensors/sbg/imu/data"
+            position: "sensors/sbg/imu/nav_sat_fix"
+            velocity: "sensors/sbg/imu/velocity"
+        fcu:
           topics:
             orientation: "mavros/imu/data"
             position: "mavros/global_position/global"
@@ -45,14 +54,29 @@
 
 /**/mru_transform:
   ros__parameters:
+    # SBG INS primary, FCU fallback (#339). Arbitration is "newest fresh
+    # sample wins, priority (sensor_names order) breaks ties"; the SBG runs
+    # faster (imu/data ~25 Hz vs FCU ~10 Hz) so it dominates while healthy and
+    # the FCU takes over only on a real SBG dropout past sensor_timeout. SBG
+    # topics are the namespaced ros_standard messages (use_enu:true); frame_id
+    # sbg_gnss_primary (identity vs base_link) serves both the fix lever-arm
+    # and the gyro path. SBG attitude verified vehicle-aligned on the boat
+    # 2026-06-27 (yaw matches FCU to 0.01 deg; roll/pitch match the tie-up).
     sensors:
-      mru:
+      sbg:
+        topics:
+          orientation: "sensors/sbg/imu/data"
+          position: "sensors/sbg/imu/nav_sat_fix"
+          velocity: "sensors/sbg/imu/velocity"
+      fcu:
         topics:
           orientation: "mavros/imu/data"
           position: "mavros/global_position/global"
           velocity: "mavros/local_position/velocity_body"
     sensor_names:
-    - mru
+    - sbg
+    - fcu
+    sensor_timeout: 0.5
 
 /**/udp_bridge:
   ros__parameters:
@@ -460,16 +484,22 @@
       - /bizzy/sensors/cameras/oak_aft/rgb/image_raw/compressed
       - /bizzy/sensors/cameras/oak_port/rgb/camera_info
       - /bizzy/sensors/cameras/oak_port/rgb/image_raw/compressed
-      # SBG Ellipse-D INS — 50 Hz IMU/EKF, 5 Hz GPS, 1 Hz status/UTC
-      - /bizzy/sensors/sbg/imu_data
-      - /bizzy/sensors/sbg/ekf_nav
-      - /bizzy/sensors/sbg/ekf_quat
-      - /bizzy/sensors/sbg/mag
-      - /bizzy/sensors/sbg/gps_pos
-      - /bizzy/sensors/sbg/gps_vel
-      - /bizzy/sensors/sbg/gps_hdt
+      # SBG Ellipse-D INS — standard ROS messages (REP-103, use_enu:true),
+      # grouped under sbg/imu/ via sbg_launch remaps (#339). These replace
+      # the proprietary sbg/* dumps: imu/data carries EKF attitude + raw
+      # gyro/accel (was ekf_quat + imu_data), nav_sat_fix the ellipsoidal
+      # fix (was gps_pos / ekf_nav), velocity the ENU velocity (was gps_vel).
+      - /bizzy/sensors/sbg/imu/data
+      - /bizzy/sensors/sbg/imu/nav_sat_fix
+      - /bizzy/sensors/sbg/imu/velocity
+      - /bizzy/sensors/sbg/imu/mag
+      - /bizzy/sensors/sbg/imu/temp
+      - /bizzy/sensors/sbg/imu/pos_ecef
+      - /bizzy/sensors/sbg/imu/utc_ref
+      # SBG solution/health status retained — proprietary, but it has NO
+      # standard equivalent (RTK fix type, EKF solution mode, aiding status).
+      # Diagnostic for SBG-as-primary nav. Drop if strict standard-only.
       - /bizzy/sensors/sbg/status
-      - /bizzy/sensors/sbg/utc_time
       # AML SVS sound-speed probe. Out-of-water → 0.0 m/s with the
       # current `regex` parser (probe firmware emits literal `0.000` when
       # the head is dry; the regex matches it). Parse failures → NaN.
@@ -583,9 +613,9 @@
       - /bizzy/sensors/sidescan/garmin_sidescan/debug/raw_config
       # Sound-speed for bathy correction in post-processing.
       - /bizzy/sensors/sound_speed/sound_speed
-      # SBG INS for sonar motion compensation + georeferencing.
-      - /bizzy/sensors/sbg/imu_data
-      - /bizzy/sensors/sbg/ekf_quat
+      # SBG INS streams dropped (#339): sonar motion-comp / georeferencing
+      # comes from TF below (base_link attitude via mru_transform), and the
+      # raw SBG topics are in the main bag if needed for offline review.
       - /tf
       - /tf_static
     storage:

--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -54,10 +54,11 @@
 
 /**/mru_transform:
   ros__parameters:
-    # SBG INS primary, FCU fallback (#339). Arbitration is "newest fresh
-    # sample wins, priority (sensor_names order) breaks ties"; the SBG runs
-    # faster (imu/data ~25 Hz vs FCU ~10 Hz) so it dominates while healthy and
-    # the FCU takes over only on a real SBG dropout past sensor_timeout. SBG
+    # SBG INS primary, FCU fallback (#339). Arbitration is strict
+    # priority-preference (sensor_names order): the highest-priority *fresh*
+    # source owns the output, so the SBG drives nav whenever it is healthy and
+    # the FCU takes over only on a real SBG dropout past sensor_timeout —
+    # regardless of relative sample rates. SBG
     # topics are the namespaced ros_standard messages (use_enu:true); frame_id
     # sbg_gnss_primary (identity vs base_link) serves both the fix lever-arm
     # and the gyro path. SBG attitude verified vehicle-aligned on the boat

--- a/bizzyboat_project11/config/sbg_ellipse_d.yaml
+++ b/bizzyboat_project11/config/sbg_ellipse_d.yaml
@@ -53,10 +53,27 @@
     output:
       time_reference: "ros"
       ros_standard: true
-      # NED matches QINSy/FCU; flip to ENU only if downstream expects REP-103.
-      use_enu: false
-      # TODO: align with URDF frame once an SBG link is added.
-      frame_id: "imu_link_ned"
+      # ENU (REP-103) is REQUIRED for the ros_standard messages: the driver
+      # gates ALL standard publishers (imu/data, imu/nav_sat_fix, imu/velocity)
+      # on use_enu — with use_enu:false it logs "ROS standard message are
+      # disabled" and publishes none (sbg_driver message_publisher.cpp). So
+      # this must be true for the SBG to feed mru_transform (#339). QINSy reads
+      # the device serial directly and is unaffected by this driver-side flag.
+      use_enu: true
+      # Antenna frame for the standard messages. The driver stamps ALL messages
+      # with this single frame_id. We point it at the SBG *primary* GNSS antenna
+      # (sbg_gnss_primary, where imu/nav_sat_fix's position is actually
+      # reported) so mru_transform's PositionSensor offsets the fix to base_link
+      # by the correct lever arm. That frame has identity rotation vs base_link,
+      # so it also correctly serves the gyro/attitude path (mru_transform uses
+      # the orientation quaternion directly as base_link attitude and only
+      # rotates angular velocity by this frame — identity here).
+      # ASSUMES the SBG output is vehicle-axis-aligned (config misRoll/Pitch/Yaw
+      # = 0). >>> VERIFY ON THE BOAT <<<: with use_enu:true, confirm imu/data
+      # attitude matches the FCU/known heading and that there's no residual
+      # mounting rotation; if there is, split into a real sbg_imu frame + a
+      # relay that re-stamps imu/nav_sat_fix to sbg_gnss_primary instead.
+      frame_id: "bizzy/sbg_gnss_primary"
 
       # Per-log output-mode params. With confWithRos: false above, these
       # are NOT pushed to the device — the device-side flash is the

--- a/bizzyboat_project11/config/sbg_ellipse_d_configure.yaml
+++ b/bizzyboat_project11/config/sbg_ellipse_d_configure.yaml
@@ -179,8 +179,13 @@
     output:
       time_reference: "ros"
       ros_standard: true
-      use_enu: false
-      frame_id: "imu_link_ned"
+      # Driver-side output convention (NOT pushed to device flash) — kept in
+      # sync with sbg_ellipse_d.yaml. use_enu:true is required for the
+      # ros_standard messages to publish; frame_id is the SBG primary GNSS
+      # antenna so mru_transform offsets fixes to base_link. See the runtime
+      # config for the full rationale + the boat-side alignment check.
+      use_enu: true
+      frame_id: "bizzy/sbg_gnss_primary"
 
       # Rate-code mapping:
       #   0     = off

--- a/bizzyboat_project11/launch/sbg_launch.py
+++ b/bizzyboat_project11/launch/sbg_launch.py
@@ -30,9 +30,19 @@ def generate_launch_description():
                 # SBG INS driver. Subscribes to RTCM via the remapping below
                 # so it shares /bizzy/sensors/rtcm with rtcm_relay. The
                 # `sensors` namespace (not `sensors/sbg`) leaves the
-                # driver's internal `sbg/` topic prefix to land output
-                # topics at /bizzy/sensors/sbg/<name> instead of the
-                # doubled /bizzy/sensors/sbg/sbg/<name>.
+                # driver's internal `sbg/` topic prefix to land the
+                # proprietary output topics at /bizzy/sensors/sbg/<name>
+                # instead of the doubled /bizzy/sensors/sbg/sbg/<name>.
+                #
+                # The driver's ros_standard publishers use an `imu/` prefix
+                # (imu/data, imu/nav_sat_fix, imu/velocity, ...) which would
+                # land them at /bizzy/sensors/imu/<name> — ambiguous against
+                # any other IMU and split from the rest of the SBG output.
+                # Remap each under `sbg/` so ALL SBG topics (proprietary and
+                # standard) group under /bizzy/sensors/sbg/. The standard
+                # topics had no consumers (mru_transform still reads mavros),
+                # so this rename is safe; the proprietary `sbg/<name>` topics
+                # are unchanged (zda_launch consumes sbg/utc_time by name).
                 Node(
                     package='sbg_driver',
                     executable='sbg_device',
@@ -40,6 +50,13 @@ def generate_launch_description():
                     parameters=[sbg_config],
                     remappings=[
                         ('ntrip_client/rtcm', 'rtcm'),
+                        ('imu/data', 'sbg/imu/data'),
+                        ('imu/nav_sat_fix', 'sbg/imu/nav_sat_fix'),
+                        ('imu/velocity', 'sbg/imu/velocity'),
+                        ('imu/mag', 'sbg/imu/mag'),
+                        ('imu/temp', 'sbg/imu/temp'),
+                        ('imu/pos_ecef', 'sbg/imu/pos_ecef'),
+                        ('imu/utc_ref', 'sbg/imu/utc_ref'),
                     ],
                     respawn=True,
                     respawn_delay=5,

--- a/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
+++ b/bizzyboat_project11/urdf/bizzyboat.urdf.xacro
@@ -167,15 +167,35 @@
     pitch="${cam_tilt}" yaw="${pi}"/>
 
 
-  <!-- ========== GNSS Antennas (2x CUAV C-RTK 2HP) ========== -->
-  <!-- Black pucks fore and aft. Baseline ~1.67m.
-       Measured from base_link (center screw hole). -->
+  <!-- ========== FCU GNSS Antennas (2x CUAV C-RTK 2HP) ========== -->
+  <!-- Black pucks fore and aft, feeding the Cube Orange FCU (moving-baseline
+       yaw). Baseline ~1.67m. Measured from base_link (center screw hole).
+       mavros reports global_position already referenced to base_link, so these
+       frames are not on the mru_transform position path; the FCU GPS position
+       reference is gnss_forward. -->
 
   <xacro:gnss_antenna parent="bizzy/base_link" name="gnss_forward"
     x="0.835" y="0.0" z="0.89"/>
 
   <xacro:gnss_antenna parent="bizzy/base_link" name="gnss_aft"
     x="-0.835" y="0.0" z="0.89"/>
+
+  <!-- ========== SBG Ellipse-D GNSS Antennas (dual-antenna INS) ========== -->
+  <!-- Separate from the C-RTK pucks (4 antennas total on the boat). Baseline
+       ~2.05m, consistent with the SBG flash lever arms (sbg_ellipse_d_configure
+       .yaml: primary -0.488 aft / secondary +1.567 fwd in the SBG IMU frame).
+       Positions below are measured from base_link directly and cross-check
+       against (lever arm + IMU offset) and an independent GPS baseline estimate
+       (FCU - SBG_primary = 1.843 m fwd) to ~3-6 cm.
+       sbg_gnss_primary (aft) is the phase center that sbg/gps_pos and the
+       ros_standard imu/nav_sat_fix report at -> this is the frame the SBG
+       NavSatFix must be stamped with so mru_transform offsets to base_link. -->
+
+  <xacro:gnss_antenna parent="bizzy/base_link" name="sbg_gnss_primary"
+    x="-1.073" y="0.0" z="0.8825"/>
+
+  <xacro:gnss_antenna parent="bizzy/base_link" name="sbg_gnss_secondary"
+    x="0.973" y="0.0" z="0.88"/>
 
 
   <!-- ========== Factory USB Camera ========== -->
@@ -248,13 +268,19 @@
     x="-0.23" y="0.0" z="-0.18"/>
 
   <!-- ========== Kongsberg M3 Multibeam ========== -->
-  <!-- Loaner unit sharing the DeltaT cavity (x); transducer-face z from the
-       #77 install log ([MEAS] rough). Frame consumed by cube_bathymetry's
-       TF lookup; kongsberg_em_bridge must stamp frame_id "bizzy/m3" (set its
-       frame_id param in the launch). Offsets + orientation to be confirmed by
-       a patch test. -->
+  <!-- Loaner unit mounted IN the DeltaT cavity (same physical location), but
+       the M3 and DeltaT reference their acoustic frames to different points, so
+       their base_link offsets legitimately differ (M3 -0.29/-0.28 vs DeltaT
+       -0.23/-0.18 — not a discrepancy). M3 transducer-face offsets measured
+       2026-06-27 (x=-0.29, z=-0.28); supersedes the earlier #77 install-log
+       rough values (-0.23, -0.145 — the z was ~half the true face depth, a
+       13.5 cm sounding-depth bias). Face z=-0.28 sits just above the hull
+       bottom (~-0.30 below base_link), matching the Garmin face at -0.29.
+       Frame consumed by cube_bathymetry's TF lookup; kongsberg_em_bridge must
+       stamp frame_id "bizzy/m3". Orientation still to be confirmed by a patch
+       test. -->
   <xacro:m3_multibeam parent="bizzy/base_link" name="m3"
-    x="-0.23" y="0.0" z="-0.145"/>
+    x="-0.29" y="0.0" z="-0.28"/>
 
   <!-- ========== Garmin GCV-20 Sidescan ========== -->
   <!-- Measured 2026-06-15 (Lake Massabesic): essentially centered (3 mm aft of


### PR DESCRIPTION
Imports the 2026-06-27 field implementation of **SBG as primary nav source** (#339), on-boat-verified, plus one comment fix.

This reuses #339 directly (the issue is precisely this work). The stale dev-side WIP branch `feature/issue-339` (`d28d256`, never PR'd) was superseded by this more complete, on-boat-verified field work and replaced (force-push, operator-approved) — the field commits carry the same SBG-ENU + URDF changes plus the `make SBG primary` commit the WIP lacked, on newer `jazzy` (post-#340/#276).

The `mru_transform` half is imported separately: rolker/mru_transform#30 / rolker/mru_transform#31.

## Commits
- `b5638de` urdf(bizzyboat): add SBG antenna frames + correct M3 transducer offset
- `f7489c0` config(sbg): enable ENU ros_standard output + point frame_id at SBG antenna
- `fb4a7ae` config(bizzyboat): make SBG the primary nav source
- `9b86bd1` docs(bizzyboat): correct mru_transform arbitration comment to strict priority *(added during import — see pre-review)*

## What it does
- **SBG → primary, FCU → fallback** in `bizzyboat.yaml` (`mru_transform` source list).
- **`use_enu: true`** on the SBG driver — required: the driver gates ALL `ros_standard` publishers (`imu/data`, `imu/nav_sat_fix`, `imu/velocity`) on `use_enu`; with `false` it publishes none. `frame_id` pointed at `bizzy/sbg_gnss_primary` so `mru_transform` offsets the fix to `base_link` by the correct lever arm. Verified vehicle-aligned on the boat 2026-06-27 (yaw matches FCU to 0.01°).
- **URDF**: adds SBG dual-antenna frames (`sbg_gnss_primary`/`secondary`) separate from the FCU C-RTK pucks; corrects the **M3 transducer z −0.145 → −0.28** (the old #77 install-log z was ~half the true face depth — a ~13.5 cm sounding-depth bias).
- **`sbg_launch.py`**: remaps the `imu/*` standard topics under `sbg/` so all SBG output groups under `/bizzy/sensors/sbg/`.

## Pre-review (Quality Standard)
- **Strong, field-verified.** Detailed rationale + on-boat checks throughout.
- **Fixed during import:** the `/**/mru_transform` comment in `bizzyboat.yaml` still described the *old* "newest fresh sample wins, faster source dominates" arbitration; the `mru_transform` field change made it strict priority-preference. Corrected in `9b86bd1` so the two halves are consistent.
- **Downstream note (not in this PR):** the M3 z correction (~13.5 cm) means existing draft bathy products generated with the old offset carry that bias and may warrant reprocessing.
- **Cross-repo coupling:** the SBG-primary config here depends on the `mru_transform` strict-priority change (#30/#31) and the `use_enu`/topic layout. Land them together.

Closes #339

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
