### PR TITLE
Bridge marine/status/mission_tasks to operator stations (mirror heartbeat_nav)

### DIFF
--- a/bizzyboat_project11/config/bizzyboat.yaml
+++ b/bizzyboat_project11/config/bizzyboat.yaml
@@ -103,6 +103,7 @@
             - diagnostics
             - heartbeat
             - heartbeat_nav
+            - mission_tasks
             - hover_viz
             - local_costmap_windowed
             - local_costmap_footprint
@@ -157,6 +158,12 @@
               diagnostics: {source: /diagnostics}
               heartbeat: {source: marine/heartbeat}
               heartbeat_nav: {source: marine/status/mission_manager}
+              # Structured running-task state for CAMP's task view (camp#123).
+              # Sibling of heartbeat_nav; same full-rate cadence (the boat
+              # publishes it periodically). Carries task poses, so it can be
+              # larger than the flattened heartbeat over cell — tune cadence
+              # after measuring the link budget, not blind (PR#239 review).
+              mission_tasks: {source: marine/status/mission_tasks}
               hover_viz: {source: hover_visualization}
               # Cropped local-costmap window for operator SA (unh_marine_navigation#38,
               # #127). Replaces the raw local_costmap, whose full grid lost ~78% over
@@ -243,6 +250,7 @@
             - diagnostics
             - heartbeat
             - heartbeat_nav
+            - mission_tasks
             - hover_viz
             - local_costmap_windowed
             - local_costmap_footprint
@@ -290,6 +298,12 @@
               diagnostics: {source: /diagnostics}
               heartbeat: {source: marine/heartbeat}
               heartbeat_nav: {source: marine/status/mission_manager}
+              # Structured running-task state for CAMP's task view (camp#123).
+              # Sibling of heartbeat_nav; same full-rate cadence (the boat
+              # publishes it periodically). Carries task poses, so it can be
+              # larger than the flattened heartbeat over cell — tune cadence
+              # after measuring the link budget, not blind (PR#239 review).
+              mission_tasks: {source: marine/status/mission_tasks}
               hover_viz: {source: hover_visualization}
               # Reflex collision cloud + danger-zone polygons + state (#170). Sent
               # unthrottled on VPN too: each is small (cloud <2 KB/msg, polygons +
@@ -381,6 +395,7 @@
             topics_list:
             - heartbeat
             - heartbeat_nav
+            - mission_tasks
             - command_response
             - battery
             - collision_monitor_state
@@ -409,6 +424,12 @@
             topics:
               heartbeat: {source: marine/heartbeat}
               heartbeat_nav: {source: marine/status/mission_manager}
+              # Structured running-task state for CAMP's task view (camp#123).
+              # Sibling of heartbeat_nav; same full-rate cadence (the boat
+              # publishes it periodically). Carries task poses, so it can be
+              # larger than the flattened heartbeat over cell — tune cadence
+              # after measuring the link budget, not blind (PR#239 review).
+              mission_tasks: {source: marine/status/mission_tasks}
               command_response: {source: marine/response}
               battery: {source: /bizzy/mavros/battery}
               collision_monitor_state: {source: collision_monitor_state}
@@ -476,6 +497,7 @@
       - /bizzy/mhhw_offset
       - /bizzy/marine/heartbeat
       - /bizzy/marine/status/mission_manager
+      - /bizzy/marine/status/mission_tasks
       - /bizzy/robot_description
       - /bizzy/sensors/cameras/oak_forward/rgb/camera_info
       - /bizzy/sensors/cameras/oak_forward/rgb/image_raw/compressed


### PR DESCRIPTION
Closes #344

## Summary

Bridges the boat's new structured task-status topic `marine/status/mission_tasks`
(`marine_nav_interfaces/TaskFeedback`) to operator stations by mirroring the
existing `heartbeat_nav` entry. Without this, CAMP's structured running-task
view (rolker/camp#123) has no data off-boat.

Pairs with the boat-side publisher rolker/unh_marine_autonomy#236
(PR rolker/unh_marine_autonomy#239), which adds the `marine/status/mission_tasks`
publisher.

## Changes (`bizzyboat_project11/config/bizzyboat.yaml`)

For each udp_bridge connection (`wifi`, `vpn`, `cell`):
- `mission_tasks` added to `topics_list`
- `mission_tasks: {source: marine/status/mission_tasks}` added to `topics`

Plus `/bizzy/marine/status/mission_tasks` added to the bag-recorder allowlist,
for parity with the already-recorded `marine/status/mission_manager`.

Mirrors `heartbeat_nav` exactly — full-rate, no period — which is how
`heartbeat_nav` is already sent on all three connections.

## Bandwidth note

The structured `TaskFeedback` carries task `poses[]`, so it can be larger than
the flattened Heartbeat over the constrained `cell` link. Mirroring exactly is
the consistent first step; cadence/decimation should be tuned **after measuring**
the link budget during bring-up (carried from the PR#239 review), not blind.

## Testing

YAML parses (`yaml.safe_load`). No new yamllint findings on the added lines (the
file has pre-existing style warnings unrelated to this change). Config-only —
no unit tests; validated by inspection against the `heartbeat_nav` pattern.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
