### PR TITLE
Retrofit script for collected M3 bags: TF offset + integer-second clock-skew (#342)

### DIFF
--- a/.agent/work-plans/issue-342/plan.md
+++ b/.agent/work-plans/issue-342/plan.md
@@ -50,8 +50,15 @@ sibling (`--out`) mode is also supported.
      `[0.3, 0.7]`; return `n`, corrected stamp, and `bool` warning flag.
    - `build_histogram(offsets: list[int]) -> dict[int, int]`: count-by-integer.
    - `print_histogram(hist)`: one line per integer offset key.
+   - **Timing target topic (must-fix, Plan Review)**: the M3 detections topic is
+     pinned as a module constant `M3_DETECTIONS_TOPIC = '/bizzy/sensors/m3/detections'`
+     (type `marine_acoustic_msgs/SonarDetections`), from the recorder config in
+     `bizzyboat.yaml`. `stream()` applies `correct_stamp` only to messages on this
+     topic — mirroring the sidescan precedent's hardcoded `SONAR` target dict. The
+     constant is documented so a namespace/topic-rename is a one-line change.
    - `stream(rd, wr_or_none, args)`: main loop — accumulate histogram,
-     apply corrections, pass everything else through. Returns counters dict.
+     apply corrections (timing on `M3_DETECTIONS_TOPIC`, geometry on `/tf_static`),
+     pass everything else through. Returns counters dict.
    - `main()`: orchestrate — open reader, determine output path (temp or
      `--out`), run `stream()`, then in-place swap if default mode.
    - **In-place swap**: write to `<in_bag>.tmp` (or `.tmp.mcap` for bare);
@@ -88,6 +95,13 @@ sibling (`--out`) mode is also supported.
      produces the same bag, not that it skips work).
    - `test_stream_passthrough`: with `--no-tf` and `--no-timing`, all messages
      pass unchanged; counters confirm zero rewrites.
+   - `test_storage_qos_preserved` (suggestion, Plan Review): round-trip a bag
+     through `main()` and assert the output's `storage_id` and every topic's
+     `TopicMetadata` (name, type, serialization_format, offered_qos_profiles)
+     match the input — covers review-issue action #1 (storage/QoS preservation),
+     which message-byte checks alone do not.
+   - `test_correct_stamp_only_target_topic`: a non-M3 topic carrying a stale
+     stamp is left untouched (timing applies only to `M3_DETECTIONS_TOPIC`).
    - `test_inplace_swap_creates_backup`: after `main()` in default mode on a
      temp bag, the `.orig` backup exists, corrected bag exists at original path,
      and backup contents match the original pre-run input.
@@ -128,10 +142,18 @@ sibling (`--out`) mode is also supported.
 
 ## Open Questions
 
-- [ ] For bare `.mcap` output in the in-place path: confirm that `SequentialReader`
-  can validate a freshly-written bare `.mcap` (open + read one message) without
-  ROS middleware; if not, use file-size > 0 as the "fully written" heuristic
-  instead. Implementer should test this on a real boat bag before committing.
+- [x] **Resolved (Plan Review suggestion)** — bare `.mcap` write-validation gating
+  the in-place backup atomicity: `validate_written(path, storage_id)` opens a
+  `SequentialReader` on the freshly-written output and reads one message; if that
+  raises (or the rosbag2 mcap writer produced an unexpected layout), it falls back
+  to a `size > 0` heuristic and emits a WARN that validation was degraded. The
+  in-place swap (rename original → `.orig`, temp → original) runs **only** after
+  `validate_written` passes, so a failed/partial write never replaces the original.
+  **Caveat carried to the PR**: boat bags are bare `.mcap`; rosbag2's
+  `SequentialWriter` may emit a *directory* bag rather than a single bare file for
+  mcap output. The script handles both input forms; the bare-file *output*
+  round-trip should be smoke-tested on a real boat bag before bulk use (noted in
+  the PR body), since the synthetic-bag tests exercise the directory form.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-342/plan.md
+++ b/.agent/work-plans/issue-342/plan.md
@@ -143,17 +143,19 @@ sibling (`--out`) mode is also supported.
 ## Open Questions
 
 - [x] **Resolved (Plan Review suggestion)** — bare `.mcap` write-validation gating
