### PR TITLE
feat(operator): record operator-marked sidescan contacts in the operator bag (#348)

### DIFF
--- a/bizzyboat_project11/launch/bag_recorder_operator_launch.py
+++ b/bizzyboat_project11/launch/bag_recorder_operator_launch.py
@@ -50,6 +50,10 @@ RECORD_TOPICS = [
     '/rosout',
     '/tf',
     '/tf_static',
+    # Operator-marked sidescan targets (rqt_operator_tools#86): the waterfall
+    # publishes a marine_interfaces/Contact per drawn box, remapped into the
+    # operator namespace by operator_ui_launch.py's rqt_sonar node.
+    '/operator/sonar_waterfall/contacts',
 ]
 
 

--- a/bizzyboat_project11/launch/operator_ui_launch.py
+++ b/bizzyboat_project11/launch/operator_ui_launch.py
@@ -89,6 +89,13 @@ def generate_launch_description():
     executable='rqt_gui',
     name='rqt_sonar',
     arguments=['-p', 'bizzy_sonar'],
+    # Namespace only the marked-contacts output (rqt_operator_tools#86) into the
+    # operator graph, leaving the node itself at root. The node must stay at root:
+    # the waterfall's tf2 listener subscribes to relative tf/tf_static, so pushing
+    # a namespace here would send it to /operator/tf and break the contact
+    # georeferencing. The input imagery topics are operator-selected absolute names,
+    # so only this one relative output needs remapping.
+    remappings=[('sonar_waterfall/contacts', '/operator/sonar_waterfall/contacts')],
     condition=IfCondition(sonar_rqt),
     respawn=True,
     respawn_delay=5,


### PR DESCRIPTION
## Summary

Capture operator-marked sidescan targets in the operator-side bag. The live
waterfall (`rqt_operator_tools#86`) publishes a `marine_interfaces/Contact` per
drawn box; this wires that topic into the existing operator recorder so marked
targets persist for the post-survey record.

## Changes

- **`operator_ui_launch.py`** — remap the `rqt_sonar` node's relative
  `sonar_waterfall/contacts` output to **`/operator/sonar_waterfall/contacts`**,
  grouping it with the rest of the operator graph (`/operator/...`).
  - The remap is deliberately scoped to that **one topic**: the node stays at root
    because the waterfall's `tf2_ros` listener subscribes to relative `tf`/`tf_static`,
    so pushing a namespace on the whole node would point it at `/operator/tf` and
    **break the contact georeferencing**. Input imagery topics are operator-selected
    absolute names, so only this relative output needs remapping.
- **`bag_recorder_operator_launch.py`** — add `/operator/sonar_waterfall/contacts`
  to `RECORD_TOPICS` (the auto-launched operator recorder, `record_diagnostics:=true`).

## Verification

Both launch files `py_compile` clean and build a `LaunchDescription`
(`generate_launch_description()` returns 10 / 2 entities respectively).

## Follow-up (not blocking)

The waterfall plugin's `contact_topic_` is currently hardcoded relative; a small
future improvement is to make it a real plugin setting rather than relying on a
launch remap. Tracked as a note here.

Closes #348

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
