### PR TITLE
Field import: unh_echoboats_project11 (2026-06-28)

### DIFF
--- a/bizzyboat_project11/scripts/retrofit_m3_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_m3_bag.py
@@ -410,6 +410,29 @@ def _inner_mcaps(bag_dir):
     return sorted(f for f in os.listdir(bag_dir) if f.endswith('.mcap'))
 
 
+def _rename_dir_segments(bag_dir, temp_basename, final_basename):
+    """Fix segment names after an in-place directory swap.
+
+    A directory bag is written to `<final>.tmp/`, so rosbag2 bakes that temp
+    basename into the segment filenames (`<final>.tmp_0.mcap`) and metadata.yaml.
+    Renaming the dir to its final name does NOT fix those, leaving a misleading
+    `.tmp` in the segment name. Rename each segment to `<final>_0.mcap` and patch
+    metadata.yaml so the bag uses its real name (rosbag2 reads via metadata, so
+    the bag works regardless, but tools/humans assuming the `<bagname>_N.mcap`
+    convention should not see a `.tmp`).
+    """
+    for fn in os.listdir(bag_dir):
+        if fn.startswith(temp_basename) and fn.endswith('.mcap'):
+            os.rename(os.path.join(bag_dir, fn),
+                      os.path.join(bag_dir, final_basename + fn[len(temp_basename):]))
+    meta = os.path.join(bag_dir, 'metadata.yaml')
+    if os.path.exists(meta):
+        with open(meta) as fh:
+            text = fh.read()
+        with open(meta, 'w') as fh:
+            fh.write(text.replace(temp_basename, final_basename))
+
+
 def _swap_in_place(in_bag, temp, backup, in_is_dir):
     """Move the validated `temp` bag to `in_bag`, preserving the input form.
 
@@ -429,6 +452,8 @@ def _swap_in_place(in_bag, temp, backup, in_is_dir):
     try:
         if in_is_dir:
             os.rename(temp, in_bag)                    # dir -> dir
+            # strip the temp basename baked into segment names + metadata
+            _rename_dir_segments(in_bag, os.path.basename(temp), os.path.basename(in_bag))
         else:
             shutil.move(os.path.join(temp, _inner_mcaps(temp)[0]), in_bag)  # bare -> bare
             _remove(temp)                              # drop the scratch dir + metadata.yaml

--- a/bizzyboat_project11/scripts/retrofit_m3_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_m3_bag.py
@@ -20,19 +20,24 @@ Two independent corrections, each toggleable:
     the integer-second clock skew (#338). From Jun 24 2026 the M3's absolute
     time-of-day jumped ahead in WHOLE-second steps (a drifting mercat Windows
     clock) while PPS kept the sub-second fraction correct. So the fix is an
-    INTEGER-second shift that PRESERVES the sub-second fraction:
+    INTEGER-second shift that PRESERVES the sub-second fraction; the per-ping
+    integer comes from a WINDOWED MAXIMUM, not a per-message round:
 
-        n = round(header.stamp - bag_receive_time)   # nearest whole second
-        header.stamp -= n seconds                     # fraction untouched
+        measured[i] = round(stamp[i] - bag_receive_time[i])   # per-message
+        n[i]        = max(measured[i-W .. i+W])                # windowed envelope
+        header.stamp[i] -= n[i] seconds                        # fraction untouched
 
-    This is computed PER MESSAGE against the bag's receive timestamp (the gabby
-    clock, which #338 confirms agreed with every other clock to < 2 ms). Doing it
-    per-message means a bag that straddles a 6 s -> 7 s jump gets each ping
-    corrected by its own integer, and a healthy ping (offset ~0.04 s -> n = 0) is
-    left untouched. The bag receive time only needs ±0.5 s accuracy to pick the
-    right integer; healthy (~0.04 s) and bad (~6.03 s) offsets are both far from a
-    0.5 s rounding boundary. A WARN is emitted for any ping whose fractional
-    offset is within ~0.2 s of a half-second (frac >= 0.3, where frac in [0, 0.5]).
+    Why the window-max: stamp-minus-receive conflates the skew with receive
+    latency, so a ping delivered > 0.5 s late rounds to the WRONG second. A
+    per-message round() therefore mis-shifts every late ping -- on the (pre-skew)
+    2026-06-12 bag that was ~9.6k clean pings dragged off zero. But latency is
+    ONE-SIDED: offset = skew - transit_delay with transit_delay >= 0, so the true
+    skew is the UPPER ENVELOPE -- the max over a window of time-neighbours,
+    i.e. the skew of whichever neighbour arrived least delayed. The receive clock
+    (gabby) agreed with every other clock to < 2 ms (#338). Unlike a mode this
+    survives sustained latency bursts (it needs only one prompt ping per window).
+    The count of pings whose windowed value overrode their own per-message
+    integer is reported as "window override".
 
 The integer-offset HISTOGRAM is always printed (e.g. "0 s: 412, 6 s: 1805") so
 the step structure is visible and the PPS assumption is validated. It always
@@ -79,6 +84,7 @@ import argparse
 import os
 import shutil
 import sys
+from collections import Counter
 
 from rclpy.serialization import deserialize_message, serialize_message
 from rosbag2_py import (ConverterOptions, SequentialReader, SequentialWriter,
@@ -109,6 +115,17 @@ AMBIG_THRESHOLD = 0.3
 # decaying tail (largest non-zero bin ~2% on a clean pre-skew bag). A non-zero bin
 # holding at least this fraction of pings is treated as a real skew to investigate.
 SKEW_BIN_FRACTION = 0.05
+
+# Windowed timing correction (#338). A per-message round(stamp - receive)
+# conflates the integer clock skew with receive latency, so a ping delivered
+# > 0.5 s late rounds to the WRONG second (this over-corrected ~9.6k clean pings on
+# the 2026-06-12 bag). Latency is one-sided (offset <= skew), so each ping takes
+# the MAXIMUM per-message integer over a window of its time-neighbours -- the
+# upper envelope = the skew of the least-delayed neighbour (see windowed_skew).
+# Half-window in PINGS (M3 ~28 Hz, so this ~401-ping window spans ~14 s) -- needs
+# only one promptly-delivered ping per window; larger = more burst-robust but lags
+# a drift crossing more. Tunable.
+SKEW_WINDOW_HALF = 200
 
 
 def correct_stamp(stamp_ns, recv_ns, forced=None):
@@ -174,6 +191,46 @@ def assess_skew(hist):
     return is_skew, detail
 
 
+def windowed_skew(measured, half):
+    """Map per-message integer offsets to a latency-robust per-ping skew.
+
+    Receive latency is ONE-SIDED: offset = skew - transit_delay with
+    transit_delay >= 0 (a ping cannot be received before it was sent, and the
+    gabby receive clock is accurate to < 2 ms, #338). So offset <= skew always,
+    and the true skew is the UPPER ENVELOPE of the offsets -- the MAXIMUM over a
+    window of time-neighbours, recovered from whichever neighbour arrived with the
+    least delay. Unlike the mode, this needs only ONE promptly-delivered ping in
+    the window, so it rejects latency outliers however they cluster, including
+    sustained bursts that a mode cannot survive. It lags a downward-drifting skew
+    by up to half a window at a crossing, where the clock is between integers and
+    +/-1 s is inherent anyway. (A ping with offset ABOVE the skew is physically
+    impossible barring a clock anomaly; if one ever appears, switch max -> a high
+    percentile.)
+
+    O(n * distinct) -- the window slides with incremental counts and there are
+    only a handful of distinct integers.
+    """
+    n = len(measured)
+    if n == 0:
+        return []
+    counts = Counter()
+    out = [0] * n
+    lo, hi = 0, -1                                      # inclusive window bounds
+    for i in range(n):
+        want_hi = min(n - 1, i + half)
+        want_lo = max(0, i - half)
+        while hi < want_hi:
+            hi += 1
+            counts[measured[hi]] += 1
+        while lo < want_lo:
+            counts[measured[lo]] -= 1
+            if counts[measured[lo]] == 0:
+                del counts[measured[lo]]
+            lo += 1
+        out[i] = max(counts)                           # upper-envelope skew
+    return out
+
+
 def rewrite_tf(msg):
     """Set the bizzy/m3 transform's translation in a TFMessage; rotation untouched.
 
@@ -219,42 +276,73 @@ def validate_written(path):
         return False
 
 
-def stream(rd, wr, msgcls, a, counters, offsets):
-    """Read every message; correct the two target topics, pass the rest through.
+def measure_pass(in_bag):
+    """First pass: read the bag once and measure, writing nothing.
 
-    `wr` may be None (report-only): corrections are counted but nothing is written.
-    The histogram (`offsets`) always records the MEASURED integer offset.
+    Returns (measured, tf_hits, total):
+      measured -- list[int], per-message round(stamp - receive) for each M3
+                  detection in bag order (feeds the histogram, the skew check, and
+                  the windowed-mode correction).
+      tf_hits  -- number of /tf_static messages carrying the bizzy/m3 frame
+                  (== how many the geometry fix would rewrite).
+      total    -- total message count (lets report-only derive its passthrough
+                  count arithmetically, without a second read).
     """
+    rd, _sid, _topics, msgcls = open_reader(in_bag)
+    measured, tf_hits, total = [], 0, 0
+    try:
+        while rd.has_next():
+            topic, data, ts = rd.read_next()
+            total += 1
+            if topic == M3_DETECTIONS_TOPIC:
+                m = deserialize_message(data, msgcls[topic])
+                stamp_ns = m.header.stamp.sec * NS + m.header.stamp.nanosec
+                measured.append(correct_stamp(stamp_ns, ts)[0])
+            elif topic == TF_STATIC_TOPIC:
+                m = deserialize_message(data, msgcls[topic])
+                if any(tr.child_frame_id == M3_FRAME for tr in m.transforms):
+                    tf_hits += 1
+    finally:
+        del rd
+    return measured, tf_hits, total
+
+
+def compute_applied(measured, a):
+    """Per-M3-ping integer-second shift to apply: None under --no-timing; a
+    constant under --offset; otherwise the latency-robust windowed mode."""
+    if a.no_timing:
+        return None
+    if a.offset is not None:
+        return [a.offset] * len(measured)
+    return windowed_skew(measured, SKEW_WINDOW_HALF)
+
+
+def stream(rd, wr, msgcls, a, counters, applied):
+    """Second pass: write `rd` to `wr`, applying the geometry fix and the
+    precomputed per-ping timing shift `applied` (None under --no-timing).
+
+    `wr` may be None (count only, no write). M3 detections are consumed in the
+    same order as measure_pass, so `applied[j]` lines up with the j-th detection.
+    """
+    j = 0
     while rd.has_next():
         topic, data, ts = rd.read_next()
         if topic == M3_DETECTIONS_TOPIC:
-            m = deserialize_message(data, msgcls[topic])
-            stamp_ns = m.header.stamp.sec * NS + m.header.stamp.nanosec
-            measured_n, applied_n, new_ns, ambiguous = correct_stamp(stamp_ns, ts, a.offset)
-            offsets.append(measured_n)          # always: feeds the histogram + skew check
-            if a.no_timing:
-                # Diagnostic-only: measure the offset so a genuinely skewed bag is
-                # still caught (see assess_skew in _summary), but never touch the
-                # stamp. Per-ping ambiguous WARNs are suppressed here; the
-                # end-of-run skew assessment is the signal.
+            n = 0 if applied is None else applied[j]
+            j += 1
+            if n != 0:
+                m = deserialize_message(data, msgcls[topic])
+                stamp_ns = m.header.stamp.sec * NS + m.header.stamp.nanosec
+                new_ns = stamp_ns - n * NS
+                m.header.stamp.sec = new_ns // NS
+                m.header.stamp.nanosec = new_ns % NS
+                counters['timing'] += 1
+                if wr:
+                    wr.write(topic, serialize_message(m), ts)
+            else:
                 counters['pass'] += 1
                 if wr:
-                    wr.write(topic, data, ts)
-            else:
-                if ambiguous:
-                    counters['ambiguous'] += 1
-                    print(f'WARN: ping offset {(stamp_ns - ts) / 1e9:+.3f}s is near a '
-                          f'rounding boundary (measured n={measured_n:+d}s)', file=sys.stderr)
-                if applied_n != 0:
-                    m.header.stamp.sec = new_ns // NS
-                    m.header.stamp.nanosec = new_ns % NS
-                    counters['timing'] += 1
-                    if wr:
-                        wr.write(topic, serialize_message(m), ts)
-                else:
-                    counters['pass'] += 1
-                    if wr:
-                        wr.write(topic, data, ts)          # unchanged -> byte passthrough
+                    wr.write(topic, data, ts)          # unchanged -> byte passthrough
         elif topic == TF_STATIC_TOPIC and not a.no_tf:
             m = deserialize_message(data, msgcls[topic])
             if rewrite_tf(m):
@@ -284,7 +372,7 @@ def open_reader(path):
     return rd, sid, topics, msgcls
 
 
-def write_bag(out, sid, topics, rd, msgcls, a, counters, offsets):
+def write_bag(out, sid, topics, rd, msgcls, a, counters, applied):
     """Stream rd into a new bag at `out` (storage `sid`), cleaning up on failure."""
     wr = SequentialWriter()
     wr.open(StorageOptions(uri=out, storage_id=sid), ConverterOptions('', ''))
@@ -292,7 +380,7 @@ def write_bag(out, sid, topics, rd, msgcls, a, counters, offsets):
         wr.create_topic(t)
     ok = False
     try:
-        stream(rd, wr, msgcls, a, counters, offsets)
+        stream(rd, wr, msgcls, a, counters, applied)
         ok = True
     finally:
         del wr                                         # finalize the writer once
@@ -384,15 +472,18 @@ def main(argv=None):
         sys.exit(f'input bag not found: {in_bag}')
     in_is_dir = os.path.isdir(in_bag)
 
-    counters = {'tf': 0, 'timing': 0, 'pass': 0, 'ambiguous': 0}
-    offsets = []
+    # --- pass 1: measure offsets + locate the geometry frame ---------------
+    measured, tf_hits, total = measure_pass(in_bag)
+    applied = compute_applied(measured, a)             # None under --no-timing
+    override = 0 if applied is None else sum(1 for w, m in zip(applied, measured) if w != m)
+    counters = {'tf': 0, 'timing': 0, 'pass': 0, 'override': override}
 
-    # --- report-only: stream without writing -------------------------------
+    # --- report-only: counts are arithmetic from pass 1, no write ----------
     if a.report_only:
-        rd, _sid, _topics, msgcls = open_reader(in_bag)
-        stream(rd, None, msgcls, a, counters, offsets)
-        del rd
-        skew = _summary(in_bag, None, counters, offsets, a, wrote=False)
+        counters['tf'] = tf_hits if not a.no_tf else 0
+        counters['timing'] = 0 if applied is None else sum(1 for n in applied if n != 0)
+        counters['pass'] = total - counters['tf'] - counters['timing']
+        skew = _summary(in_bag, None, counters, measured, a, wrote=False)
         # Exit codes: 3 = real skew detected under --no-timing (investigate);
         # 2 = a correction WOULD apply (batch "needs fixing?" probe); 0 = clean.
         if skew:
@@ -405,12 +496,12 @@ def main(argv=None):
         if os.path.exists(out):
             sys.exit(f'output already exists: {out}')
         rd, sid, topics, msgcls = open_reader(in_bag)
-        write_bag(out, sid, topics, rd, msgcls, a, counters, offsets)
+        write_bag(out, sid, topics, rd, msgcls, a, counters, applied)
         del rd
         if not validate_written(out):
             _remove(out)
             sys.exit('aborting: written bag failed validation (input untouched)')
-        skew = _summary(out, None, counters, offsets, a, wrote=True)
+        skew = _summary(out, None, counters, measured, a, wrote=True)
         return 3 if skew else 0
 
     # --- in-place with backup ----------------------------------------------
@@ -425,27 +516,27 @@ def main(argv=None):
         sys.exit(f'backup already exists (refusing to overwrite): {backup}')
 
     rd, sid, topics, msgcls = open_reader(in_bag)
-    write_bag(temp, sid, topics, rd, msgcls, a, counters, offsets)
+    write_bag(temp, sid, topics, rd, msgcls, a, counters, applied)
     del rd                                             # release input before renaming
     if not validate_written(temp):
         _remove(temp)
         sys.exit('aborting: written bag failed validation; original untouched')
 
     _swap_in_place(in_bag, temp, backup, in_is_dir)
-    skew = _summary(in_bag, backup, counters, offsets, a, wrote=True)
+    skew = _summary(in_bag, backup, counters, measured, a, wrote=True)
     return 3 if skew else 0
 
 
-def _summary(target, backup, counters, offsets, a, wrote):
+def _summary(target, backup, counters, measured, a, wrote):
     """Print the histogram and a one-line outcome; under --no-timing also run and
     print the skew assessment. Returns True iff --no-timing is set AND a real clock
     skew was detected (the caller turns that into exit code 3)."""
-    hist = build_histogram(offsets)
+    hist = build_histogram(measured)
     print('integer-second offset histogram (M3 detections, measured):')
     print_histogram(hist)
     verb = 'wrote' if wrote else 'would correct'
-    print(f'{verb}: {counters["tf"]} tf_static, {counters["timing"]} timing; '
-          f'{counters["pass"]} passthrough; {counters["ambiguous"]} ambiguous-band WARN')
+    print(f'{verb}: {counters["tf"]} tf_static, {counters["timing"]} timing '
+          f'({counters["override"]} via window override); {counters["pass"]} passthrough')
     if wrote:
         print(f'  -> {target}')
         if backup:

--- a/bizzyboat_project11/scripts/retrofit_m3_bag.py
+++ b/bizzyboat_project11/scripts/retrofit_m3_bag.py
@@ -41,6 +41,13 @@ honest when a manual shift is forced. Use --report-only to see it without writin
 (exits non-zero if any correction would apply, so it doubles as a "does this bag
 need fixing?" probe in batch scripts).
 
+Under --no-timing the offsets are STILL measured (just not applied) and a skew
+assessment runs: if a real clock skew is present (a large fraction of pings on one
+non-zero integer second, vs. a latency tail centred on 0 s) it is reported and the
+exit code is 3 -- so skipping the timing fix on a bag that genuinely needs it is
+never silent. Exit codes: 0 = clean; 2 = a correction would apply (--report-only);
+3 = real skew detected under --no-timing.
+
 File handling (default: in-place with backup) — downstream paths reference the
 original bag name, so the corrected bag takes the original name and the original
 is preserved as a backup. Persist-then-rename: the corrected bag is written to a
@@ -95,6 +102,14 @@ M3_XYZ = (-0.29, 0.0, -0.28)   # measured 2026-06-27 (#339); supersedes (-0.23,0
 # [0, 0.5], so this is "within (0.5 - 0.3) = 0.2 s of a half-second boundary".
 AMBIG_THRESHOLD = 0.3
 
+# When the timing fix is skipped (--no-timing) we STILL measure the offsets so a
+# genuinely skewed bag is not silently passed over. A real #338 clock skew puts a
+# large fraction of pings on a single NON-ZERO integer second (e.g. -9 s covered
+# ~100% on 2026-06-26); receive-latency jitter instead peaks at 0 s with a small
+# decaying tail (largest non-zero bin ~2% on a clean pre-skew bag). A non-zero bin
+# holding at least this fraction of pings is treated as a real skew to investigate.
+SKEW_BIN_FRACTION = 0.05
+
 
 def correct_stamp(stamp_ns, recv_ns, forced=None):
     """Compute the integer-second stamp correction, preserving the fraction.
@@ -127,6 +142,36 @@ def print_histogram(hist):
         return
     for n in sorted(hist):
         print(f'  {n:+d} s: {hist[n]}')
+
+
+def assess_skew(hist):
+    """Classify an integer-offset histogram: real clock skew vs. receive latency.
+
+    Returns (is_skew, detail). A genuine #338 skew shows a dominant NON-ZERO
+    offset -- either the most-populated bin is non-zero, or a single non-zero bin
+    holds >= SKEW_BIN_FRACTION of pings (a bag that straddles a skew jump, where
+    0 s may still be the plurality). Receive latency instead peaks at 0 s with a
+    decaying tail, so no non-zero bin grows large.
+    """
+    total = sum(hist.values())
+    if total == 0:
+        return False, 'no M3 detections to assess'
+    mode_n = max(hist, key=lambda n: hist[n])
+    nonzero = {n: c for n, c in hist.items() if n != 0}
+    top_nz, top_nz_frac = 0, 0.0
+    if nonzero:
+        top_nz = max(nonzero, key=lambda n: nonzero[n])
+        top_nz_frac = nonzero[top_nz] / total
+    is_skew = mode_n != 0 or top_nz_frac >= SKEW_BIN_FRACTION
+    zero_frac = hist.get(0, 0) / total
+    if is_skew:
+        detail = (f'dominant offset {top_nz:+d} s on {top_nz_frac:.1%} of pings '
+                  f'(mode {mode_n:+d} s) -- looks like a real clock skew')
+    else:
+        detail = (f'offset mode 0 s ({zero_frac:.1%} of pings); largest non-zero bin '
+                  f'{top_nz:+d} s on {top_nz_frac:.1%} -- consistent with receive '
+                  f'latency, no clock skew')
+    return is_skew, detail
 
 
 def rewrite_tf(msg):
@@ -182,25 +227,34 @@ def stream(rd, wr, msgcls, a, counters, offsets):
     """
     while rd.has_next():
         topic, data, ts = rd.read_next()
-        if topic == M3_DETECTIONS_TOPIC and not a.no_timing:
+        if topic == M3_DETECTIONS_TOPIC:
             m = deserialize_message(data, msgcls[topic])
             stamp_ns = m.header.stamp.sec * NS + m.header.stamp.nanosec
             measured_n, applied_n, new_ns, ambiguous = correct_stamp(stamp_ns, ts, a.offset)
-            offsets.append(measured_n)
-            if ambiguous:
-                counters['ambiguous'] += 1
-                print(f'WARN: ping offset {(stamp_ns - ts) / 1e9:+.3f}s is near a '
-                      f'rounding boundary (measured n={measured_n:+d}s)', file=sys.stderr)
-            if applied_n != 0:
-                m.header.stamp.sec = new_ns // NS
-                m.header.stamp.nanosec = new_ns % NS
-                counters['timing'] += 1
-                if wr:
-                    wr.write(topic, serialize_message(m), ts)
-            else:
+            offsets.append(measured_n)          # always: feeds the histogram + skew check
+            if a.no_timing:
+                # Diagnostic-only: measure the offset so a genuinely skewed bag is
+                # still caught (see assess_skew in _summary), but never touch the
+                # stamp. Per-ping ambiguous WARNs are suppressed here; the
+                # end-of-run skew assessment is the signal.
                 counters['pass'] += 1
                 if wr:
-                    wr.write(topic, data, ts)          # unchanged -> byte passthrough
+                    wr.write(topic, data, ts)
+            else:
+                if ambiguous:
+                    counters['ambiguous'] += 1
+                    print(f'WARN: ping offset {(stamp_ns - ts) / 1e9:+.3f}s is near a '
+                          f'rounding boundary (measured n={measured_n:+d}s)', file=sys.stderr)
+                if applied_n != 0:
+                    m.header.stamp.sec = new_ns // NS
+                    m.header.stamp.nanosec = new_ns % NS
+                    counters['timing'] += 1
+                    if wr:
+                        wr.write(topic, serialize_message(m), ts)
+                else:
+                    counters['pass'] += 1
+                    if wr:
+                        wr.write(topic, data, ts)          # unchanged -> byte passthrough
         elif topic == TF_STATIC_TOPIC and not a.no_tf:
             m = deserialize_message(data, msgcls[topic])
             if rewrite_tf(m):
@@ -338,8 +392,11 @@ def main(argv=None):
         rd, _sid, _topics, msgcls = open_reader(in_bag)
         stream(rd, None, msgcls, a, counters, offsets)
         del rd
-        _summary(in_bag, None, counters, offsets, a, wrote=False)
-        # Non-zero exit if any correction WOULD apply (batch "needs fixing?" probe).
+        skew = _summary(in_bag, None, counters, offsets, a, wrote=False)
+        # Exit codes: 3 = real skew detected under --no-timing (investigate);
+        # 2 = a correction WOULD apply (batch "needs fixing?" probe); 0 = clean.
+        if skew:
+            return 3
         return 2 if (counters['tf'] or counters['timing']) else 0
 
     # --- non-destructive sibling (--out) -----------------------------------
@@ -353,8 +410,8 @@ def main(argv=None):
         if not validate_written(out):
             _remove(out)
             sys.exit('aborting: written bag failed validation (input untouched)')
-        _summary(out, None, counters, offsets, a, wrote=True)
-        return 0
+        skew = _summary(out, None, counters, offsets, a, wrote=True)
+        return 3 if skew else 0
 
     # --- in-place with backup ----------------------------------------------
     temp, backup = inplace_paths(in_bag)
@@ -375,14 +432,17 @@ def main(argv=None):
         sys.exit('aborting: written bag failed validation; original untouched')
 
     _swap_in_place(in_bag, temp, backup, in_is_dir)
-    _summary(in_bag, backup, counters, offsets, a, wrote=True)
-    return 0
+    skew = _summary(in_bag, backup, counters, offsets, a, wrote=True)
+    return 3 if skew else 0
 
 
 def _summary(target, backup, counters, offsets, a, wrote):
-    """Print the histogram and a one-line outcome."""
+    """Print the histogram and a one-line outcome; under --no-timing also run and
+    print the skew assessment. Returns True iff --no-timing is set AND a real clock
+    skew was detected (the caller turns that into exit code 3)."""
+    hist = build_histogram(offsets)
     print('integer-second offset histogram (M3 detections, measured):')
-    print_histogram(build_histogram(offsets))
+    print_histogram(hist)
     verb = 'wrote' if wrote else 'would correct'
     print(f'{verb}: {counters["tf"]} tf_static, {counters["timing"]} timing; '
           f'{counters["pass"]} passthrough; {counters["ambiguous"]} ambiguous-band WARN')
@@ -390,9 +450,21 @@ def _summary(target, backup, counters, offsets, a, wrote):
         print(f'  -> {target}')
         if backup:
             print(f'  backup: {backup}')
+
+    skew_detected = False
+    if a.no_timing:
+        is_skew, detail = assess_skew(hist)
+        print(f'no-timing skew check: {detail}')
+        if is_skew:
+            skew_detected = True
+            print('WARN: a real clock skew is present but the timing fix was '
+                  'skipped (--no-timing) -- investigate; this bag likely needs the '
+                  'timing correction.', file=sys.stderr)
+
     if not a.no_timing and not a.no_tf and not counters['tf'] and not counters['timing']:
         print('NOTE: nothing matched -- no /tf_static bizzy/m3 frame and no M3 '
               'detection corrections. Is this an M3 bag?', file=sys.stderr)
+    return skew_detected
 
 
 if __name__ == '__main__':

--- a/bizzyboat_project11/test/test_retrofit_m3_bag.py
+++ b/bizzyboat_project11/test/test_retrofit_m3_bag.py
@@ -394,3 +394,72 @@ def test_stale_temp_blocks_then_force_clears(tmp_path, msgs):
     rc = rm.main([str(bag), '--force'])
     assert rc == 0
     assert (tmp_path / 'm3bag.orig').exists()
+
+
+# ======================================================================
+# Skew assessment (assess_skew) + --no-timing reporting (#342 follow-up)
+# ======================================================================
+
+def test_assess_skew_latency_is_not_skew():
+    # Mode at 0 s with a small decaying tail (largest non-zero ~2%): latency.
+    is_skew, detail = rm.assess_skew({0: 970, -1: 22, -2: 5, -3: 3})
+    assert is_skew is False
+    assert 'latency' in detail
+
+
+def test_assess_skew_clean_skew_detected():
+    # Dominant non-zero mode (the 2026-06-26 shape): real skew.
+    is_skew, detail = rm.assess_skew({-9: 3090, -10: 1})
+    assert is_skew is True
+    assert 'skew' in detail
+
+
+def test_assess_skew_straddle_detected():
+    # 0 s is the plurality but a large non-zero bin (bag straddles a jump): skew.
+    assert rm.assess_skew({0: 60, -6: 40})[0] is True
+
+
+def test_assess_skew_empty_is_not_skew():
+    assert rm.assess_skew({})[0] is False
+
+
+def test_assess_skew_threshold_boundary():
+    # SKEW_BIN_FRACTION = 0.05: 4% non-zero -> latency; 5% -> skew.
+    assert rm.assess_skew({0: 96, -1: 4})[0] is False
+    assert rm.assess_skew({0: 95, -1: 5})[0] is True
+
+
+def test_no_timing_skew_exits_3_without_touching_stamps(tmp_path, msgs):
+    """--no-timing on a genuinely skewed bag reports the skew (exit 3) and leaves
+    the detection stamps unchanged."""
+    bag = tmp_path / 'm3skew'
+    _make_bag(bag, msgs, detection_offsets=[6.02, 6.03, 6.04, 6.01])
+    out = tmp_path / 'out'
+    rc = rm.main([str(bag), '--no-timing', '--out', str(out)])
+    assert rc == 3
+
+    geometry = msgs[0]
+    _sid, _tmd, msgs_out = _read_all(out)
+    det = [m for m in msgs_out if m[0] == rm.M3_DETECTIONS_TOPIC]
+    assert det
+    for (_topic, data, ts) in det:
+        ps = deserialize_message(data, geometry.PointStamped)
+        stamp_ns = ps.header.stamp.sec * NS + ps.header.stamp.nanosec
+        assert round((stamp_ns - ts) / 1e9) == 6        # NOT shifted to 0
+
+
+def test_no_timing_latency_exits_0(tmp_path, msgs):
+    """--no-timing on a latency-only bag finds no skew and exits 0."""
+    bag = tmp_path / 'm3lat'
+    _make_bag(bag, msgs, detection_offsets=[0.04] * 20 + [-1.05])  # 1/21 ~ 4.8% < 5%
+    rc = rm.main([str(bag), '--no-timing', '--out', str(tmp_path / 'out')])
+    assert rc == 0
+
+
+def test_no_timing_report_only_skew_exits_3_and_no_write(tmp_path, msgs):
+    """--no-timing --report-only detects the skew (exit 3) and writes nothing."""
+    bag = tmp_path / 'm3skew_ro'
+    _make_bag(bag, msgs, detection_offsets=[6.02, 6.03, 6.04])
+    rc = rm.main([str(bag), '--no-timing', '--report-only'])
+    assert rc == 3
+    assert not (tmp_path / 'm3skew_ro.orig').exists()

--- a/bizzyboat_project11/test/test_retrofit_m3_bag.py
+++ b/bizzyboat_project11/test/test_retrofit_m3_bag.py
@@ -254,7 +254,7 @@ def _read_all(path):
 def test_inplace_creates_backup_and_corrects(tmp_path, msgs):
     """Default mode: corrected bag at original name, original preserved as .orig."""
     bag = tmp_path / 'm3bag'
-    _make_bag(bag, msgs, detection_offsets=[0.04, 6.03, 6.03])
+    _make_bag(bag, msgs, detection_offsets=[6.03, 6.03, 6.03])
     rc = rm.main([str(bag)])
     assert rc == 0
     assert (tmp_path / 'm3bag.orig').exists()
@@ -427,6 +427,57 @@ def test_assess_skew_threshold_boundary():
     # SKEW_BIN_FRACTION = 0.05: 4% non-zero -> latency; 5% -> skew.
     assert rm.assess_skew({0: 96, -1: 4})[0] is False
     assert rm.assess_skew({0: 95, -1: 5})[0] is True
+
+
+# ======================================================================
+# Windowed timing (windowed_skew) — latency-robust upper-envelope skew
+# ======================================================================
+
+def test_windowed_skew_uniform_and_empty():
+    assert rm.windowed_skew([-9, -9, -9, -9], 200) == [-9, -9, -9, -9]
+    assert rm.windowed_skew([0, 0, 0], 200) == [0, 0, 0]
+    assert rm.windowed_skew([], 200) == []
+
+
+def test_windowed_skew_latency_outlier_pulled_up():
+    # Latency is one-sided (offset <= skew): a late ping among a -9 s skew sits
+    # BELOW it (-10) and is corrected up to the envelope -9, not left at -10.
+    assert rm.windowed_skew([-9, -9, -10, -9, -9], 200) == [-9, -9, -9, -9, -9]
+    # A clean (no-skew) baseline with a latency dip stays at 0.
+    assert rm.windowed_skew([0, 0, -1, 0, 0], 200) == [0, 0, 0, 0, 0]
+
+
+def test_windowed_skew_tracks_downward_drift_with_lag():
+    # Max holds the higher value until it leaves the window, so a 0 -> -6 drift
+    # lags by ~half a window (here half=1: index 4 still reads 0).
+    assert rm.windowed_skew([0, 0, 0, 0, -6, -6, -6, -6], 1) == [0, 0, 0, 0, 0, -6, -6, -6]
+
+
+def test_windowed_skew_prefers_least_delayed():
+    # Window holds both -> the envelope (max) wins -> the smaller correction.
+    assert rm.windowed_skew([0, -6], 5) == [0, 0]
+
+
+def test_windowed_corrects_latency_outlier_in_bag(tmp_path, msgs):
+    """End-to-end: a late ping inside a 6 s skew is shifted by the window's
+    envelope (6 s), not its own measured 5 s, so it is not left a second off."""
+    bag = tmp_path / 'm3win'
+    offs = [6.03] * 10 + [5.04] + [6.03] * 10        # one late outlier (below 6) mid-bag
+    _make_bag(bag, msgs, detection_offsets=offs)
+    out = tmp_path / 'out'
+    rc = rm.main([str(bag), '--out', str(out)])
+    assert rc == 0
+
+    geometry = msgs[0]
+    _sid, _tmd, msgs_out = _read_all(out)
+    shifts = []
+    for (_t, data, ts) in [m for m in msgs_out if m[0] == rm.M3_DETECTIONS_TOPIC]:
+        ps = deserialize_message(data, geometry.PointStamped)
+        stamp_ns = ps.header.stamp.sec * NS + ps.header.stamp.nanosec
+        shifts.append(round((stamp_ns - ts) / 1e9))
+    # all shifted by the envelope 6: clean pings residual ~0; the late outlier was
+    # at 5.04, shifted by 6 -> residual ~-0.96 -> round -1 (NOT shifted by its own 5).
+    assert shifts.count(0) == 20 and shifts.count(-1) == 1
 
 
 def test_no_timing_skew_exits_3_without_touching_stamps(tmp_path, msgs):

--- a/bizzyboat_project11/test/test_retrofit_m3_bag.py
+++ b/bizzyboat_project11/test/test_retrofit_m3_bag.py
@@ -279,6 +279,24 @@ def test_inplace_creates_backup_and_corrects(tmp_path, msgs):
     assert other.transform.translation.x == 1.0       # unrelated frame untouched
 
 
+def test_inplace_dir_segment_named_without_tmp(tmp_path, msgs):
+    """In-place on a directory bag must not leave the temp '.tmp' baked into the
+    segment filename or metadata.yaml (regression: writes go to <name>.tmp/, and
+    renaming the dir alone left <name>.tmp_0.mcap)."""
+    bag = tmp_path / 'm3bag'
+    _make_bag(bag, msgs, detection_offsets=[6.03, 6.03])
+    assert rm.main([str(bag)]) == 0
+
+    segs = [f for f in os.listdir(bag) if f.endswith('.mcap')]
+    assert segs == ['m3bag_0.mcap']                    # final name, no '.tmp'
+    assert not any('.tmp' in f for f in os.listdir(bag))
+    meta = (bag / 'metadata.yaml').read_text()
+    assert '.tmp' not in meta
+    # and it still opens with the right data
+    _sid, _tmd, out = _read_all(bag)
+    assert sum(1 for m in out if m[0] == rm.M3_DETECTIONS_TOPIC) == 2
+
+
 def test_inplace_bare_mcap_stays_bare(tmp_path, msgs):
     """A bare single .mcap input yields a bare .mcap output (not a directory)."""
     bare = _make_bare_mcap(tmp_path, msgs, 'boat.mcap', detection_offsets=[6.03])


### PR DESCRIPTION
Imports 3 field commits from `gitcloud/jazzy` improving `retrofit_m3_bag.py` (relates to #342): latency-robust **windowed-max** timing correction (replaces a per-message round that over-corrected ~9.6k clean pings), real **clock-skew detection under `--no-timing`** (exit code 3 so a skipped-but-needed fix is never silent), and stripping the temp `.tmp` baked into in-place dir segment names. **14 new tests.** Pre-review clean.

## ⚠ Diverged — merge `jazzy` before merging
This branch is cut from `gitcloud/jazzy` (ahead 2 / behind 3 vs local `jazzy`). The local-ahead commits (#344 / merge #345) touch only `config/bizzyboat.yaml`; these field commits touch only `retrofit_m3_bag.py` + its test — **no overlap, the merge is conflict-free.** Merge `jazzy` into `feature/issue-346` before this can land.

See the import issue for the full pre-review.

Closes #346

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