-  the in-place backup atomicity: `validate_written(path, storage_id)` opens a
-  `SequentialReader` on the freshly-written output and reads one message; if that
-  raises (or the rosbag2 mcap writer produced an unexpected layout), it falls back
-  to a `size > 0` heuristic and emits a WARN that validation was degraded. The
-  in-place swap (rename original → `.orig`, temp → original) runs **only** after
-  `validate_written` passes, so a failed/partial write never replaces the original.
-  **Caveat carried to the PR**: boat bags are bare `.mcap`; rosbag2's
-  `SequentialWriter` may emit a *directory* bag rather than a single bare file for
-  mcap output. The script handles both input forms; the bare-file *output*
-  round-trip should be smoke-tested on a real boat bag before bulk use (noted in
-  the PR body), since the synthetic-bag tests exercise the directory form.
+  the in-place backup atomicity: `validate_written(path)` opens a
+  `SequentialReader` on the freshly-written output and reads one message. It is
+  **fail-closed** — any failure aborts (no `size > 0` fallback), because in
+  destructive in-place mode a validation failure must stop rather than be papered
+  over. The in-place swap (rename original → `.orig`, install corrected → original)
+  runs **only** after `validate_written` passes; if the final move fails, the
+  original is rolled back from `.orig`, and the installed bag is re-validated
+  (restored on failure), so a failed/partial write never replaces the original.
+  **Bag form is preserved**: rosbag2's `SequentialWriter` only emits *directory*
+  bags, so for a bare `.mcap` input the single inner segment is extracted to the
+  original name (a multi-segment write aborts and asks for `--out`). The bare-file
+  round-trip is covered by `test_inplace_bare_mcap_stays_bare`; still worth a
+  smoke-test on a real boat bag before bulk use (noted in the PR body).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-342/plan.md
+++ b/.agent/work-plans/issue-342/plan.md
@@ -1,0 +1,138 @@
+# Plan: Retrofit M3 bag — TF offset + integer-second clock-skew correction
+
+## Issue
+
+https://github.com/rolker/unh_echoboats_project11/issues/342
+
+## Context
+
+M3 bags recorded since the #77 install carry two defects that corrupt offline
+bathy reprocessing:
+
+1. **TF offset wrong** — `bizzy/m3` translation was `(-0.23, 0.0, -0.145)` at
+   record time; corrected to `(-0.29, 0.0, -0.28)` in the URDF by #339/#341.
+   Every historical M3 bag carries the old transform in its `/tf_static`.
+
+2. **Integer-second clock-skew** — M3 detection `header.stamp` jumped to +6 s
+   relative to bag receive-timestamp from Jun 24 onward (mercat Windows clock
+   drift in whole-second steps while PPS kept the sub-second fraction correct).
+   A 6 s offset causes ~9 m georef error at survey speed.
+
+The fix follows the `retrofit_sidescan_bag.py` precedent: offline rosbag2
+read→write (no replay, no ROS node, not installed) with byte-for-byte
+passthrough except the two targeted topics.
+
+One key difference from the sidescan script: boat bags are bare `.mcap` files
+(not rosbag2 directories), so the script must detect the input type and set
+`storage_id='mcap'` for bare files (vs. `storage_id=''` auto-detect for
+directories).
+
+A second difference: default mode is in-place replacement with backup (downstream
+paths reference the original bag name), not a `_retrofit`-suffix sibling. The
+sibling (`--out`) mode is also supported.
+
+## Approach
+
+1. **Create `retrofit_m3_bag.py`** in `bizzyboat_project11/scripts/`.
+   - `parse_args()`: positional `in_bag`; `--out PATH`; `--report-only`;
+     `--offset N` (force integer); `--no-tf`; `--no-timing`.
+   - `detect_storage(path)`: return `'mcap'` for bare `.mcap` file,
+     `''` (auto-detect) for directory.
+   - `open_reader(path)`: `SequentialReader` using detected storage_id.
+   - `open_writer(path, sid, topics)`: `SequentialWriter` preserving
+     storage_id and all TopicMetadata (type, QoS, serialization format).
+   - `rewrite_tf(msg)`: iterate `transforms`, match `child_frame_id ==
+     'bizzy/m3'`, set translation to `(-0.29, 0.0, -0.28)`, rotation
+     untouched. Return `(modified_msg, changed: bool)`.
+   - `correct_stamp(header_stamp_ns, recv_ts_ns)`: compute
+     `offset_s = (header_stamp_ns − recv_ts_ns) / 1e9`;
+     `n = round(offset_s)`; emit WARN if `abs(offset_s − n)` is in
+     `[0.3, 0.7]`; return `n`, corrected stamp, and `bool` warning flag.
+   - `build_histogram(offsets: list[int]) -> dict[int, int]`: count-by-integer.
+   - `print_histogram(hist)`: one line per integer offset key.
+   - `stream(rd, wr_or_none, args)`: main loop — accumulate histogram,
+     apply corrections, pass everything else through. Returns counters dict.
+   - `main()`: orchestrate — open reader, determine output path (temp or
+     `--out`), run `stream()`, then in-place swap if default mode.
+   - **In-place swap**: write to `<in_bag>.tmp` (or `.tmp.mcap` for bare);
+     only after fully written + `SequentialReader` can open the output: rename
+     original → `<in_bag>.orig` (directory) / `<in_bag_stem>.orig.mcap`
+     (bare file); rename temp → original name. Clean up temp on failure
+     (no partial bag left behind).
+   - Print histogram + counters; exit non-zero if `--report-only` and offsets
+     detected (no write performed).
+
+2. **Add test infrastructure to `CMakeLists.txt`**.
+   - `find_package(ament_cmake_pytest REQUIRED)` inside `if(BUILD_TESTING)`.
+   - `ament_add_pytest_test(test_retrofit_m3_bag test/test_retrofit_m3_bag.py)`.
+   - `ament_cmake_pytest` is a test-only dep; add to `test_depend` in
+     `package.xml`.
+
+3. **Create `test/test_retrofit_m3_bag.py`** with a synthetic bag fixture
+   (create a small in-memory MCAP or a temp bag dir via `rosbag2_py` + rclpy
+   serialization, or mock the reader/writer at the stream-function level).
+   Tests:
+   - `test_correct_stamp_healthy`: offset ~0.04 s → `n=0`, stamp unchanged,
+     no warning.
+   - `test_correct_stamp_six_second`: offset ~6.03 s → `n=6`, stamp shifted
+     by 6 s, sub-second fraction preserved.
+   - `test_correct_stamp_ambiguous`: offset ~0.5 s → WARN emitted (function
+     returns `warning=True`).
+   - `test_histogram`: given offsets `[0, 0, 6, 6, 6]` → `{0: 2, 6: 3}`.
+   - `test_rewrite_tf_target_frame`: msg with `bizzy/m3` child → translation
+     set to `(-0.29, 0.0, -0.28)`, rotation quaternion unchanged, `changed=True`.
+   - `test_rewrite_tf_other_frame`: msg with unrelated child → not touched,
+     `changed=False`.
+   - `test_rewrite_tf_idempotent`: already-corrected translation → still
+     `changed=True` (field set; the idempotency guarantee means re-running
+     produces the same bag, not that it skips work).
+   - `test_stream_passthrough`: with `--no-tf` and `--no-timing`, all messages
+     pass unchanged; counters confirm zero rewrites.
+   - `test_inplace_swap_creates_backup`: after `main()` in default mode on a
+     temp bag, the `.orig` backup exists, corrected bag exists at original path,
+     and backup contents match the original pre-run input.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `bizzyboat_project11/scripts/retrofit_m3_bag.py` | New script (main deliverable) |
+| `bizzyboat_project11/test/test_retrofit_m3_bag.py` | New unit test file |
+| `bizzyboat_project11/CMakeLists.txt` | Add `BUILD_TESTING` block with `ament_cmake_pytest` |
+| `bizzyboat_project11/package.xml` | Add `<test_depend>ament_cmake_pytest</test_depend>` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Tests and docstring are in-scope (issue specifies both); CMakeLists + package.xml are updated to register tests |
+| Only what's needed | No ROS node, no install entry, no new dependency beyond `ament_cmake_pytest` for test discovery |
+| Test what breaks | Tests cover the non-obvious invariants: PPS rounding, ambiguous-band WARN, idempotent TF rewrite, backup atomicity |
+| Capture decisions, not just implementations | Script docstring explains *why* `round(offset)` is correct (PPS-disciplined sub-second + whole-second Windows drift), per Issue Review action item |
+| Improve incrementally | Single PR touching only this script and its tests; no broader refactor |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 (ROS 2 conventions) | Yes | Script not installed (not a node); test dir follows `test/` convention; `package.xml` uses `<test_depend>` tag correctly |
+| ADR-0009 (Python package management) | No — uses only packages already available in the sourced ROS 2 env (`rosbag2_py`, `rclpy`, `rosidl_runtime_py`) | No new pip installs; no requirements.txt change needed |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `scripts/retrofit_m3_bag.py` (new script) | CMakeLists — no install entry needed (not a node), but test infrastructure added | Yes |
+| `CMakeLists.txt` test block | `package.xml` `<test_depend>` | Yes |
+| `bizzy/m3` TF correction | Orientation unchanged (patch test still pending per URDF comment) | N/A — script leaves rotation untouched by design |
+
+## Open Questions
+
+- [ ] For bare `.mcap` output in the in-place path: confirm that `SequentialReader`
+  can validate a freshly-written bare `.mcap` (open + read one message) without
+  ROS middleware; if not, use file-size > 0 as the "fully written" heuristic
+  instead. Implementer should test this on a real boat bag before committing.
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-342/progress.md
+++ b/.agent/work-plans/issue-342/progress.md
@@ -29,3 +29,17 @@ issue: 342
 
 ### Open questions
 - [ ] For bare `.mcap` output in the in-place path: confirm that `SequentialReader` can validate a freshly-written bare `.mcap` (open + read one message) without ROS middleware; if not, use file-size > 0 as the "fully written" heuristic instead. Implementer should test on a real boat bag before committing.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-27 20:53 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-342/plan.md` at `132d60c`
+**PR**: PR-less (--issue mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) Timing correction never names which topic(s) carry M3 detections — `stream()`/`correct_stamp` have no topic filter; sidescan precedent hardcodes targets (SONAR dict) and no M3 topic is defined in this repo's config. Pin the exact topic name(s). — `plan.md:48-54`
+- [ ] (suggestion) No dedicated storage-format + QoS preservation test, though review-issue action #1 requires it; `test_stream_passthrough` checks message bytes, not round-tripped TopicMetadata/storage_id. — `plan.md:90`
+- [ ] (suggestion) Bare-`.mcap` SequentialReader-validation open question is unresolved; it gates the in-place/backup atomicity guarantee — track before relying on in-place mode. — `plan.md:131-134`

--- a/.agent/work-plans/issue-342/progress.md
+++ b/.agent/work-plans/issue-342/progress.md
@@ -43,3 +43,28 @@ issue: 342
 - [ ] (must-fix) Timing correction never names which topic(s) carry M3 detections — `stream()`/`correct_stamp` have no topic filter; sidescan precedent hardcodes targets (SONAR dict) and no M3 topic is defined in this repo's config. Pin the exact topic name(s). — `plan.md:48-54`
 - [ ] (suggestion) No dedicated storage-format + QoS preservation test, though review-issue action #1 requires it; `test_stream_passthrough` checks message bytes, not round-tripped TopicMetadata/storage_id. — `plan.md:90`
 - [ ] (suggestion) Bare-`.mcap` SequentialReader-validation open question is unresolved; it gates the in-place/backup atomicity guarantee — track before relying on in-place mode. — `plan.md:131-134`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 21:25 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-342 at `387d7e9`
+**Mode**: pre-push
+**Depth**: Deep (reason: 707 lines of new code ≥ 200; plan.md is a project-repo governance trigger)
+**Must-fix**: 1 | **Suggestions**: 8
+**Round**: 1 | **Ship**: continue — one real correctness gap on the default in-place path (bare `.mcap` → directory); address then re-review
+
+Tests: 19/19 pass locally (pytest, jazzy sourced). Static analysis run (flake8 ament profile; package registers no lint test, so not CI-caught). Copilot off (not opted in). Reviewed against local `origin/jazzy` (fetch failed offline).
+
+### Findings
+- [ ] (must-fix) Default in-place mode silently installs a *directory* bag at a bare `.mcap`'s original filename (verified: `.mcap` URI → rosbag2 directory bag); guard output-form ≠ input-form or require `--out` for bare files — `retrofit_m3_bag.py:260-266,308-327`
+- [ ] (suggestion) `validate_written` degrades to `size>0` on any reader exception; in destructive in-place mode a validation exception should abort, not fall back — `retrofit_m3_bag.py:158-178,321`
+- [ ] (suggestion) Two-rename in-place swap is non-atomic; SIGINT between renames leaves the bag only at `.orig` and the re-run guard then refuses — add rollback + recovery hint — `retrofit_m3_bag.py:311,326-327`
+- [ ] (suggestion) Input reader `rd` not released before the in-place rename (works on Linux; release for robustness) — `retrofit_m3_bag.py:317-327`
+- [ ] (suggestion) `AMBIG_HI=0.7` is dead (frac maxes at 0.5); behavior correct but constant + docstring "|frac| in [0.3,0.7]" mislead — `retrofit_m3_bag.py:89,102`
+- [ ] (suggestion) Stale `.tmp` from a SIGKILLed run blocks all future runs with no auto-clean/--force — `retrofit_m3_bag.py:309-312`
+- [ ] (suggestion) Histogram under `--offset N` records the forced value, undercutting its "validates the PPS assumption" claim — `retrofit_m3_bag.py:100,191`
+- [ ] (suggestion) Banker's-rounding direction at exactly n+0.5 untested; `test_correct_stamp_ambiguous_band` discards `n` — `test_retrofit_m3_bag.py:70-75`
+- [ ] (suggestion) flake8 ament profile (not run in this package's CI): unused `import os` (F401), plus D401/D403 docstring nits on test helpers — `test_retrofit_m3_bag.py:16,93,165`

--- a/.agent/work-plans/issue-342/progress.md
+++ b/.agent/work-plans/issue-342/progress.md
@@ -17,3 +17,15 @@ issue: 342
 - [ ] Unit tests required (as specified): integer-second rounding, histogram (including ambiguous-band WARN at ±0.3–0.7 s), `bizzy/m3` TF translation rewrite, storage format + QoS preservation, and original recoverable from backup.
 - [ ] Capture the PPS/integer-second correction rationale in the script docstring (why `round(offset)` is correct: PPS disciplines the sub-second fraction, whole-second jumps from mercat Windows clock drift).
 - [ ] Handle both rosbag2 mcap bag directories and bare `.mcap` files — confirm sidescan precedent and adjust accordingly for the bare-file path.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-27 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-342/plan.md` at `132d60c`
+**Branch**: feature/issue-342 at `132d60c`
+**Phases**: single
+
+### Open questions
+- [ ] For bare `.mcap` output in the in-place path: confirm that `SequentialReader` can validate a freshly-written bare `.mcap` (open + read one message) without ROS middleware; if not, use file-size > 0 as the "fully written" heuristic instead. Implementer should test on a real boat bag before committing.

--- a/.agent/work-plans/issue-342/progress.md
+++ b/.agent/work-plans/issue-342/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 342
+---
+
+# Issue #342 — Retrofit M3 bag: TF offset + integer-second clock-skew correction
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-27 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #342
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] Unit tests required (as specified): integer-second rounding, histogram (including ambiguous-band WARN at ±0.3–0.7 s), `bizzy/m3` TF translation rewrite, storage format + QoS preservation, and original recoverable from backup.
+- [ ] Capture the PPS/integer-second correction rationale in the script docstring (why `round(offset)` is correct: PPS disciplines the sub-second fraction, whole-second jumps from mercat Windows clock drift).
+- [ ] Handle both rosbag2 mcap bag directories and bare `.mcap` files — confirm sidescan precedent and adjust accordingly for the bare-file path.

--- a/.agent/work-plans/issue-342/progress.md
+++ b/.agent/work-plans/issue-342/progress.md
@@ -59,12 +59,29 @@ issue: 342
 Tests: 19/19 pass locally (pytest, jazzy sourced). Static analysis run (flake8 ament profile; package registers no lint test, so not CI-caught). Copilot off (not opted in). Reviewed against local `origin/jazzy` (fetch failed offline).
 
 ### Findings
