### PR TITLE
Wrap up deployment #359: Lake Massabesic survey

### DIFF
--- a/docs/logs/2026/2026-06-30_dev_logs.md
+++ b/docs/logs/2026/2026-06-30_dev_logs.md
@@ -1,0 +1,78 @@
+# 2026-06-30 — dev log (BizzyBoat deployment #359)
+
+Deployment issue: https://github.com/rolker/unh_echoboats_project11/issues/359
+Host: deadpool
+Side: dev
+Started: 2026-06-30 11:07 -04:00
+
+## 2026-06-30
+
+### Pre-flight
+
+Freshwater site (Lake Massabesic, Auburn NH) — tides/currents N/A.
+
+Weather — NWS GYX, zone NHZ012, gridpoint GYX/40,20 (nr. Manchester NH), pulled 2026-06-30 11:07 -04:00:
+
+- **Today**: Mostly Sunny, high 91°F. Wind S 0–5 mph (~0–4 kn).
+- **Tonight**: 68°F, chance showers/thunderstorms (developing). Wind SW ~5 mph (~4 kn).
+- Hot, light winds, calm water expected; watch for afternoon/evening thunderstorm development.
+
+
+**2026-06-30 11:53 -04:00** — Operator status (reported after the fact, dev-side relay): off the dock a few hours; transited to the survey area; ran manda_coverage for a while, then switched to regular survey lines (manda set aside this session). No fault reported with the switch.
+
+**2026-06-30 17:14 -04:00** — Boat back at the dock (operator) — on-water ops ending, recovery phase. Session: transited out, ran manda_coverage then regular survey lines; no faults reported. Wx held (light SW winds, storms stayed in late-evening window).
+
+## Summary
+
+BizzyBoat Lake Massabesic survey, ~09:25–17:02 on the water (gabby field host; deadpool
+dev support). Transited to the survey area, tested `manda_coverage` for a stretch, then
+switched to traditional survey lines for the remainder. No hardware faults reported; mru
+ran FCU-primary on all three channels with no SBG fail-over. The notable finding was
+elevated battery drain under manda coverage: the operator observed turns commanding speeds
+above the task target, confirmed in the gabby log by `/bizzy/cmd_vel_nav` sampling
+(commanded speed slightly higher in hard turns than on straight legs, yaw rate uncapped).
+Operator dialed `FollowPath.default_speed` through several values live to find a good survey
+speed while monitoring throttle, and switched off manda coverage as the mitigation. Camera
+captures collected cleanly. Weather held (hot, light SW winds; thunderstorms stayed in the
+late-evening window and didn't affect ops).
+
+## Operator Corrections
+
+- Start date: Operator confirmed 2026-06-30 is the correct in-water day (no rollover / multi-day span).
+- Host set: Operator confirmed gabby (boat) + dev (deadpool) are the complete set; no other host logs.
+- manda-coverage power-draw RCA: Operator confirmed — "it seems like speeds above the task
+  provided target speed were commanded during turns and that the battery consumption was higher
+  when running manda coverage." Root-cause read not overstated.
+- Live `FollowPath.default_speed` changes + switch to traditional planning: Operator confirmed
+  all his calls — "all my calls; we were finding a good survey speed and I was monitoring the
+  commanded throttle as we changed speeds." No agent overreach to walk back.
+- Unlogged events: Operator reported none.
+
+## Lessons Learned
+
+- `manda_coverage` emits paths with **no per-waypoint speed/time** (SurveyPath::sendPath builds
+  PoseStamped with position + orientation only), so `FollowPath.default_speed` is the sole
+  effective speed source under coverage planning. Lowering the base survey speed alone won't fix
+  turn-speed overshoot, because turn-commanded speed exceeds `default_speed` regardless.
+- `avoid_speed=0.0` + `max_yaw_rate≈π` (uncapped) means the controller does not slow through the
+  many coverage turnarounds — the dominant power sink. Turn handling, not base survey speed, is
+  the lever.
+- Live param overrides (`FollowPath.default_speed`) revert on a full nav2 relaunch — none of this
+  session's values were persisted to `nav2_overlay.yaml` by design. If a survey speed is settled,
+  persist it deliberately.
+- Issue-less field start worked as intended: gabby started before the dev issue existed and was
+  cleanly backfilled to #359 at wrap-up.
+
+## Field Reconciliation
+
+No other repos had field commits this deployment (all session changes were runtime-only
+live param overrides, nothing persisted/committed elsewhere — operator confirmed at wrap-up).
+`/import-field-changes` not needed. The gabby deployment log was folded into this repo's
+wrap-up branch via SHA-preserving merge of `gitcloud/jazzy` (commit d1fccfe).
+
+## RCA / Follow-up Backlog
+
+- [ ] manda_coverage excess power draw from turn-speed overshoot — controller does not slow for
+  turns (uncapped yaw rate + commanded speed > default_speed through coverage turnarounds);
+  manda_coverage sets no per-waypoint speed. RCA target = controller turn behavior, not waypoint
+  timing. Confirmed by operator + gabby `/bizzy/cmd_vel_nav` data.

--- a/docs/logs/2026/2026-06-30_gabby_logs.md
+++ b/docs/logs/2026/2026-06-30_gabby_logs.md
@@ -1,6 +1,6 @@
-# 2026-06-30 — gabby log (BizzyBoat deployment — issue pending)
+# 2026-06-30 — gabby log (BizzyBoat deployment #359)
 
-Deployment issue: pending (backfill from a dev host)
+Deployment issue: https://github.com/rolker/unh_echoboats_project11/issues/359 <!-- backfilled at wrap-up: issue-less field start linked to #359 -->
 Host: gabby
 Side: field
 Started: 2026-06-30 09:25 -04:00

--- a/docs/logs/2026/2026-06-30_gabby_logs.md
+++ b/docs/logs/2026/2026-06-30_gabby_logs.md
@@ -1,0 +1,47 @@
+# 2026-06-30 — gabby log (BizzyBoat deployment — issue pending)
+
+Deployment issue: pending (backfill from a dev host)
+Host: gabby
+Side: field
+Started: 2026-06-30 09:25 -04:00
+
+
+**2026-06-30 09:26 -04:00** — deployment mode activated on gabby (field side, issue-less start #533); repo on jazzy, clean tree
+
+**2026-06-30 10:10 -04:00** — mru_transform live active source = fcu on all three (/bizzy/nav/active_sensor/orientation, position, velocity all report 'fcu'). No fail-over to SBG. Matches config sensor_names=[fcu,sbg].
+
+**2026-06-30 10:28 -04:00** — OPERATOR: testing manda coverage again.
+
+**2026-06-30 11:03 -04:00** — OPERATOR: battery draining faster during manda coverage; turning seems to command higher speeds sometimes, likely contributing to the higher drain.
+
+**2026-06-30 11:06 -04:00** — Battery (/bizzy/mavros/battery) at time of note: voltage 26.78 V. current reads ~0.01 A and charge/capacity/percentage are NaN/zero -> no current-sensor telemetry, so instantaneous draw is NOT available from this topic; voltage is the only usable drain indicator.
+
+**2026-06-30 11:14 -04:00** — CONFIRMING DATA — /bizzy/cmd_vel_nav, 94 samples over 20s during manda coverage. Commanded speed min 0.00 / mean 1.62 / max 1.87 m/s; |yaw_rate| up to 1.41 rad/s. Binned: near-straight (|w|<0.05) mean speed 1.48 m/s vs hard-turn (|w|>0.20) mean speed 1.64 m/s. Controller is NOT slowing for turns — commanded speed is slightly HIGHER in turns than on straight legs, at high yaw rates. Supports operator hypothesis: coverage turning holds/raises speed -> high differential thrust both sides -> faster drain. (Single 20s window, small straight-leg n=12.)
+
+**2026-06-30 11:35 -04:00** — ISSUE (wrap-up RCA candidate): manda coverage draws too much power. Supporting data this session — controller does NOT slow for turns; /bizzy/cmd_vel_nav mean speed 1.48 m/s straight vs 1.64 m/s in hard turns (|yaw| up to 1.41 rad/s), so high differential thrust on both sides through the many coverage turnarounds. Survey speed was 3.0 kn, sent WITH the mission (not boat config); levers for later = lower mission speed to 2.5 kn, or override target_speed on the controller (an agent did this in a prior session). MITIGATION NOW: switched to traditional planning for the rest of this run. RCA deferred to post-deployment.
+
+**2026-06-30 12:52 -04:00** — Controller speed param read live: FollowPath.default_speed = 1.4404432 m/s = exactly 2.80 kn (already a hand-set override BELOW the mission's 3.0 kn — matches operator's recollection of a prior agent override). avoid_speed=0.0 (no maneuver slowdown), max_yaw_rate=pi (~uncapped). KEY for RCA: measured turn commanded speed (up to 1.87 m/s / ~3.6 kn) EXCEEDS default_speed 1.44 m/s -> turns add forward speed on top of the straight-line default, so the power sink is in turn handling (uncapped yaw rate + speed overshoot through coverage turnarounds), not just the base survey speed. Lowering default_speed alone wouldn't fully fix it.
+
+**2026-06-30 12:53 -04:00** — ACTION (operator-directed): set FollowPath.default_speed 1.4404432 -> 1.5433333 m/s (2.80 -> 3.00 kn) live on /bizzy/controller_server. Read-back verified 1.5433333 (not a zenoh silent-drop). Runtime override only — a full nav2 relaunch reverts it to YAML; not persisted to nav2_overlay.yaml.
+
+**2026-06-30 12:55 -04:00** — ACTION (operator-directed): set FollowPath.default_speed 1.5433333 -> 1.2861111 m/s (3.00 -> 2.50 kn) live on /bizzy/controller_server. Read-back verified 1.2861111 (not a zenoh silent-drop). Runtime override only — reverts on full nav2 relaunch; not persisted to YAML.
+
+**2026-06-30 12:59 -04:00** — ACTION (operator-directed): set FollowPath.default_speed 1.2861111 -> 1.6462222 m/s (2.50 -> 3.20 kn) live on /bizzy/controller_server. Read-back verified 1.6462222 (not a zenoh silent-drop). Runtime override only — reverts on full nav2 relaunch; not persisted to YAML. Note: 3.2 kt is inside the current pid p=-13 + gain-scheduling validated-stable band (3.0-3.75 kt per config history); watch cross-track weave.
+
+**2026-06-30 12:59 -04:00** — ACTION (operator-directed): set FollowPath.default_speed 1.6462222 -> 1.2861111 m/s (3.20 -> 2.50 kn) live on /bizzy/controller_server. Read-back verified 1.2861111. Runtime override only — reverts on full nav2 relaunch; not persisted to YAML.
+
+**2026-06-30 13:08 -04:00** — Started 10-min (600s) camera capture via record_camera_topics.sh -> ~/data/logs/bizzy_images/bag_2026-06-30T13.08.05_ffmpeg_seg (4 OAK cams ffmpeg+segmentation raw/compressed, TF, diagnostics, robot_description, local_costmap). Began 13:08:05, auto-stops ~13:18. Context: running at FollowPath.default_speed 2.5 kn on traditional planning.
+
+**2026-06-30 13:18 -04:00** — 10-min camera capture complete + verified: 388 MB mcap, clean close. 76521 msgs total; all 4 OAK cams ~2997 msgs each on ffmpeg + segmentation raw/compressed (~5 Hz x 600s, no dropped camera), TF 18578, local_costmap 998. Bag: ~/data/logs/bizzy_images/bag_2026-06-30T13.08.05_ffmpeg_seg.
+
+**2026-06-30 13:32 -04:00** — RCA FINDING (manda coverage waypoint timing): manda_coverage does NOT set times or velocities at survey waypoints. SurveyPath::sendPath (manda_coverage/src/SurveyPath.cpp:384-415) builds each PoseStamped with only frame_id + position.x/y + orientation (adjustPathOrientations); no per-pose header.stamp, no velocity, and path-level stamp also unset. => the survey path carries no speed info and cannot override target speed; FollowPath.default_speed is the sole effective speed source (consistent with our live param changes taking effect). The turn-speed overshoot (commanded > default_speed in turns) therefore comes from controller turn handling (CrabbingPathFollower/AvoidanceController + uncapped max_yaw_rate=pi), not from waypoint timing. RCA should target controller turn behavior.
+
+**2026-06-30 13:53 -04:00** — Started 2-min (120s) camera capture via record_camera_topics.sh -> ~/data/logs/bizzy_images/bag_2026-06-30T13.52.57_ffmpeg_seg. Began 13:52:57, auto-stops ~13:55. Context: FollowPath.default_speed 2.5 kn, traditional planning.
+
+**2026-06-30 13:55 -04:00** — 2-min camera capture complete + verified: 79 MB, clean close, 15259 msgs total; oak_forward ~598 ffmpeg/597 seg (~5 Hz x 120s, cameras nominal). Bag: ~/data/logs/bizzy_images/bag_2026-06-30T13.52.57_ffmpeg_seg.
+
+**2026-06-30 14:41 -04:00** — Started 2-min (120s) camera capture via record_camera_topics.sh -> ~/data/logs/bizzy_images/bag_2026-06-30T14.41.20_ffmpeg_seg. Began 14:41:20, auto-stops ~14:43. Context: FollowPath.default_speed 2.5 kn, traditional planning.
+
+**2026-06-30 14:44 -04:00** — 2-min camera capture complete + verified: 79 MB, clean close, 15244 msgs total; oak_forward ~597 ffmpeg/597 seg (cameras nominal). Bag: ~/data/logs/bizzy_images/bag_2026-06-30T14.41.20_ffmpeg_seg.
+
+**2026-06-30 17:02 -04:00** — Back at the dock (operator-reported) — on-water ops ending, recovery phase.


### PR DESCRIPTION
Closes #359

Wrap-up for [Deployment 2026-06-30: Lake Massabesic survey](https://github.com/rolker/unh_echoboats_project11/issues/359).

## Summary

BizzyBoat Lake Massabesic survey, ~09:25–17:02 on the water (gabby field host; deadpool dev support). Transited to the survey area, tested `manda_coverage`, then switched to traditional survey lines for the remainder. No hardware faults; mru ran FCU-primary with no SBG fail-over. Notable finding: elevated battery drain under manda coverage — turns commanded speeds above the task target (confirmed via `/bizzy/cmd_vel_nav` sampling; yaw rate uncapped). Operator tuned `FollowPath.default_speed` live to find a good survey speed while monitoring throttle, and switched off manda coverage as mitigation. Camera captures collected cleanly. Weather held.

## Logs

- [dev log](docs/logs/2026/2026-06-30_dev_logs.md)
- [gabby log](docs/logs/2026/2026-06-30_gabby_logs.md) (issue-less field start, backfilled to #359)

## Operator corrections

Operator confirmed start date, host set (gabby + dev), the manda-coverage power-draw RCA, and that all live speed changes + the switch to traditional planning were his calls. No corrections to the record; no unlogged events.

## Field reconciliation

Gabby field log folded in via SHA-preserving merge of `gitcloud/jazzy` (d1fccfe). No other repos had field commits — all session changes were runtime-only param overrides.

## RCA follow-up

- manda_coverage excess power draw from turn-speed overshoot (controller does not slow for turns; manda sets no per-waypoint speed). Issue filed separately.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