-- [ ] (must-fix) Default in-place mode silently installs a *directory* bag at a bare `.mcap`'s original filename (verified: `.mcap` URI → rosbag2 directory bag); guard output-form ≠ input-form or require `--out` for bare files — `retrofit_m3_bag.py:260-266,308-327`
-- [ ] (suggestion) `validate_written` degrades to `size>0` on any reader exception; in destructive in-place mode a validation exception should abort, not fall back — `retrofit_m3_bag.py:158-178,321`
-- [ ] (suggestion) Two-rename in-place swap is non-atomic; SIGINT between renames leaves the bag only at `.orig` and the re-run guard then refuses — add rollback + recovery hint — `retrofit_m3_bag.py:311,326-327`
-- [ ] (suggestion) Input reader `rd` not released before the in-place rename (works on Linux; release for robustness) — `retrofit_m3_bag.py:317-327`
-- [ ] (suggestion) `AMBIG_HI=0.7` is dead (frac maxes at 0.5); behavior correct but constant + docstring "|frac| in [0.3,0.7]" mislead — `retrofit_m3_bag.py:89,102`
-- [ ] (suggestion) Stale `.tmp` from a SIGKILLed run blocks all future runs with no auto-clean/--force — `retrofit_m3_bag.py:309-312`
-- [ ] (suggestion) Histogram under `--offset N` records the forced value, undercutting its "validates the PPS assumption" claim — `retrofit_m3_bag.py:100,191`
-- [ ] (suggestion) Banker's-rounding direction at exactly n+0.5 untested; `test_correct_stamp_ambiguous_band` discards `n` — `test_retrofit_m3_bag.py:70-75`
-- [ ] (suggestion) flake8 ament profile (not run in this package's CI): unused `import os` (F401), plus D401/D403 docstring nits on test helpers — `test_retrofit_m3_bag.py:16,93,165`
+- [x] (must-fix) Default in-place mode silently installs a *directory* bag at a bare `.mcap`'s original filename (verified: `.mcap` URI → rosbag2 directory bag); guard output-form ≠ input-form or require `--out` for bare files — `retrofit_m3_bag.py:260-266,308-327`
+- [x] (suggestion) `validate_written` degrades to `size>0` on any reader exception; in destructive in-place mode a validation exception should abort, not fall back — `retrofit_m3_bag.py:158-178,321`
+- [x] (suggestion) Two-rename in-place swap is non-atomic; SIGINT between renames leaves the bag only at `.orig` and the re-run guard then refuses — add rollback + recovery hint — `retrofit_m3_bag.py:311,326-327`
+- [x] (suggestion) Input reader `rd` not released before the in-place rename (works on Linux; release for robustness) — `retrofit_m3_bag.py:317-327`
+- [x] (suggestion) `AMBIG_HI=0.7` is dead (frac maxes at 0.5); behavior correct but constant + docstring "|frac| in [0.3,0.7]" mislead — `retrofit_m3_bag.py:89,102`
+- [x] (suggestion) Stale `.tmp` from a SIGKILLed run blocks all future runs with no auto-clean/--force — `retrofit_m3_bag.py:309-312`
+- [x] (suggestion) Histogram under `--offset N` records the forced value, undercutting its "validates the PPS assumption" claim — `retrofit_m3_bag.py:100,191`
+- [x] (suggestion) Banker's-rounding direction at exactly n+0.5 untested; `test_correct_stamp_ambiguous_band` discards `n` — `test_retrofit_m3_bag.py:70-75`
+- [x] (suggestion) flake8 ament profile (not run in this package's CI): unused `import os` (F401), plus D401/D403 docstring nits on test helpers — `test_retrofit_m3_bag.py:16,93,165`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 21:41 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-342 at `adafe2a`
+**Mode**: pre-push
+**Depth**: Deep (reason: 795 lines of new code ≥ 200; plan.md is a project-repo governance trigger)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 2 | **Ship**: recommended — all 9 Round-1 findings resolved; 0 must-fix; remaining item is doc-only
+
+Round-1 closure verified: bare-`.mcap`→bare-`.mcap` form preserved (`inplace_paths` + `_swap_in_place` single-segment extraction, `test_inplace_bare_mcap_stays_bare`); `validate_written` now fail-closed (no `size>0` fallback); in-place swap has try/except rollback from backup; `del rd` before swap; single `AMBIG_THRESHOLD=0.3`; `--force` for stale `.tmp`; histogram records measured `n`; `test_correct_stamp_half_rounds_to_even` + `test_storage_and_metadata_preserved` added. Tests: 22/22 pass (pytest, jazzy sourced; now CI-registered via `ament_add_pytest_test`). Static analysis: `ament_flake8` clean. Two disjoint-lens Claude Adversarial passes (A logic, B systemic/safety) found no new actionable bugs — flagged items (`del wr` finalization on Windows/networked FS, the inherent SIGKILL window in the FS swap, stale-`.orig` handling) are inapplicable to this Linux-only manual tool, already mitigated, or inherent-and-acceptable given the mandatory backup. Copilot off (not opted in). Reviewed against local `origin/jazzy` (94a9ea5; fetch failed offline — branch is pure additions, base unchanged).
+
+### Findings
+- [ ] (suggestion) `plan.md:148-151` still describes `validate_written` falling back to a `size>0` heuristic; the implementation intentionally dropped that fallback (Round-1 finding #2). Doc-only — update the plan to match the shipped fail-closed behavior. — `.agent/work-plans/issue-342/plan.md:148-151`

--- a/bizzyboat_project11/CMakeLists.txt
+++ b/bizzyboat_project11/CMakeLists.txt
@@ -24,4 +24,11 @@ ament_export_dependencies(
   xacro
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  # Unit tests for the one-off bag-retrofit utility (#342). The script itself is
+  # not installed (manual offline tool, like retrofit_sidescan_bag.py).
+  ament_add_pytest_test(test_retrofit_m3_bag test/test_retrofit_m3_bag.py)
+endif()
+
 ament_package()

--- a/bizzyboat_project11/package.xml
+++ b/bizzyboat_project11/package.xml
@@ -36,6 +36,15 @@
   <exec_depend>usb_cam</exec_depend>
   <depend>xacro</depend>
 
+  <!-- Test-only: unit tests for the M3 bag-retrofit utility (#342). -->
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>rosbag2_py</test_depend>
+  <test_depend>rosidl_runtime_py</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>tf2_msgs</test_depend>
+  <test_depend>std_msgs</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/bizzyboat_project11/scripts/retrofit_m3_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_m3_bag.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Retrofit a collected bizzy M3 (Kongsberg) bag with corrected geometry + timing.
+
+ONE-OFF utility. New captures should not need this once the boat's clock-sync is
+fixed (#338) and the corrected M3 transducer offset is in the URDF (#339/#341).
+This exists to make *already-recorded* M3 bags reprocessable (cube_bathymetry
+import) with correct georeferencing. Run it manually; it is not a ROS node and is
+not installed.
+
+Two independent corrections, each toggleable:
+
+  * /tf_static  ->  the `bizzy/m3` transducer transform's TRANSLATION is set to
+    the measured (-0.29, 0.0, -0.28). Rotation is left untouched (only the
+    offsets changed in #339; the M3 orientation is still pending a patch test).
+    The old recorded value (-0.23, 0.0, -0.145) put the transducer face ~13.5 cm
+    too shallow -> a constant sounding-depth bias. Idempotent: re-running sets
+    the same value. Applies to every M3 bag (the offset was wrong since install).
+
+  * /bizzy/sensors/m3/detections  ->  the detection header.stamp is corrected for
+    the integer-second clock skew (#338). From Jun 24 2026 the M3's absolute
+    time-of-day jumped ahead in WHOLE-second steps (a drifting mercat Windows
+    clock) while PPS kept the sub-second fraction correct. So the fix is an
+    INTEGER-second shift that PRESERVES the sub-second fraction:
+
+        n = round(header.stamp - bag_receive_time)   # nearest whole second
+        header.stamp -= n seconds                     # fraction untouched
+
+    This is computed PER MESSAGE against the bag's receive timestamp (the gabby
+    clock, which #338 confirms agreed with every other clock to < 2 ms). Doing it
+    per-message means a bag that straddles a 6 s -> 7 s jump gets each ping
+    corrected by its own integer, and a healthy ping (offset ~0.04 s -> n = 0) is
+    left untouched. The bag receive time only needs ±0.5 s accuracy to pick the
+    right integer; healthy (~0.04 s) and bad (~6.03 s) offsets are both far from a
+    0.5 s rounding boundary. A WARN is emitted for any ping whose fractional
+    offset lands in an ambiguous band (|frac| in [0.3, 0.7]).
+
+The integer-offset HISTOGRAM is always printed (e.g. "0 s: 412, 6 s: 1805") so
+the step structure is visible and the PPS assumption is validated. Use
+--report-only to see it without writing (exits non-zero if any correction would
+apply, so it doubles as a "does this bag need fixing?" probe in batch scripts).
+
+File handling (default: in-place with backup) — downstream paths reference the
+original bag name, so the corrected bag takes the original name and the original
+is preserved as a backup. Persist-then-rename: the corrected bag is written to a
+temp path and VALIDATED (open + read one message) BEFORE the original is renamed
+to `<name>.orig` and the temp moved into place, so a failed/partial write never
+destroys the original. `--out PATH` instead writes a non-destructive sibling
+(the retrofit_sidescan_bag.py style) and never touches the input.
+
+Offline read/write (rosbag2), no replay. Requires a sourced ROS 2 (jazzy) env.
+Storage format + QoS are preserved (writer reuses the reader's TopicMetadata).
+
+NOTE on bare .mcap: boat bags are often bare single `.mcap` files (not rosbag2
+directories). This script detects the input form and opens bare files with
+storage_id='mcap'. rosbag2's writer may emit a *directory* bag for mcap output
+even from a bare-file input; the result is still correct and reloadable, but
+smoke-test the bare-file round-trip on a real boat bag before bulk use.
+
+Usage:
+    python3 retrofit_m3_bag.py <in_bag> [--out OUT] [--report-only] \
+        [--offset N] [--no-tf] [--no-timing]
+
+See #342 / #338 / #339, and retrofit_sidescan_bag.py (the precedent).
+"""
+import argparse
+import os
+import shutil
+import sys
+
+from rclpy.serialization import deserialize_message, serialize_message
+from rosbag2_py import (ConverterOptions, SequentialReader, SequentialWriter,
+                        StorageOptions)
+from rosidl_runtime_py.utilities import get_message
+
+NS = 1_000_000_000
+
+# Timing-correction target (must-fix, Plan Review): the M3 detections topic, from
+# the recorder config in bizzyboat.yaml. Type marine_acoustic_msgs/SonarDetections.
+# A namespace/topic rename is a one-line change here.
+M3_DETECTIONS_TOPIC = '/bizzy/sensors/m3/detections'
+
+# Geometry-correction target.
+TF_STATIC_TOPIC = '/tf_static'
+M3_FRAME = 'bizzy/m3'
+M3_XYZ = (-0.29, 0.0, -0.28)   # measured 2026-06-27 (#339); supersedes (-0.23,0,-0.145)
+
+# Fractional offset band (seconds either side of a half-second) that makes the
+# round-to-nearest-second ambiguous; pings here get a WARN.
+AMBIG_LO, AMBIG_HI = 0.3, 0.7
+
+
+def correct_stamp(stamp_ns, recv_ns, forced=None):
+    """Integer-second stamp correction, preserving the sub-second fraction.
+
+    Returns (n, new_stamp_ns, ambiguous): the whole-second shift applied, the
+    corrected stamp in ns, and whether the raw fractional offset was in the
+    ambiguous rounding band. `forced` overrides the measured integer (--offset).
+    """
+    offset_s = (stamp_ns - recv_ns) / 1e9
+    n = forced if forced is not None else round(offset_s)
+    frac = abs(offset_s - round(offset_s))
+    ambiguous = AMBIG_LO <= frac <= AMBIG_HI
+    return n, stamp_ns - n * NS, ambiguous
+
+
+def build_histogram(offsets):
+    """Count integer offsets: list[int] -> {int: count}."""
+    hist = {}
+    for n in offsets:
+        hist[n] = hist.get(n, 0) + 1
+    return hist
+
+
+def print_histogram(hist):
+    """Print one line per integer-second offset, ascending."""
+    if not hist:
+        print('  (no M3 detection messages)')
+        return
+    for n in sorted(hist):
+        print(f'  {n:+d} s: {hist[n]}')
+
+
+def rewrite_tf(msg):
+    """Set the bizzy/m3 transform's translation in a TFMessage; rotation untouched.
+
+    Returns True if a matching transform was found and rewritten.
+    """
+    changed = False
+    for tr in msg.transforms:
+        if tr.child_frame_id == M3_FRAME:
+            tr.transform.translation.x = M3_XYZ[0]
+            tr.transform.translation.y = M3_XYZ[1]
+            tr.transform.translation.z = M3_XYZ[2]
+            changed = True
+    return changed
+
+
+def detect_storage(path):
+    """Storage id for opening: 'mcap' for a bare .mcap file, '' (auto) for a dir."""
+    if os.path.isdir(path):
+        return ''
+    if path.endswith('.mcap'):
+        return 'mcap'
+    return ''
+
+
+def path_size(path):
+    """Total bytes of a bag file or directory (0 if missing)."""
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for f in files:
+            total += os.path.getsize(os.path.join(root, f))
+    return total
+
+
+def validate_written(path, storage_id):
+    """Confirm a freshly-written bag is loadable before we trust it.
+
+    Opens a SequentialReader and reads one message (an empty-but-openable bag is
+    still valid). On any failure, falls back to a size>0 heuristic and WARNs that
+    validation was degraded. Returns True if the output is considered usable.
+    """
+    try:
+        rd = SequentialReader()
+        rd.open(StorageOptions(uri=path, storage_id=storage_id), ConverterOptions('', ''))
+        if rd.has_next():
+            rd.read_next()
+        del rd
+        return True
+    except Exception as exc:                       # noqa: BLE001 - degrade, don't crash
+        if path_size(path) > 0:
+            print(f'WARN: could not open written bag for validation ({exc}); '
+                  f'falling back to size>0 check (passed)', file=sys.stderr)
+            return True
+        print(f'ERROR: written bag failed validation and is empty ({exc})', file=sys.stderr)
+        return False
+
+
+def stream(rd, wr, msgcls, a, counters, offsets):
+    """Read every message; correct the two target topics, pass the rest through.
+
+    `wr` may be None (report-only): corrections are counted but nothing is written.
+    """
+    while rd.has_next():
+        topic, data, ts = rd.read_next()
+        if topic == M3_DETECTIONS_TOPIC and not a.no_timing:
+            m = deserialize_message(data, msgcls[topic])
+            stamp_ns = m.header.stamp.sec * NS + m.header.stamp.nanosec
+            n, new_ns, ambiguous = correct_stamp(stamp_ns, ts, a.offset)
+            offsets.append(n)
+            if ambiguous:
+                counters['ambiguous'] += 1
+                print(f'WARN: ping offset {(stamp_ns - ts) / 1e9:+.3f}s is near a '
+                      f'rounding boundary (applied n={n:+d}s)', file=sys.stderr)
+            if n != 0:
+                m.header.stamp.sec = new_ns // NS
+                m.header.stamp.nanosec = new_ns % NS
+                counters['timing'] += 1
+                if wr:
+                    wr.write(topic, serialize_message(m), ts)
+            else:
+                counters['pass'] += 1
+                if wr:
+                    wr.write(topic, data, ts)          # unchanged -> byte passthrough
+        elif topic == TF_STATIC_TOPIC and not a.no_tf:
+            m = deserialize_message(data, msgcls[topic])
+            if rewrite_tf(m):
+                counters['tf'] += 1
+                if wr:
+                    wr.write(topic, serialize_message(m), ts)
+            else:
+                counters['pass'] += 1
+                if wr:
+                    wr.write(topic, data, ts)
+        else:
+            counters['pass'] += 1
+            if wr:
+                wr.write(topic, data, ts)
+
+
+def open_reader(path):
+    """Open a SequentialReader; return (reader, storage_identifier, topics, msgcls)."""
+    rd = SequentialReader()
+    rd.open(StorageOptions(uri=path, storage_id=detect_storage(path)),
+            ConverterOptions('', ''))
+    sid = rd.get_metadata().storage_identifier
+    if not sid:                                        # don't silently change format
+        sys.exit('could not determine input bag storage format')
+    topics = rd.get_all_topics_and_types()
+    msgcls = {t.name: get_message(t.type) for t in topics}
+    return rd, sid, topics, msgcls
+
+
+def write_bag(out, sid, topics, rd, msgcls, a, counters, offsets):
+    """Stream rd into a new bag at `out` (storage `sid`), cleaning up on failure."""
+    wr = SequentialWriter()
+    wr.open(StorageOptions(uri=out, storage_id=sid), ConverterOptions('', ''))
+    for t in topics:                                   # preserve type, QoS, hash
+        wr.create_topic(t)
+    ok = False
+    try:
+        stream(rd, wr, msgcls, a, counters, offsets)
+        ok = True
+    finally:
+        del wr                                         # finalize the writer once
+        if not ok and os.path.exists(out):
+            _remove(out)                               # no partial bag left behind
+
+
+def _remove(path):
+    """Remove a bag path (file or directory)."""
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    elif os.path.exists(path):
+        os.remove(path)
+
+
+def inplace_paths(in_bag):
+    """(temp, backup) paths for an in-place retrofit, matching the input form."""
+    if os.path.isdir(in_bag):
+        return in_bag + '.tmp', in_bag + '.orig'
+    stem = in_bag[:-len('.mcap')] if in_bag.endswith('.mcap') else in_bag
+    suffix = '.mcap' if in_bag.endswith('.mcap') else ''
+    return stem + '.tmp' + suffix, stem + '.orig' + suffix
+
+
+def parse_args(argv=None):
+    """Parse command-line arguments."""
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('in_bag')
+    ap.add_argument('--out', help='write a non-destructive sibling here instead of in-place')
+    ap.add_argument('--report-only', action='store_true',
+                    help='print the offset histogram + counts without writing')
+    ap.add_argument('--offset', type=int, default=None,
+                    help='force this integer-second shift on every M3 ping')
+    ap.add_argument('--no-tf', action='store_true', help='skip the tf_static geometry fix')
+    ap.add_argument('--no-timing', action='store_true', help='skip the detection timing fix')
+    return ap.parse_args(argv)
+
+
+def main(argv=None):
+    """Retrofit one M3 bag (geometry + timing); in-place with backup by default."""
+    a = parse_args(argv)
+    in_bag = a.in_bag.rstrip('/')
+    if not os.path.exists(in_bag):
+        sys.exit(f'input bag not found: {in_bag}')
+
+    counters = {'tf': 0, 'timing': 0, 'pass': 0, 'ambiguous': 0}
+    offsets = []
+
+    # --- report-only: stream without writing -------------------------------
+    if a.report_only:
+        rd, _sid, _topics, msgcls = open_reader(in_bag)
+        stream(rd, None, msgcls, a, counters, offsets)
+        _summary(in_bag, None, counters, offsets, a, wrote=False)
+        # Non-zero exit if any correction WOULD apply (batch "needs fixing?" probe).
+        return 2 if (counters['tf'] or counters['timing']) else 0
+
+    # --- determine output path ---------------------------------------------
+    if a.out:
+        out = a.out.rstrip('/')
+        if os.path.exists(out):
+            sys.exit(f'output already exists: {out}')
+        target = out
+    else:
+        temp, backup = inplace_paths(in_bag)
+        if os.path.exists(temp):
+            sys.exit(f'temp path already exists: {temp}')
+        if os.path.exists(backup):
+            sys.exit(f'backup already exists (refusing to overwrite): {backup}')
+        out = temp
+        target = in_bag
+
+    # --- write --------------------------------------------------------------
+    rd, sid, topics, msgcls = open_reader(in_bag)
+    write_bag(out, sid, topics, rd, msgcls, a, counters, offsets)
+
+    # --- validate then (for in-place) swap in -------------------------------
+    if not validate_written(out, sid):
+        _remove(out)
+        sys.exit('aborting: written bag failed validation; original untouched')
+
+    if not a.out:
+        os.rename(in_bag, backup)                      # preserve original first
+        os.rename(out, in_bag)                         # then move corrected into place
+        _summary(in_bag, backup, counters, offsets, a, wrote=True)
+    else:
+        _summary(target, None, counters, offsets, a, wrote=True)
+    return 0
+
+
+def _summary(target, backup, counters, offsets, a, wrote):
+    """Print the histogram and a one-line outcome."""
+    print('integer-second offset histogram (M3 detections):')
+    print_histogram(build_histogram(offsets))
+    verb = 'wrote' if wrote else 'would correct'
+    print(f'{verb}: {counters["tf"]} tf_static, {counters["timing"]} timing; '
+          f'{counters["pass"]} passthrough; {counters["ambiguous"]} ambiguous-band WARN')
+    if wrote:
+        print(f'  -> {target}')
+        if backup:
+            print(f'  backup: {backup}')
+    if not a.no_timing and not a.no_tf and not counters['tf'] and not counters['timing']:
+        print('NOTE: nothing matched -- no /tf_static bizzy/m3 frame and no M3 '
+              'detection corrections. Is this an M3 bag?', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bizzyboat_project11/scripts/retrofit_m3_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_m3_bag.py
@@ -32,33 +32,39 @@ Two independent corrections, each toggleable:
     left untouched. The bag receive time only needs ±0.5 s accuracy to pick the
     right integer; healthy (~0.04 s) and bad (~6.03 s) offsets are both far from a
     0.5 s rounding boundary. A WARN is emitted for any ping whose fractional
-    offset lands in an ambiguous band (|frac| in [0.3, 0.7]).
+    offset is within ~0.2 s of a half-second (frac >= 0.3, where frac in [0, 0.5]).
 
 The integer-offset HISTOGRAM is always printed (e.g. "0 s: 412, 6 s: 1805") so
-the step structure is visible and the PPS assumption is validated. Use
---report-only to see it without writing (exits non-zero if any correction would
-apply, so it doubles as a "does this bag need fixing?" probe in batch scripts).
+the step structure is visible and the PPS assumption is validated. It always
+records the MEASURED integer offset, even under --offset, so the diagnostic stays
+honest when a manual shift is forced. Use --report-only to see it without writing
+(exits non-zero if any correction would apply, so it doubles as a "does this bag
+need fixing?" probe in batch scripts).
 
 File handling (default: in-place with backup) — downstream paths reference the
 original bag name, so the corrected bag takes the original name and the original
 is preserved as a backup. Persist-then-rename: the corrected bag is written to a
 temp path and VALIDATED (open + read one message) BEFORE the original is renamed
-to `<name>.orig` and the temp moved into place, so a failed/partial write never
-destroys the original. `--out PATH` instead writes a non-destructive sibling
-(the retrofit_sidescan_bag.py style) and never touches the input.
+to `<name>.orig` and the corrected bag moved into place. A failed/partial write
+never replaces the original; if the final move fails the original is rolled back
+from the backup. `--out PATH` instead writes a non-destructive sibling and never
+touches the input.
+
+Bag form is preserved across the in-place retrofit:
+  * directory bag in  -> directory bag out (backup `<name>.orig`)
+  * bare single .mcap in (boat bags) -> bare single .mcap out. rosbag2's writer
+    only emits *directory* bags, so for a bare input the single inner `.mcap`
+    segment is extracted to the original name and the scratch directory dropped
+    (a bare .mcap carries its own schemas/channels; the rosbag2 metadata.yaml is
+    not part of the bare form). A multi-segment write cannot be reduced to one
+    bare file -> the script aborts and asks for --out.
 
 Offline read/write (rosbag2), no replay. Requires a sourced ROS 2 (jazzy) env.
 Storage format + QoS are preserved (writer reuses the reader's TopicMetadata).
 
-NOTE on bare .mcap: boat bags are often bare single `.mcap` files (not rosbag2
-directories). This script detects the input form and opens bare files with
-storage_id='mcap'. rosbag2's writer may emit a *directory* bag for mcap output
-even from a bare-file input; the result is still correct and reloadable, but
-smoke-test the bare-file round-trip on a real boat bag before bulk use.
-
 Usage:
     python3 retrofit_m3_bag.py <in_bag> [--out OUT] [--report-only] \
-        [--offset N] [--no-tf] [--no-timing]
+        [--offset N] [--no-tf] [--no-timing] [--force]
 
 See #342 / #338 / #339, and retrofit_sidescan_bag.py (the precedent).
 """
@@ -84,23 +90,26 @@ TF_STATIC_TOPIC = '/tf_static'
 M3_FRAME = 'bizzy/m3'
 M3_XYZ = (-0.29, 0.0, -0.28)   # measured 2026-06-27 (#339); supersedes (-0.23,0,-0.145)
 
-# Fractional offset band (seconds either side of a half-second) that makes the
-# round-to-nearest-second ambiguous; pings here get a WARN.
-AMBIG_LO, AMBIG_HI = 0.3, 0.7
+# A ping whose fractional offset is this close to a half-second makes the
+# round-to-nearest-second ambiguous; such pings get a WARN. `frac` ranges over
+# [0, 0.5], so this is "within (0.5 - 0.3) = 0.2 s of a half-second boundary".
+AMBIG_THRESHOLD = 0.3
 
 
 def correct_stamp(stamp_ns, recv_ns, forced=None):
-    """Integer-second stamp correction, preserving the sub-second fraction.
+    """Compute the integer-second stamp correction, preserving the fraction.
 
-    Returns (n, new_stamp_ns, ambiguous): the whole-second shift applied, the
-    corrected stamp in ns, and whether the raw fractional offset was in the
-    ambiguous rounding band. `forced` overrides the measured integer (--offset).
+    Returns (measured_n, applied_n, new_stamp_ns, ambiguous): the integer offset
+    measured against the receive time (always, for the histogram), the integer
+    actually applied (== forced when --offset is given), the corrected stamp in
+    ns, and whether the raw fractional offset was in the ambiguous rounding band.
     """
     offset_s = (stamp_ns - recv_ns) / 1e9
-    n = forced if forced is not None else round(offset_s)
-    frac = abs(offset_s - round(offset_s))
-    ambiguous = AMBIG_LO <= frac <= AMBIG_HI
-    return n, stamp_ns - n * NS, ambiguous
+    measured_n = round(offset_s)
+    frac = abs(offset_s - measured_n)              # in [0, 0.5]
+    ambiguous = frac >= AMBIG_THRESHOLD
+    applied_n = forced if forced is not None else measured_n
+    return measured_n, applied_n, stamp_ns - applied_n * NS, ambiguous
 
 
 def build_histogram(offsets):
@@ -136,7 +145,7 @@ def rewrite_tf(msg):
 
 
 def detect_storage(path):
-    """Storage id for opening: 'mcap' for a bare .mcap file, '' (auto) for a dir."""
+    """Return the storage id for opening: 'mcap' for a bare .mcap file, '' for a dir."""
     if os.path.isdir(path):
         return ''
     if path.endswith('.mcap'):
@@ -144,37 +153,24 @@ def detect_storage(path):
     return ''
 
 
-def path_size(path):
-    """Total bytes of a bag file or directory (0 if missing)."""
-    if os.path.isfile(path):
-        return os.path.getsize(path)
-    total = 0
-    for root, _dirs, files in os.walk(path):
-        for f in files:
-            total += os.path.getsize(os.path.join(root, f))
-    return total
+def validate_written(path):
+    """Confirm a freshly-written bag is loadable: open and read one message.
 
-
-def validate_written(path, storage_id):
-    """Confirm a freshly-written bag is loadable before we trust it.
-
-    Opens a SequentialReader and reads one message (an empty-but-openable bag is
-    still valid). On any failure, falls back to a size>0 heuristic and WARNs that
-    validation was degraded. Returns True if the output is considered usable.
+    Returns True if the bag opens and (if non-empty) yields a message. An
+    empty-but-openable bag is still valid. Returns False on any failure -- no
+    size>0 fallback, because in destructive in-place mode a validation failure
+    must abort rather than be papered over.
     """
     try:
         rd = SequentialReader()
-        rd.open(StorageOptions(uri=path, storage_id=storage_id), ConverterOptions('', ''))
+        rd.open(StorageOptions(uri=path, storage_id=detect_storage(path)),
+                ConverterOptions('', ''))
         if rd.has_next():
             rd.read_next()
         del rd
         return True
-    except Exception as exc:                       # noqa: BLE001 - degrade, don't crash
-        if path_size(path) > 0:
-            print(f'WARN: could not open written bag for validation ({exc}); '
-                  f'falling back to size>0 check (passed)', file=sys.stderr)
-            return True
-        print(f'ERROR: written bag failed validation and is empty ({exc})', file=sys.stderr)
+    except Exception as exc:                       # noqa: BLE001 - report + fail closed
+        print(f'ERROR: written bag failed validation: {exc}', file=sys.stderr)
         return False
 
 
@@ -182,19 +178,20 @@ def stream(rd, wr, msgcls, a, counters, offsets):
     """Read every message; correct the two target topics, pass the rest through.
 
     `wr` may be None (report-only): corrections are counted but nothing is written.
+    The histogram (`offsets`) always records the MEASURED integer offset.
     """
     while rd.has_next():
         topic, data, ts = rd.read_next()
         if topic == M3_DETECTIONS_TOPIC and not a.no_timing:
             m = deserialize_message(data, msgcls[topic])
             stamp_ns = m.header.stamp.sec * NS + m.header.stamp.nanosec
-            n, new_ns, ambiguous = correct_stamp(stamp_ns, ts, a.offset)
-            offsets.append(n)
+            measured_n, applied_n, new_ns, ambiguous = correct_stamp(stamp_ns, ts, a.offset)
+            offsets.append(measured_n)
             if ambiguous:
                 counters['ambiguous'] += 1
                 print(f'WARN: ping offset {(stamp_ns - ts) / 1e9:+.3f}s is near a '
-                      f'rounding boundary (applied n={n:+d}s)', file=sys.stderr)
-            if n != 0:
+                      f'rounding boundary (measured n={measured_n:+d}s)', file=sys.stderr)
+            if applied_n != 0:
                 m.header.stamp.sec = new_ns // NS
                 m.header.stamp.nanosec = new_ns % NS
                 counters['timing'] += 1
@@ -258,12 +255,55 @@ def _remove(path):
 
 
 def inplace_paths(in_bag):
-    """(temp, backup) paths for an in-place retrofit, matching the input form."""
+    """Return (temp, backup) paths for an in-place retrofit, matching input form."""
     if os.path.isdir(in_bag):
         return in_bag + '.tmp', in_bag + '.orig'
     stem = in_bag[:-len('.mcap')] if in_bag.endswith('.mcap') else in_bag
     suffix = '.mcap' if in_bag.endswith('.mcap') else ''
     return stem + '.tmp' + suffix, stem + '.orig' + suffix
+
+
+def _inner_mcaps(bag_dir):
+    """Return the .mcap segment filenames inside a rosbag2 directory bag, sorted."""
+    return sorted(f for f in os.listdir(bag_dir) if f.endswith('.mcap'))
+
+
+def _swap_in_place(in_bag, temp, backup, in_is_dir):
+    """Move the validated `temp` bag to `in_bag`, preserving the input form.
+
+    Renames the original to `backup` first, then installs the corrected bag. On a
+    failed install the original is rolled back from `backup`. For a bare-file
+    input the single inner `.mcap` segment is extracted so the output stays a bare
+    file; a multi-segment write aborts (cannot reduce to one bare file).
+    """
+    if not in_is_dir:
+        inner = _inner_mcaps(temp)
+        if len(inner) != 1:
+            _remove(temp)
+            sys.exit(f'cannot reduce a {len(inner)}-segment write to a bare .mcap; '
+                     f'rerun with --out to keep a directory bag')
+
+    os.rename(in_bag, backup)                          # preserve the original first
+    try:
+        if in_is_dir:
+            os.rename(temp, in_bag)                    # dir -> dir
+        else:
+            shutil.move(os.path.join(temp, _inner_mcaps(temp)[0]), in_bag)  # bare -> bare
+            _remove(temp)                              # drop the scratch dir + metadata.yaml
+    except Exception:
+        # Roll the original back so we never leave the bag only at `.orig`.
+        if os.path.exists(in_bag):
+            _remove(in_bag)
+        os.rename(backup, in_bag)
+        _remove(temp)
+        raise
+
+    if not validate_written(in_bag):
+        # Corrected bag is bad after the move; restore the original.
+        _remove(in_bag)
+        os.rename(backup, in_bag)
+        sys.exit(f'aborting: corrected bag failed post-move validation; original '
+                 f'restored from {backup}')
 
 
 def parse_args(argv=None):
@@ -277,6 +317,8 @@ def parse_args(argv=None):
                     help='force this integer-second shift on every M3 ping')
     ap.add_argument('--no-tf', action='store_true', help='skip the tf_static geometry fix')
     ap.add_argument('--no-timing', action='store_true', help='skip the detection timing fix')
+    ap.add_argument('--force', action='store_true',
+                    help='remove a stale leftover .tmp bag from an interrupted run')
     return ap.parse_args(argv)
 
 
@@ -286,6 +328,7 @@ def main(argv=None):
     in_bag = a.in_bag.rstrip('/')
     if not os.path.exists(in_bag):
         sys.exit(f'input bag not found: {in_bag}')
+    in_is_dir = os.path.isdir(in_bag)
 
     counters = {'tf': 0, 'timing': 0, 'pass': 0, 'ambiguous': 0}
     offsets = []
@@ -294,46 +337,51 @@ def main(argv=None):
     if a.report_only:
         rd, _sid, _topics, msgcls = open_reader(in_bag)
         stream(rd, None, msgcls, a, counters, offsets)
+        del rd
         _summary(in_bag, None, counters, offsets, a, wrote=False)
         # Non-zero exit if any correction WOULD apply (batch "needs fixing?" probe).
         return 2 if (counters['tf'] or counters['timing']) else 0
 
-    # --- determine output path ---------------------------------------------
+    # --- non-destructive sibling (--out) -----------------------------------
     if a.out:
         out = a.out.rstrip('/')
         if os.path.exists(out):
             sys.exit(f'output already exists: {out}')
-        target = out
-    else:
-        temp, backup = inplace_paths(in_bag)
-        if os.path.exists(temp):
-            sys.exit(f'temp path already exists: {temp}')
-        if os.path.exists(backup):
-            sys.exit(f'backup already exists (refusing to overwrite): {backup}')
-        out = temp
-        target = in_bag
+        rd, sid, topics, msgcls = open_reader(in_bag)
+        write_bag(out, sid, topics, rd, msgcls, a, counters, offsets)
+        del rd
+        if not validate_written(out):
+            _remove(out)
+            sys.exit('aborting: written bag failed validation (input untouched)')
+        _summary(out, None, counters, offsets, a, wrote=True)
+        return 0
 
-    # --- write --------------------------------------------------------------
+    # --- in-place with backup ----------------------------------------------
+    temp, backup = inplace_paths(in_bag)
+    if os.path.exists(temp):
+        if a.force:
+            _remove(temp)
+        else:
+            sys.exit(f'temp path already exists (stale interrupted run?): {temp}\n'
+                     f'  inspect it, or rerun with --force to remove it')
+    if os.path.exists(backup):
+        sys.exit(f'backup already exists (refusing to overwrite): {backup}')
+
     rd, sid, topics, msgcls = open_reader(in_bag)
-    write_bag(out, sid, topics, rd, msgcls, a, counters, offsets)
-
-    # --- validate then (for in-place) swap in -------------------------------
-    if not validate_written(out, sid):
-        _remove(out)
+    write_bag(temp, sid, topics, rd, msgcls, a, counters, offsets)
+    del rd                                             # release input before renaming
+    if not validate_written(temp):
+        _remove(temp)
         sys.exit('aborting: written bag failed validation; original untouched')
 
-    if not a.out:
-        os.rename(in_bag, backup)                      # preserve original first
-        os.rename(out, in_bag)                         # then move corrected into place
-        _summary(in_bag, backup, counters, offsets, a, wrote=True)
-    else:
-        _summary(target, None, counters, offsets, a, wrote=True)
+    _swap_in_place(in_bag, temp, backup, in_is_dir)
+    _summary(in_bag, backup, counters, offsets, a, wrote=True)
     return 0
 
 
 def _summary(target, backup, counters, offsets, a, wrote):
     """Print the histogram and a one-line outcome."""
-    print('integer-second offset histogram (M3 detections):')
+    print('integer-second offset histogram (M3 detections, measured):')
     print_histogram(build_histogram(offsets))
     verb = 'wrote' if wrote else 'would correct'
     print(f'{verb}: {counters["tf"]} tf_static, {counters["timing"]} timing; '

--- a/bizzyboat_project11/test/test_retrofit_m3_bag.py
+++ b/bizzyboat_project11/test/test_retrofit_m3_bag.py
@@ -6,15 +6,15 @@ use lightweight fakes and need no ROS messages. Integration tests build a real
 rosbag2 bag and round-trip it through main(); they request the `msgs` fixture,
 which skips them if the message packages aren't on the path.
 
-Note: rosbag2's SequentialWriter always emits a *directory* bag (metadata.yaml +
-<name>_0.mcap), even for a .mcap URI, so the integration fixtures are directory
-bags. The bare-single-.mcap input form (boat bags) is covered by the
-detect_storage / inplace_paths pure tests; bare-file *reading* is exercised by
-the boat in practice and confirmed to work with storage_id='mcap'.
+rosbag2's SequentialWriter always emits a *directory* bag (metadata.yaml +
+<name>_0.mcap), even for a .mcap URI. Directory-bag round-trips use that form
+directly; the bare-single-.mcap input form (boat bags) is built by extracting a
+dir bag's inner segment and is covered by test_inplace_bare_mcap_stays_bare.
 """
 import importlib.util
 import os
 import pathlib
+import shutil
 import types
 
 import pytest
@@ -38,21 +38,23 @@ NS = rm.NS
 # ======================================================================
 
 def test_correct_stamp_healthy():
-    """~0.04 s offset -> n=0, stamp unchanged, not ambiguous."""
+    """A ~0.04 s offset yields n=0, stamp unchanged, not ambiguous."""
     recv = 100 * NS
     stamp = recv + int(0.04 * NS)
-    n, new_ns, ambiguous = rm.correct_stamp(stamp, recv)
-    assert n == 0
+    measured, applied, new_ns, ambiguous = rm.correct_stamp(stamp, recv)
+    assert measured == 0
+    assert applied == 0
     assert new_ns == stamp
     assert ambiguous is False
 
 
 def test_correct_stamp_six_second_preserves_fraction():
-    """~6.03 s offset -> n=6, 6 whole seconds removed, sub-second fraction kept."""
+    """A ~6.03 s offset removes 6 whole seconds, keeping the sub-second fraction."""
     recv = 100 * NS
     stamp = recv + int(6.03 * NS)
-    n, new_ns, ambiguous = rm.correct_stamp(stamp, recv)
-    assert n == 6
+    measured, applied, new_ns, ambiguous = rm.correct_stamp(stamp, recv)
+    assert measured == 6
+    assert applied == 6
     assert new_ns == stamp - 6 * NS
     assert new_ns % NS == stamp % NS          # PPS-disciplined fraction untouched
     assert ambiguous is False
@@ -62,8 +64,9 @@ def test_correct_stamp_seven_second_step():
     """A later 7 s step is handled per-message (multi-step drift)."""
     recv = 200 * NS
     stamp = recv + int(7.02 * NS)
-    n, new_ns, _ = rm.correct_stamp(stamp, recv)
-    assert n == 7
+    measured, applied, new_ns, _ = rm.correct_stamp(stamp, recv)
+    assert measured == 7
+    assert applied == 7
     assert new_ns == stamp - 7 * NS
 
 
@@ -71,16 +74,27 @@ def test_correct_stamp_ambiguous_band():
     """A ~0.5 s offset lands in the ambiguous rounding band -> WARN flag."""
     recv = 100 * NS
     stamp = recv + int(0.5 * NS)
-    _n, _new, ambiguous = rm.correct_stamp(stamp, recv)
+    measured, _applied, _new, ambiguous = rm.correct_stamp(stamp, recv)
+    assert ambiguous is True
+    assert measured == 0                       # round(0.5) -> 0 (banker's)
+
+
+def test_correct_stamp_half_rounds_to_even():
+    """Exactly n+0.5 rounds to even (round(2.5) -> 2) and flags ambiguous."""
+    recv = 100 * NS
+    stamp = recv + 2 * NS + NS // 2            # exactly +2.5 s
+    measured, _applied, _new, ambiguous = rm.correct_stamp(stamp, recv)
+    assert measured == 2
     assert ambiguous is True
 
 
-def test_correct_stamp_forced_override():
-    """--offset forces the integer regardless of the measured value."""
+def test_correct_stamp_forced_override_keeps_measured():
+    """--offset forces the applied shift but the measured value is preserved."""
     recv = 100 * NS
     stamp = recv + int(6.03 * NS)
-    n, new_ns, _ = rm.correct_stamp(stamp, recv, forced=7)
-    assert n == 7
+    measured, applied, new_ns, _ = rm.correct_stamp(stamp, recv, forced=7)
+    assert measured == 6                       # histogram stays honest
+    assert applied == 7
     assert new_ns == stamp - 7 * NS
 
 
@@ -90,7 +104,7 @@ def test_build_histogram():
 
 
 def _fake_tf(*child_frames):
-    """A duck-typed TFMessage with the fields rewrite_tf touches."""
+    """Return a duck-typed TFMessage with the fields rewrite_tf touches."""
     transforms = []
     for cf in child_frames:
         transforms.append(types.SimpleNamespace(
@@ -149,7 +163,7 @@ def test_inplace_paths_bare_mcap(tmp_path):
 
 
 # ======================================================================
-# Integration tests (real rosbag2 directory-bag round-trip)
+# Integration tests (real rosbag2 bag round-trip)
 # ======================================================================
 
 @pytest.fixture
@@ -162,7 +176,7 @@ def msgs():
 
 
 def _topic_md(name, type_str):
-    """TopicMetadata for the installed rosbag2 (jazzy: id first positional)."""
+    """Build a TopicMetadata for the installed rosbag2 (jazzy: id first positional)."""
     return TopicMetadata(0, name, type_str, 'cdr')
 
 
@@ -211,6 +225,18 @@ def _make_bag(path, msgs, *, detection_offsets, tf_old=True):
     del wr
 
 
+def _make_bare_mcap(tmp_path, msgs, name, **kw):
+    """Build a genuine bare single .mcap file by extracting a dir bag's segment."""
+    src = tmp_path / 'src'
+    _make_bag(src, msgs, **kw)
+    inner = [f for f in os.listdir(src) if f.endswith('.mcap')]
+    assert len(inner) == 1
+    bare = tmp_path / name
+    shutil.move(str(src / inner[0]), str(bare))
+    shutil.rmtree(src)
+    return bare
+
+
 def _read_all(path):
     """Return (storage_id, {topic: TopicMetadata}, [(topic, data, ts)])."""
     rd = SequentialReader()
@@ -249,9 +275,25 @@ def test_inplace_creates_backup_and_corrects(tmp_path, msgs):
     m3 = [t for t in msg.transforms if t.child_frame_id == rm.M3_FRAME][0]
     assert (m3.transform.translation.x, m3.transform.translation.y,
             m3.transform.translation.z) == rm.M3_XYZ
-    # Unrelated frame untouched.
     other = [t for t in msg.transforms if t.child_frame_id == 'bizzy/imu'][0]
-    assert other.transform.translation.x == 1.0
+    assert other.transform.translation.x == 1.0       # unrelated frame untouched
+
+
+def test_inplace_bare_mcap_stays_bare(tmp_path, msgs):
+    """A bare single .mcap input yields a bare .mcap output (not a directory)."""
+    bare = _make_bare_mcap(tmp_path, msgs, 'boat.mcap', detection_offsets=[6.03])
+    assert bare.is_file()
+    rc = rm.main([str(bare)])
+    assert rc == 0
+    assert (tmp_path / 'boat.mcap').is_file()          # still a bare FILE
+    assert (tmp_path / 'boat.orig.mcap').is_file()     # backup is the original file
+    geometry = msgs[0]
+    _sid, _tmd, out = _read_all(tmp_path / 'boat.mcap')
+    det = [m for m in out if m[0] == rm.M3_DETECTIONS_TOPIC]
+    assert len(det) == 1
+    ps = deserialize_message(det[0][1], geometry.PointStamped)
+    stamp_ns = ps.header.stamp.sec * NS + ps.header.stamp.nanosec
+    assert abs((stamp_ns - det[0][2]) / 1e9) < 0.5
 
 
 def test_storage_and_metadata_preserved(tmp_path, msgs):
@@ -318,9 +360,8 @@ def test_report_only_clean_bag_exit_zero(tmp_path, msgs):
 
 def test_only_target_topic_timed(tmp_path, msgs):
     """Timing correction touches only M3_DETECTIONS_TOPIC, not other headers."""
-    geometry, tf2, std = msgs
+    geometry, _tf2, _std = msgs
     bag = tmp_path / 'm3bag'
-    # A non-M3 PointStamped topic carrying a +6 s stamp must be left untouched.
     wr = SequentialWriter()
     wr.open(StorageOptions(uri=str(bag), storage_id='mcap'), ConverterOptions('', ''))
     wr.create_topic(_topic_md('/other/stamped', 'geometry_msgs/msg/PointStamped'))
@@ -338,3 +379,18 @@ def test_only_target_topic_timed(tmp_path, msgs):
     ps_out = deserialize_message(msgs_out[0][1], geometry.PointStamped)
     out_ns = ps_out.header.stamp.sec * NS + ps_out.header.stamp.nanosec
     assert out_ns == stamp_ns                          # unchanged (not the M3 topic)
+
+
+def test_stale_temp_blocks_then_force_clears(tmp_path, msgs):
+    """A leftover .tmp blocks an in-place run; --force clears it."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[6.03])
+    stale = tmp_path / 'm3bag.tmp'
+    stale.mkdir()
+    (stale / 'junk').write_text('x')
+    with pytest.raises(SystemExit):
+        rm.main([str(bag)])
+    assert stale.exists()                              # untouched without --force
+    rc = rm.main([str(bag), '--force'])
+    assert rc == 0
+    assert (tmp_path / 'm3bag.orig').exists()

--- a/bizzyboat_project11/test/test_retrofit_m3_bag.py
+++ b/bizzyboat_project11/test/test_retrofit_m3_bag.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Unit tests for retrofit_m3_bag.py (#342).
+
+Pure-logic tests (integer-second rounding, histogram, tf rewrite, path naming)
+use lightweight fakes and need no ROS messages. Integration tests build a real
+rosbag2 bag and round-trip it through main(); they request the `msgs` fixture,
+which skips them if the message packages aren't on the path.
+
+Note: rosbag2's SequentialWriter always emits a *directory* bag (metadata.yaml +
+<name>_0.mcap), even for a .mcap URI, so the integration fixtures are directory
+bags. The bare-single-.mcap input form (boat bags) is covered by the
+detect_storage / inplace_paths pure tests; bare-file *reading* is exercised by
+the boat in practice and confirmed to work with storage_id='mcap'.
+"""
+import importlib.util
+import os
+import pathlib
+import types
+
+import pytest
+
+from rclpy.serialization import deserialize_message, serialize_message
+from rosbag2_py import (ConverterOptions, SequentialReader, SequentialWriter,
+                        StorageOptions, TopicMetadata)
+
+# --- load the script as a module ------------------------------------------
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPT = HERE.parent / 'scripts' / 'retrofit_m3_bag.py'
+_spec = importlib.util.spec_from_file_location('retrofit_m3_bag', SCRIPT)
+rm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rm)
+
+NS = rm.NS
+
+
+# ======================================================================
+# Pure-logic tests (no ROS messages)
+# ======================================================================
+
+def test_correct_stamp_healthy():
+    """~0.04 s offset -> n=0, stamp unchanged, not ambiguous."""
+    recv = 100 * NS
+    stamp = recv + int(0.04 * NS)
+    n, new_ns, ambiguous = rm.correct_stamp(stamp, recv)
+    assert n == 0
+    assert new_ns == stamp
+    assert ambiguous is False
+
+
+def test_correct_stamp_six_second_preserves_fraction():
+    """~6.03 s offset -> n=6, 6 whole seconds removed, sub-second fraction kept."""
+    recv = 100 * NS
+    stamp = recv + int(6.03 * NS)
+    n, new_ns, ambiguous = rm.correct_stamp(stamp, recv)
+    assert n == 6
+    assert new_ns == stamp - 6 * NS
+    assert new_ns % NS == stamp % NS          # PPS-disciplined fraction untouched
+    assert ambiguous is False
+
+
+def test_correct_stamp_seven_second_step():
+    """A later 7 s step is handled per-message (multi-step drift)."""
+    recv = 200 * NS
+    stamp = recv + int(7.02 * NS)
+    n, new_ns, _ = rm.correct_stamp(stamp, recv)
+    assert n == 7
+    assert new_ns == stamp - 7 * NS
+
+
+def test_correct_stamp_ambiguous_band():
+    """A ~0.5 s offset lands in the ambiguous rounding band -> WARN flag."""
+    recv = 100 * NS
+    stamp = recv + int(0.5 * NS)
+    _n, _new, ambiguous = rm.correct_stamp(stamp, recv)
+    assert ambiguous is True
+
+
+def test_correct_stamp_forced_override():
+    """--offset forces the integer regardless of the measured value."""
+    recv = 100 * NS
+    stamp = recv + int(6.03 * NS)
+    n, new_ns, _ = rm.correct_stamp(stamp, recv, forced=7)
+    assert n == 7
+    assert new_ns == stamp - 7 * NS
+
+
+def test_build_histogram():
+    assert rm.build_histogram([0, 0, 6, 6, 6]) == {0: 2, 6: 3}
+    assert rm.build_histogram([]) == {}
+
+
+def _fake_tf(*child_frames):
+    """A duck-typed TFMessage with the fields rewrite_tf touches."""
+    transforms = []
+    for cf in child_frames:
+        transforms.append(types.SimpleNamespace(
+            child_frame_id=cf,
+            transform=types.SimpleNamespace(
+                translation=types.SimpleNamespace(x=0.0, y=0.0, z=0.0))))
+    return types.SimpleNamespace(transforms=transforms)
+
+
+def test_rewrite_tf_target_frame():
+    msg = _fake_tf('bizzy/m3')
+    assert rm.rewrite_tf(msg) is True
+    tr = msg.transforms[0].transform.translation
+    assert (tr.x, tr.y, tr.z) == rm.M3_XYZ
+
+
+def test_rewrite_tf_other_frame_untouched():
+    msg = _fake_tf('bizzy/base_link')
+    assert rm.rewrite_tf(msg) is False
+    tr = msg.transforms[0].transform.translation
+    assert (tr.x, tr.y, tr.z) == (0.0, 0.0, 0.0)
+
+
+def test_rewrite_tf_idempotent():
+    """Re-running sets the same value and still reports changed (field is set)."""
+    msg = _fake_tf('bizzy/m3')
+    rm.rewrite_tf(msg)
+    assert rm.rewrite_tf(msg) is True
+    tr = msg.transforms[0].transform.translation
+    assert (tr.x, tr.y, tr.z) == rm.M3_XYZ
+
+
+def test_detect_storage(tmp_path):
+    bare = tmp_path / 'foo.mcap'
+    bare.write_bytes(b'\x00')
+    assert rm.detect_storage(str(bare)) == 'mcap'
+    d = tmp_path / 'bagdir'
+    d.mkdir()
+    assert rm.detect_storage(str(d)) == ''
+
+
+def test_inplace_paths_directory(tmp_path):
+    d = tmp_path / 'bag'
+    d.mkdir()
+    temp, backup = rm.inplace_paths(str(d))
+    assert temp == str(d) + '.tmp'
+    assert backup == str(d) + '.orig'
+
+
+def test_inplace_paths_bare_mcap(tmp_path):
+    f = tmp_path / 'm3.mcap'
+    f.write_bytes(b'\x00')
+    temp, backup = rm.inplace_paths(str(f))
+    assert temp == str(tmp_path / 'm3.tmp.mcap')
+    assert backup == str(tmp_path / 'm3.orig.mcap')
+
+
+# ======================================================================
+# Integration tests (real rosbag2 directory-bag round-trip)
+# ======================================================================
+
+@pytest.fixture
+def msgs():
+    """Message classes for fixtures; skip integration tests if unavailable."""
+    geometry = pytest.importorskip('geometry_msgs.msg')
+    tf2 = pytest.importorskip('tf2_msgs.msg')
+    std = pytest.importorskip('std_msgs.msg')
+    return geometry, tf2, std
+
+
+def _topic_md(name, type_str):
+    """TopicMetadata for the installed rosbag2 (jazzy: id first positional)."""
+    return TopicMetadata(0, name, type_str, 'cdr')
+
+
+def _make_bag(path, msgs, *, detection_offsets, tf_old=True):
+    """Write a synthetic M3 directory bag.
+
+    detection_offsets: list of float seconds (header.stamp − receive_time) per ping.
+    Writes the M3 detections topic (PointStamped — header carries the stamp), a
+    /tf_static with a bizzy/m3 frame at the OLD offset + an unrelated frame, and a
+    passthrough /chatter topic.
+    """
+    geometry, tf2, std = msgs
+    wr = SequentialWriter()
+    wr.open(StorageOptions(uri=str(path), storage_id='mcap'), ConverterOptions('', ''))
+    wr.create_topic(_topic_md(rm.M3_DETECTIONS_TOPIC, 'geometry_msgs/msg/PointStamped'))
+    wr.create_topic(_topic_md(rm.TF_STATIC_TOPIC, 'tf2_msgs/msg/TFMessage'))
+    wr.create_topic(_topic_md('/chatter', 'std_msgs/msg/String'))
+
+    recv0 = 1000 * NS
+    for i, off in enumerate(detection_offsets):
+        recv = recv0 + i * NS
+        ps = geometry.PointStamped()
+        stamp_ns = recv + int(round(off * NS))
+        ps.header.stamp.sec = stamp_ns // NS
+        ps.header.stamp.nanosec = stamp_ns % NS
+        ps.header.frame_id = rm.M3_FRAME
+        wr.write(rm.M3_DETECTIONS_TOPIC, serialize_message(ps), recv)
+
+    tfm = tf2.TFMessage()
+    t_m3 = geometry.TransformStamped()
+    t_m3.header.frame_id = 'bizzy/base_link'
+    t_m3.child_frame_id = rm.M3_FRAME
+    if tf_old:
+        t_m3.transform.translation.x = -0.23
+        t_m3.transform.translation.z = -0.145
+    t_other = geometry.TransformStamped()
+    t_other.header.frame_id = 'bizzy/base_link'
+    t_other.child_frame_id = 'bizzy/imu'
+    t_other.transform.translation.x = 1.0
+    tfm.transforms = [t_m3, t_other]
+    wr.write(rm.TF_STATIC_TOPIC, serialize_message(tfm), recv0)
+
+    s = std.String()
+    s.data = 'hello'
+    wr.write('/chatter', serialize_message(s), recv0)
+    del wr
+
+
+def _read_all(path):
+    """Return (storage_id, {topic: TopicMetadata}, [(topic, data, ts)])."""
+    rd = SequentialReader()
+    rd.open(StorageOptions(uri=str(path), storage_id=rm.detect_storage(str(path))),
+            ConverterOptions('', ''))
+    sid = rd.get_metadata().storage_identifier
+    tmd = {t.name: t for t in rd.get_all_topics_and_types()}
+    out = []
+    while rd.has_next():
+        out.append(rd.read_next())
+    del rd
+    return sid, tmd, out
+
+
+def test_inplace_creates_backup_and_corrects(tmp_path, msgs):
+    """Default mode: corrected bag at original name, original preserved as .orig."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[0.04, 6.03, 6.03])
+    rc = rm.main([str(bag)])
+    assert rc == 0
+    assert (tmp_path / 'm3bag.orig').exists()
+    assert bag.exists()
+
+    geometry = msgs[0]
+    _sid, _tmd, out = _read_all(bag)
+    det = [m for m in out if m[0] == rm.M3_DETECTIONS_TOPIC]
+    assert len(det) == 3
+    for (_topic, data, ts) in det:
+        ps = deserialize_message(data, geometry.PointStamped)
+        stamp_ns = ps.header.stamp.sec * NS + ps.header.stamp.nanosec
+        assert abs((stamp_ns - ts) / 1e9) < 0.5       # all realigned to ~receive time
+
+    tf2 = msgs[1]
+    tfm = [m for m in out if m[0] == rm.TF_STATIC_TOPIC][0]
+    msg = deserialize_message(tfm[1], tf2.TFMessage)
+    m3 = [t for t in msg.transforms if t.child_frame_id == rm.M3_FRAME][0]
+    assert (m3.transform.translation.x, m3.transform.translation.y,
+            m3.transform.translation.z) == rm.M3_XYZ
+    # Unrelated frame untouched.
+    other = [t for t in msg.transforms if t.child_frame_id == 'bizzy/imu'][0]
+    assert other.transform.translation.x == 1.0
+
+
+def test_storage_and_metadata_preserved(tmp_path, msgs):
+    """storage_id + every topic's TopicMetadata round-trip unchanged."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[6.03])
+    in_sid, in_tmd, _ = _read_all(bag)
+    rm.main([str(bag)])
+    out_sid, out_tmd, _ = _read_all(bag)
+
+    assert out_sid == in_sid
+    assert set(out_tmd) == set(in_tmd)
+    for name, md_in in in_tmd.items():
+        md_out = out_tmd[name]
+        assert md_out.type == md_in.type
+        assert md_out.serialization_format == md_in.serialization_format
+        assert md_out.offered_qos_profiles == md_in.offered_qos_profiles
+        assert md_out.type_description_hash == md_in.type_description_hash
+
+
+def test_out_mode_leaves_input_untouched(tmp_path, msgs):
+    """--out writes a sibling and never modifies the input."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[6.03])
+    _sid, _tmd, before = _read_all(bag)
+    out = tmp_path / 'fixed'
+    rm.main([str(bag), '--out', str(out)])
+    assert out.exists()
+    assert not (tmp_path / 'm3bag.orig').exists()
+    _sid2, _tmd2, after = _read_all(bag)
+    assert before == after                             # input unchanged
+
+
+def test_passthrough_only(tmp_path, msgs):
+    """--no-tf --no-timing: every message passes through byte-identical."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[6.03])
+    _sid, _tmd, before = _read_all(bag)
+    out = tmp_path / 'pass'
+    rm.main([str(bag), '--out', str(out), '--no-tf', '--no-timing'])
+    _sid2, _tmd2, after = _read_all(out)
+    assert [(t, d) for (t, d, _) in before] == [(t, d) for (t, d, _) in after]
+
+
+def test_report_only_exit_code_and_no_write(tmp_path, msgs):
+    """--report-only writes nothing and exits 2 when corrections would apply."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[6.03])
+    _sid, _tmd, before = _read_all(bag)
+    rc = rm.main([str(bag), '--report-only'])
+    assert rc == 2
+    assert not (tmp_path / 'm3bag.orig').exists()
+    _sid2, _tmd2, after = _read_all(bag)
+    assert before == after                             # untouched
+
+
+def test_report_only_clean_bag_exit_zero(tmp_path, msgs):
+    """A healthy bag with no corrections -> report-only exits 0."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[0.04], tf_old=False)
+    rc = rm.main([str(bag), '--report-only', '--no-tf'])
+    assert rc == 0
+
+
+def test_only_target_topic_timed(tmp_path, msgs):
+    """Timing correction touches only M3_DETECTIONS_TOPIC, not other headers."""
+    geometry, tf2, std = msgs
+    bag = tmp_path / 'm3bag'
+    # A non-M3 PointStamped topic carrying a +6 s stamp must be left untouched.
+    wr = SequentialWriter()
+    wr.open(StorageOptions(uri=str(bag), storage_id='mcap'), ConverterOptions('', ''))
+    wr.create_topic(_topic_md('/other/stamped', 'geometry_msgs/msg/PointStamped'))
+    recv = 1000 * NS
+    ps = geometry.PointStamped()
+    stamp_ns = recv + int(6.03 * NS)
+    ps.header.stamp.sec = stamp_ns // NS
+    ps.header.stamp.nanosec = stamp_ns % NS
+    wr.write('/other/stamped', serialize_message(ps), recv)
+    del wr
+
+    out = tmp_path / 'fixed'
+    rm.main([str(bag), '--out', str(out)])
+    _sid, _tmd, msgs_out = _read_all(out)
+    ps_out = deserialize_message(msgs_out[0][1], geometry.PointStamped)
+    out_ns = ps_out.header.stamp.sec * NS + ps_out.header.stamp.nanosec
+    assert out_ns == stamp_ns                          # unchanged (not the M3 topic)


### PR DESCRIPTION
Adds `retrofit_m3_bag.py` — a one-off offline utility to make already-collected M3 (Kongsberg) bags reprocessable, mirroring the `retrofit_sidescan_bag.py` precedent.

## Two corrections (each toggleable)

1. **Geometry** — `/tf_static` frame `bizzy/m3` translation → `(-0.29, 0.0, -0.28)` (rotation untouched). Fixes the ~13.5 cm sounding-depth bias from the old `(-0.23, 0, -0.145)` offset (#339 / #341). Idempotent; applies to every M3 bag.
2. **Timing** — `/bizzy/sensors/m3/detections` `header.stamp` integer-second clock-skew (#338). Per-message `n = round(header.stamp − bag_receive_time)`, subtract `n` whole seconds, **preserve the PPS-disciplined sub-second fraction**. Per-message handles multi-step drift (a bag straddling a 6 s→7 s jump); healthy pings (`n=0`) are untouched; ambiguous-band offsets WARN. Prints the **measured** integer-offset histogram (honest even under `--offset`).

## Behaviour
- **Default: in-place with backup**, persist-then-rename — write to temp, validate (open + read, **fail-closed**), then rename original → `.orig` and install the corrected bag; rollback from backup if the final move fails.
- **Bag form preserved**: directory→directory; bare `.mcap`→bare `.mcap` (the single inner segment is extracted, since rosbag2 only writes directory bags; multi-segment aborts → use `--out`).
- `--out` writes a non-destructive sibling; `--report-only` prints the histogram and exits non-zero if corrections would apply (batch "needs fixing?" probe); `--force` clears a stale `.tmp`.
- Storage format + QoS preserved (writer reuses reader `TopicMetadata`). Not installed (manual tool).

## Tests
23 pytest cases (now CI-registered via `ament_add_pytest_test`): integer-second rounding incl. half-to-even, histogram, tf rewrite/idempotency, path naming, **bare→bare in-place**, storage/metadata preservation, passthrough, report-only exit codes, topic targeting, stale-temp/`--force`. `ament_flake8` clean.

## Review
Local (pre-push) review: 2 rounds, **approved** (Round 1: 1 must-fix + 8 suggestions → all resolved; Round 2: 0 must-fix, doc-only). Two disjoint-lens Claude Adversarial passes; Copilot not opted in (standing quota decision).

## Caveat
Synthetic-bag tests + a real bare-segment test pass; still worth a smoke-test on a real boat M3 bag before bulk reprocessing.

Closes #342

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
